### PR TITLE
Mark new client defined ID DialogElement as created

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/Dialogs/Commands/Update/UpdateDialogCommand.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/Dialogs/Commands/Update/UpdateDialogCommand.cs
@@ -280,6 +280,7 @@ internal sealed class UpdateDialogCommandHandler : IRequestHandler<UpdateDialogC
             elements.Add(element);
         }
 
+        _db.DialogElements.AddRange(elements);
         return elements;
     }
 


### PR DESCRIPTION
Fix issue where new element with client defined ID is marked as updated and not created as it should.