### PR TITLE
Use Medo.Uuid7 guid generator

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Application/Common/Extensions/FluentValidation/FluentValidation_Enumerable_Extensions.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Common/Extensions/FluentValidation/FluentValidation_Enumerable_Extensions.cs
@@ -14,7 +14,9 @@ internal static class FluentValidation_Enumerable_Extensions
         return ruleBuilder.Must((parent, enumerable, ctx) =>
         {
             var duplicateKeys = enumerable
-                .GroupBy(keySelector)
+                .Select(keySelector)
+                .Where(x => !Equals(x, default(TKey)))
+                .GroupBy(x => x)
                 .Where(x => x.Count() > 1)
                 .Select(x => x.Key)
                 .ToArray();

--- a/src/Digdir.Domain.Dialogporten.WebApi/Program.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Program.cs
@@ -60,15 +60,17 @@ static void BuildAndRun(string[] args)
         .AddApplicationInsightsTelemetry()
         .AddEndpointsApiExplorer()
         .AddFastEndpoints()
-        .AddSwaggerDoc(
-            maxEndpointVersion: 1,
-            shortSchemaNames: true,
-            settings: s =>
+        .SwaggerDocument(x =>
+        {
+            x.MaxEndpointVersion = 2;
+            x.ShortSchemaNames = true;
+            x.DocumentSettings = s =>
             {
                 s.Title = "Dialogporten";
                 s.DocumentName = "V0.1";
                 s.Version = "v0.1";
-            })
+            };
+        })
         .AddControllers(options =>
             {
                 options.InputFormatters.Insert(0, JsonPatchInputFormatter.Get());

--- a/src/Digdir.Library.Entity.Abstractions/Digdir.Library.Entity.Abstractions.csproj
+++ b/src/Digdir.Library.Entity.Abstractions/Digdir.Library.Entity.Abstractions.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="UUIDNext" Version="2.0.2" />
+    <PackageReference Include="Medo.Uuid7" Version="1.5.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Digdir.Library.Entity.Abstractions/Features/Identifiable/IdentifiableExtensions.cs
+++ b/src/Digdir.Library.Entity.Abstractions/Features/Identifiable/IdentifiableExtensions.cs
@@ -1,4 +1,4 @@
-﻿using UUIDNext;
+﻿using Medo;
 
 namespace Digdir.Library.Entity.Abstractions.Features.Identifiable;
 
@@ -14,7 +14,7 @@ public static class IdentifiableExtensions
     public static Guid CreateId(this IIdentifiableEntity identifiable)
     {
         return identifiable.Id = identifiable.Id == Guid.Empty
-            ? Uuid.NewDatabaseFriendly(Database.PostgreSql)
+            ? Uuid7.NewUuid7().ToGuid()
             : identifiable.Id;
     }
 }


### PR DESCRIPTION
* Use Medo.Uuid7 instead of UuidNext. Medo.Uuid7 generates uuids in sequence, even within the same ms. The idea is to give a better integration experiance by returning items in the arrays in the same order they were added to the API.
* Fix a bug where the FluentValidation extension `UniqueBy` did not allow default key values. That is - if the user inputs two items in the same array without specifying id, effectively saying to the API "please generate the ids for me", `UniqueBy` would invalidate the request. 
* Use SwaggerDocument instead of deprecated FastEndpoint `AddSwaggerDoc` method.