### PR TITLE
Improve PATCH dialog.

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Application/Digdir.Domain.Dialogporten.Application.csproj
+++ b/src/Digdir.Domain.Dialogporten.Application/Digdir.Domain.Dialogporten.Application.csproj
@@ -11,7 +11,6 @@
     <PackageReference Include="HtmlAgilityPack" Version="1.11.48" />
 	<PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.5.2" />
-    <PackageReference Include="JsonPatch.Net" Version="2.1.0" />
     <PackageReference Include="MediatR" Version="12.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.8" />
     <PackageReference Include="OneOf" Version="3.0.255" />

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/Common/ReturnTypes/EntityExists.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/Common/ReturnTypes/EntityExists.cs
@@ -1,4 +1,6 @@
-﻿namespace Digdir.Domain.Dialogporten.Application.Features.V1.Common.ReturnTypes;
+﻿using FluentValidation.Results;
+
+namespace Digdir.Domain.Dialogporten.Application.Features.V1.Common.ReturnTypes;
 
 public record EntityExists<T>(IEnumerable<object> Keys) : EntityExists(typeof(T).Name, Keys)
 {
@@ -19,4 +21,6 @@ public record EntityExists(string Name, IEnumerable<object> Keys)
     public EntityExists(string name, Guid key) : this(name, new object[] { key }) { }
     public EntityExists(string name, int key) : this(name, new object[] { key }) { }
     public EntityExists(string name, long key) : this(name, new object[] { key }) { }
+
+    public List<ValidationFailure> ToValidationResults() => new() { new ValidationFailure(Name, Message) };
 }

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/Common/ReturnTypes/EntityNotFound.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/Common/ReturnTypes/EntityNotFound.cs
@@ -1,4 +1,6 @@
-﻿namespace Digdir.Domain.Dialogporten.Application.Features.V1.Common.ReturnTypes;
+﻿using FluentValidation.Results;
+
+namespace Digdir.Domain.Dialogporten.Application.Features.V1.Common.ReturnTypes;
 
 public record EntityNotFound<T>(IEnumerable<object> Keys) : EntityNotFound(typeof(T).Name, Keys)
 {
@@ -19,4 +21,6 @@ public record EntityNotFound(string Name, IEnumerable<object> Keys)
     public EntityNotFound(string name, Guid key) : this(name, new object[] { key }) { }
     public EntityNotFound(string name, int key) : this(name, new object[] { key }) { }
     public EntityNotFound(string name, long key) : this(name, new object[] { key }) { }
+
+    public List<ValidationFailure> ToValidationResults() => new() { new ValidationFailure(Name, Message) };
 }

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/Dialogs/Commands/Update/MappingProfile.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/Dialogs/Commands/Update/MappingProfile.cs
@@ -1,5 +1,6 @@
 ﻿using AutoMapper;
 using Digdir.Domain.Dialogporten.Application.Common.Extensions;
+using Digdir.Domain.Dialogporten.Application.Features.V1.Dialogs.Queries.Get;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Actions;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Activities;
@@ -11,8 +12,6 @@ internal sealed class MappingProfile : Profile
 {
     public MappingProfile()
     {
-        // TODO: should we ignore id for entities where user cannot set id on create?
-
         // In
         CreateMap<UpdateDialogDto, DialogEntity>()
             .IgnoreComplexDestinationProperties()
@@ -49,17 +48,13 @@ internal sealed class MappingProfile : Profile
             .ForMember(dest => dest.TypeId, opt => opt.MapFrom(src => src.Type));
 
         // To support json patch
-        CreateMap<DialogEntity, UpdateDialogDto>()
-            .ForMember(dest => dest.Status, opt => opt.MapFrom(src => src.StatusId));
-        CreateMap<DialogActivity, UpdateDialogDialogActivityDto>()
-            .ForMember(dest => dest.Type, opt => opt.MapFrom(src => src.TypeId));
-        CreateMap<DialogApiAction, UpdateDialogDialogApiActionDto>();
-        CreateMap<DialogApiActionEndpoint, UpdateDialogDialogApiActionEndpointDto>()
-            .ForMember(dest => dest.HttpMethod, opt => opt.MapFrom(src => src.HttpMethodId));
-        CreateMap<DialogGuiAction, UpdateDialogDialogGuiActionDto>()
-            .ForMember(dest => dest.Priority, opt => opt.MapFrom(src => src.PriorityId));
-        CreateMap<DialogElement, UpdateDialogDialogElementDto>();
-        CreateMap<DialogElementUrl, UpdateDialogDialogElementUrlDto>()
-            .ForMember(dest => dest.ConsumerType, opt => opt.MapFrom(src => src.ConsumerTypeId));
+        CreateMap<GetDialogDto, UpdateDialogDto>();
+        CreateMap<GetDialogDialogActivityDto, UpdateDialogDialogActivityDto>();
+        CreateMap<GetDialogDialogApiActionDto, UpdateDialogDialogApiActionDto>();
+        CreateMap<GetDialogDialogApiActionEndpointDto, UpdateDialogDialogApiActionEndpointDto>();
+        CreateMap<GetDialogDialogGuiActionDto, UpdateDialogDialogGuiActionDto>();
+        CreateMap<GetDialogDialogElementDto, UpdateDialogDialogElementDto>();
+        CreateMap<GetDialogDialogElementUrlDto, UpdateDialogDialogElementUrlDto>();
+        CreateMap<DateTimeOffset, DateTime>().ConstructUsing(dateTimeOffset => dateTimeOffset.UtcDateTime);
     }
 }

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/Dialogs/Commands/Update/UpdateDialogCommandValidator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/Dialogs/Commands/Update/UpdateDialogCommandValidator.cs
@@ -11,12 +11,9 @@ internal sealed class UpdateDialogCommandValidator : AbstractValidator<UpdateDia
     {
         RuleFor(x => x.Id)
             .NotEmpty();
-        When(x => x.Dto.IsT0, () =>
-        {
-            RuleFor(x => x.Dto.AsT0)
-                .NotEmpty()
-                .SetValidator(updateDialogDtoValidator);
-        });
+        RuleFor(x => x.Dto)
+            .NotEmpty()
+            .SetValidator(updateDialogDtoValidator);
     }
 }
 

--- a/src/Digdir.Domain.Dialogporten.ChangeDataCapture/Common/AzureAppConfigurationExtensions.cs
+++ b/src/Digdir.Domain.Dialogporten.ChangeDataCapture/Common/AzureAppConfigurationExtensions.cs
@@ -3,7 +3,7 @@ using Azure.Identity;
 using Microsoft.Extensions.Configuration.AzureAppConfiguration;
 using System.Diagnostics.CodeAnalysis;
 
-namespace Digdir.Domain.Dialogporten.WebApi.Common;
+namespace Digdir.Domain.Dialogporten.ChangeDataCapture.Common;
 
 /// <summary>
 /// Wrapper around azure app configuration bootstraping such that azure app 

--- a/src/Digdir.Domain.Dialogporten.ChangeDataCapture/Program.cs
+++ b/src/Digdir.Domain.Dialogporten.ChangeDataCapture/Program.cs
@@ -1,7 +1,7 @@
 ﻿using Digdir.Domain.Dialogporten.ChangeDataCapture;
 using Digdir.Domain.Dialogporten.ChangeDataCapture.ChangeDataCapture;
+using Digdir.Domain.Dialogporten.ChangeDataCapture.Common;
 using Digdir.Domain.Dialogporten.Domain.Outboxes;
-using Digdir.Domain.Dialogporten.WebApi.Common;
 using MassTransit;
 using Microsoft.ApplicationInsights.Extensibility;
 using Serilog;

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Digdir.Domain.Dialogporten.Infrastructure.csproj
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Digdir.Domain.Dialogporten.Infrastructure.csproj
@@ -10,11 +10,11 @@
 	<ItemGroup>
 		<PackageReference Include="Altinn.ApiClients.Maskinporten" Version="9.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="7.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" />
 		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.4" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.8">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<TreatAsUsed>true</TreatAsUsed>
 		</PackageReference>
 		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
 		<PackageReference Include="Polly" Version="7.2.4" />

--- a/src/Digdir.Domain.Dialogporten.WebApi/Common/JsonPatchInputFormatter.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Common/JsonPatchInputFormatter.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using Microsoft.AspNetCore.Mvc.Formatters;
+
+namespace Digdir.Domain.Dialogporten.WebApi.Common;
+
+public static class JsonPatchInputFormatter
+{
+    public static NewtonsoftJsonPatchInputFormatter Get()
+    {
+        return new ServiceCollection()
+            .AddLogging()
+            .AddMvc()
+            .AddNewtonsoftJson()
+            .Services.BuildServiceProvider()
+            .GetRequiredService<IOptions<MvcOptions>>()
+            .Value
+            .InputFormatters
+            .OfType<NewtonsoftJsonPatchInputFormatter>()
+            .First();
+    }
+}

--- a/src/Digdir.Domain.Dialogporten.WebApi/Digdir.Domain.Dialogporten.WebApi.csproj
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Digdir.Domain.Dialogporten.WebApi.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Azure.Identity" Version="1.9.0" />
     <PackageReference Include="FastEndpoints.Swagger" Version="5.13.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.8" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.8" />
     <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="6.0.1" />
     <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />

--- a/src/Digdir.Domain.Dialogporten.WebApi/EndpointExtensions.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/EndpointExtensions.cs
@@ -13,7 +13,7 @@ public static class EndpointExtensions
 
     public static Task NotFoundAsync(this IEndpoint ep, EntityNotFound notFound, CancellationToken cancellationToken = default) 
         => ep.HttpContext.Response.SendErrorsAsync(
-            new() { new ValidationFailure(notFound.Name, notFound.Message) }, 
+            notFound.ToValidationResults(), 
             StatusCodes.Status404NotFound, 
             cancellation: cancellationToken);
 
@@ -25,7 +25,7 @@ public static class EndpointExtensions
 
     public static Task ConflictAsync(this IEndpoint ep, EntityExists entityExists, CancellationToken cancellationToken = default)
         => ep.HttpContext.Response.SendErrorsAsync(
-            new() { new ValidationFailure(entityExists.Name, entityExists.Message) },
+            entityExists.ToValidationResults(),
             StatusCodes.Status409Conflict,
             cancellation: cancellationToken);
 }

--- a/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/Dialog/DialogsController.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/Dialog/DialogsController.cs
@@ -1,0 +1,54 @@
+﻿using Digdir.Domain.Dialogporten.Application.Features.V1.Dialogs.Commands.Update;
+using Digdir.Domain.Dialogporten.Application.Features.V1.Dialogs.Queries.Get;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.JsonPatch;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Digdir.Domain.Dialogporten.WebApi.Endpoints.V1.Dialog;
+
+/* Since minimal apis don't support json patch documents out of the box, 
+ * and we've not been able to find a good alternative library for it yet, 
+ * we've decided to use the old way of doing it using controllers and 
+ * NewtonsoftJson. System.Text.Json will still be used for everything 
+ * else. */
+
+[ApiController]
+[Route("api/v1/dialogs")]
+public sealed class DialogsController : ControllerBase
+{
+    private readonly ISender _sender;
+    private readonly AutoMapper.IMapper _mapper;
+
+    public DialogsController(ISender sender, AutoMapper.IMapper mapper)
+    {
+        _sender = sender ?? throw new ArgumentNullException(nameof(sender));
+        _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
+    }
+
+    [AllowAnonymous]
+    [HttpPatch("{id}")]
+    public async Task<IActionResult> Patch(Guid id, [FromBody] JsonPatchDocument<UpdateDialogDto> patchDocument, CancellationToken ct)
+    {
+        var dialogQueryResult = await _sender.Send(new GetDialogQuery { Id = id }, ct);
+        if (dialogQueryResult.TryPickT1(out var entityNotFound, out var dialog))
+        {
+            return NotFound(HttpContext.ResponseBuilder(StatusCodes.Status404NotFound, entityNotFound.ToValidationResults()));
+        }
+
+        var updateDialogDto = _mapper.Map<UpdateDialogDto>(dialog);
+        patchDocument.ApplyTo(updateDialogDto, ModelState);
+        if (!ModelState.IsValid)
+        {
+            return BadRequest(ModelState);
+        }
+
+        var command = new UpdateDialogCommand { Id = id, Dto = updateDialogDto };
+        var result = await _sender.Send(command, ct);
+        return result.Match(
+            success => (IActionResult)NoContent(),
+            entityNotFound => NotFound(HttpContext.ResponseBuilder(StatusCodes.Status404NotFound, entityNotFound.ToValidationResults())),
+            entityExists => Conflict(HttpContext.ResponseBuilder(StatusCodes.Status409Conflict, entityExists.ToValidationResults())),
+            validationFailed => BadRequest(HttpContext.ResponseBuilder(StatusCodes.Status400BadRequest, validationFailed.Errors.ToList())));
+    }
+}

--- a/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/Dialog/PatchDialogEndpoint.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/Dialog/PatchDialogEndpoint.cs
@@ -1,40 +1,38 @@
-﻿using Digdir.Domain.Dialogporten.Application.Features.V1.Dialogs.Commands.Update;
-using FastEndpoints;
-using Json.Patch;
-using MediatR;
-using Microsoft.AspNetCore.Authorization;
-using System.Text.Json;
+﻿//using FastEndpoints;
+//using MediatR;
+//using Microsoft.AspNetCore.Authorization;
 
-namespace Digdir.Domain.Dialogporten.WebApi.Endpoints.V1.Dialog;
+//namespace Digdir.Domain.Dialogporten.WebApi.Endpoints.V1.Dialog;
 
-[AllowAnonymous]
-[HttpPatch("dialogs/{id}")]
-public sealed class PatchDialogEndpoint : Endpoint<PatchDialogRequest>
-{
-    private readonly ISender _sender;
+//[AllowAnonymous]
+//[HttpPatch("dialogs/{id}")]
+//public sealed class PatchDialogEndpoint : Endpoint<PatchDialogRequest>
+//{
+//    private readonly ISender _sender;
 
-    public PatchDialogEndpoint(ISender sender)
-    {
-        _sender = sender ?? throw new ArgumentNullException(nameof(sender));
-    }
+//    public PatchDialogEndpoint(ISender sender)
+//    {
+//        _sender = sender ?? throw new ArgumentNullException(nameof(sender));
+//    }
 
-    public override async Task HandleAsync(PatchDialogRequest req, CancellationToken ct)
-    {
-        var command = new UpdateDialogCommand { Id = req.Id, Dto = req.PatchDocument };
-        var result = await _sender.Send(command, ct);
-        await result.Match(
-            success => SendNoContentAsync(ct),
-            entityNotFound => this.NotFoundAsync(entityNotFound, ct),
-            entityExists => this.ConflictAsync(entityExists, ct),
-            validationFailed => this.BadRequestAsync(validationFailed, ct));
-    }
-}
+//    public override async Task HandleAsync(PatchDialogRequest req, CancellationToken ct)
+//    {
+//        var command = new UpdateDialogCommand { Id = req.Id, Dto = updateDialogDto };
+//        var result = await _sender.Send(command, ct);
+//        await result.Match(
+//            success => SendNoContentAsync(ct),
+//            entityNotFound => this.NotFoundAsync(entityNotFound, ct),
+//            entityExists => this.ConflictAsync(entityExists, ct),
+//            validationFailed => this.BadRequestAsync(validationFailed, ct));
+//    }
+//}
 
-public class PatchDialogRequest : IPlainTextRequest
-{
-    public Guid Id { get; set; }
+//public sealed class PatchDialogRequest
+//{
+//    public Guid Id { get; set; }
 
-    [FromBody]
-    public string Content { get; set; } = null!;
-    public JsonPatch PatchDocument => JsonSerializer.Deserialize<JsonPatch>(Content);
-}
+//    [FromBody]
+//    public string Content { get; set; } = null!;
+//    public JsonPatch PatchDocument => JsonSerializer.Deserialize<JsonPatch>(Content);
+//}
+

--- a/src/Digdir.Domain.Dialogporten.WebApi/Program.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Program.cs
@@ -69,11 +69,17 @@ static void BuildAndRun(string[] args)
                 s.DocumentName = "V0.1";
                 s.Version = "v0.1";
             })
+        .AddControllers(options =>
+            {
+                options.InputFormatters.Insert(0, JsonPatchInputFormatter.Get());
+            })
+            .AddNewtonsoftJson()
+            .Services
         .AddApplication(builder.Configuration.GetSection(ApplicationSettings.ConfigurationSectionName))
         .AddInfrastructure(builder.Configuration.GetSection(InfrastructureSettings.ConfigurationSectionName));
 
     var app = builder.Build();
-
+    
     app.UseHttpsRedirection()
         .UseSerilogRequestLogging()
         .UseProblemDetailsExceptionHandler()
@@ -96,7 +102,7 @@ static void BuildAndRun(string[] args)
         })
         .UseOpenApi()
         .UseSwaggerUi3(x => x.ConfigureDefaults());
-
+    app.MapControllers();
     app.Run();
 }
 


### PR DESCRIPTION
Since minimal apis don't support json patch documents out of the box, and I've not been able to find a good alternative library for it yet, I've decided to use the old way of doing it using controllers and NewtonsoftJson. System.Text.Json will still be used for everything else. 