### PR TITLE
Add culture code validation

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/Common/Localizations/LocalizationDtoValidator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/Common/Localizations/LocalizationDtoValidator.cs
@@ -32,7 +32,7 @@ internal sealed class LocalizationDtoValidator : AbstractValidator<LocalizationD
 
         RuleFor(x => x.CultureCode)
             .NotEmpty()
-            .Must(x => ValidCultureNames.Contains(x.Replace('_', '-'), StringComparer.InvariantCultureIgnoreCase))
+            .Must(x => ValidCultureNames.Contains(x.Trim().Replace('_', '-'), StringComparer.InvariantCultureIgnoreCase))
             .WithMessage("'{PropertyName}' must be a valid culture code.");
     }
 }

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/Common/Localizations/LocalizationDtoValidator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/Common/Localizations/LocalizationDtoValidator.cs
@@ -1,5 +1,6 @@
 ﻿using Digdir.Domain.Dialogporten.Application.Common.Extensions.FluentValidation;
 using FluentValidation;
+using System.Globalization;
 
 namespace Digdir.Domain.Dialogporten.Application.Features.V1.Common.Localizations;
 
@@ -15,6 +16,12 @@ internal sealed class LocalizationDtosValidator : AbstractValidator<IEnumerable<
 
 internal sealed class LocalizationDtoValidator : AbstractValidator<LocalizationDto>
 {
+    private static readonly HashSet<string> ValidCultureNames = CultureInfo
+        .GetCultures(CultureTypes.NeutralCultures | CultureTypes.SpecificCultures)
+        .Where(x => !string.IsNullOrWhiteSpace(x.Name))
+        .Select(x => x.Name)
+        .ToHashSet();
+
     public LocalizationDtoValidator(int maximumLength = 255)
     {
         RuleFor(x => x).NotNull();
@@ -23,8 +30,9 @@ internal sealed class LocalizationDtoValidator : AbstractValidator<LocalizationD
             .NotNull()
             .MaximumLength(maximumLength);
 
-        // TODO: Validate correct culture code?
         RuleFor(x => x.CultureCode)
-            .NotEmpty();
+            .NotEmpty()
+            .Must(x => ValidCultureNames.Contains(x.Replace('_', '-'), StringComparer.InvariantCultureIgnoreCase))
+            .WithMessage("'{PropertyName}' must be a valid culture code.");
     }
 }

--- a/src/Digdir.Domain.Dialogporten.Domain/Localizations/Localization.cs
+++ b/src/Digdir.Domain.Dialogporten.Domain/Localizations/Localization.cs
@@ -4,11 +4,20 @@ namespace Digdir.Domain.Dialogporten.Domain.Localizations;
 
 public class Localization : IJoinEntity
 {
+    private string cultureCode = null!;
+
     public DateTimeOffset CreatedAt { get; set; }
     public DateTimeOffset UpdatedAt { get; set; }
 
     public string Value { get; set; } = null!;
-    public string CultureCode { get; set; } = null!;
+    public string CultureCode 
+    { 
+        get => cultureCode; 
+        set => cultureCode = value?
+            .Trim()
+            .Replace('_', '-')
+            .ToLower()!; 
+    }
 
     // === Dependent relationships ===
     public Guid LocalizationSetId { get; set; }


### PR DESCRIPTION
Har lagt til validering av culture code. Vi aksepterer både '-' og '_' som separator og er case insensitive og tåler trailing og leading whitespace.

Applikasjonen vil konsolidere formatene. Dersom en bruker sender inn 'en_gb', en annen sender inn 'en-gb    ', og en tredje sender inn 'en-GB' vil alle passere valideringsregelen og referere til den samme kulturen, og bli lagret som 'en-gb'?

De aksepterte kulturene hentes ut fra .nets System.Globalization.CultureInfo. Under er en fil med gyldige kultur strenger:
[SupportedCultures.txt](https://github.com/digdir/dialogporten/files/11881529/SupportedCultures.txt)