### PR TITLE
Add GET dialog activities for service owners

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/DialogActivities/Queries/Get/GetDialogActivityDto.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/DialogActivities/Queries/Get/GetDialogActivityDto.cs
@@ -11,7 +11,7 @@ public sealed class GetDialogActivityDto
     
     public DialogActivityType.Enum Type { get; set; }
     
-    public DateTimeOffset? DialogDeletedAt { get; set; }
+    public DateTimeOffset? DeletedAt { get; set; }
     
     public Guid? RelatedActivityId { get; set; }
     public Guid? DialogElementId { get; set; }

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/DialogActivities/Queries/Get/GetDialogActivityDto.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/DialogActivities/Queries/Get/GetDialogActivityDto.cs
@@ -1,0 +1,21 @@
+using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Localizations;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Activities;
+
+namespace Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.DialogActivities.Queries.Get;
+
+public sealed class GetDialogActivityDto
+{
+    public Guid Id { get; set; }
+    public DateTimeOffset? CreatedAt { get; set; }
+    public Uri? ExtendedType { get; set; }
+    
+    public DialogActivityType.Enum Type { get; set; }
+    
+    public DateTimeOffset? DialogDeletedAt { get; set; }
+    
+    public Guid? RelatedActivityId { get; set; }
+    public Guid? DialogElementId { get; set; }
+
+    public List<LocalizationDto>? PerformedBy { get; set; } = new();
+    public List<LocalizationDto> Description { get; set; } = new();
+}

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/DialogActivities/Queries/Get/GetDialogActivityQuery.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/DialogActivities/Queries/Get/GetDialogActivityQuery.cs
@@ -1,0 +1,57 @@
+using AutoMapper;
+using Digdir.Domain.Dialogporten.Application.Common.ReturnTypes;
+using Digdir.Domain.Dialogporten.Application.Externals;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Activities;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using OneOf;
+
+namespace Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.DialogActivities.Queries.Get;
+
+public sealed class GetDialogActivityQuery : IRequest<GetDialogActivityResult>
+{
+    public Guid DialogId { get; set; }
+    public Guid ActivityId { get; set; }
+}
+
+[GenerateOneOf]
+public partial class GetDialogActivityResult : OneOfBase<GetDialogActivityDto, EntityNotFound>
+{
+}
+
+internal sealed class GetDialogActivityQueryHandler : IRequestHandler<GetDialogActivityQuery, GetDialogActivityResult>
+{
+    private readonly IMapper _mapper;
+    private readonly IDialogDbContext _dbContext;
+
+    public GetDialogActivityQueryHandler(IMapper mapper, IDialogDbContext dbContext)
+    {
+        _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+    }
+
+    public async Task<GetDialogActivityResult> Handle(GetDialogActivityQuery request,
+        CancellationToken cancellationToken)
+    {
+        var dialog = await _dbContext.Dialogs
+            .Include(x => x.Activities.Where(x => x.Id == request.ActivityId))
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(x => x.Id == request.DialogId,
+                cancellationToken: cancellationToken);
+
+        if (dialog is null)
+        {
+            return new EntityNotFound<DialogEntity>(request.DialogId);
+        }
+
+        var activity = dialog.Activities.FirstOrDefault();
+
+        if (activity is null)
+        {
+            return new EntityNotFound<DialogActivity>(request.ActivityId);
+        }
+
+        return _mapper.Map<GetDialogActivityDto>(activity);
+    }
+}

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/DialogActivities/Queries/Get/MappingProfile.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/DialogActivities/Queries/Get/MappingProfile.cs
@@ -1,0 +1,14 @@
+using AutoMapper;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Activities;
+
+namespace Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.DialogActivities.Queries.Get;
+
+public class MappingProfile : Profile 
+{
+    public MappingProfile()
+    {
+        CreateMap<DialogActivity, GetDialogActivityDto>()
+            .ForMember(dest => dest.Type, opt => opt.MapFrom(src => src.TypeId))
+            .ForMember(dest => dest.DialogDeletedAt, opt => opt.MapFrom(src => src.Dialog.DeletedAt));
+    }
+}

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/DialogActivities/Queries/Get/MappingProfile.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/DialogActivities/Queries/Get/MappingProfile.cs
@@ -9,6 +9,6 @@ public class MappingProfile : Profile
     {
         CreateMap<DialogActivity, GetDialogActivityDto>()
             .ForMember(dest => dest.Type, opt => opt.MapFrom(src => src.TypeId))
-            .ForMember(dest => dest.DialogDeletedAt, opt => opt.MapFrom(src => src.Dialog.DeletedAt));
+            .ForMember(dest => dest.DeletedAt, opt => opt.MapFrom(src => src.Dialog.DeletedAt));
     }
 }

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/DialogActivities/Queries/List/ListDialogActivityDto.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/DialogActivities/Queries/List/ListDialogActivityDto.cs
@@ -10,7 +10,7 @@ public sealed class ListDialogActivityDto
 
     public DialogActivityType.Enum Type { get; set; }
 
-    public DateTimeOffset? DialogDeletedAt { get; set; }
+    public DateTimeOffset? DeletedAt { get; set; }
 
     public Guid? RelatedActivityId { get; set; }
     public Guid? DialogElementId { get; set; }

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/DialogActivities/Queries/List/ListDialogActivityDto.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/DialogActivities/Queries/List/ListDialogActivityDto.cs
@@ -1,0 +1,17 @@
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Activities;
+
+namespace Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.DialogActivities.Queries.List;
+
+public sealed class ListDialogActivityDto
+{
+    public Guid Id { get; set; }
+    public DateTimeOffset CreatedAt { get; set; }
+    public Uri? ExtendedType { get; set; }
+
+    public DialogActivityType.Enum Type { get; set; }
+
+    public DateTimeOffset? DialogDeletedAt { get; set; }
+
+    public Guid? RelatedActivityId { get; set; }
+    public Guid? DialogElementId { get; set; }
+}

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/DialogActivities/Queries/List/ListDialogActivityQuery.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/DialogActivities/Queries/List/ListDialogActivityQuery.cs
@@ -1,0 +1,45 @@
+using AutoMapper;
+using Digdir.Domain.Dialogporten.Application.Common.ReturnTypes;
+using Digdir.Domain.Dialogporten.Application.Externals;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using OneOf;
+
+namespace Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.DialogActivities.Queries.List;
+
+public sealed class ListDialogActivityQuery : IRequest<ListDialogActivityResult>
+{
+    public Guid DialogId { get; set; }
+}
+
+[GenerateOneOf]
+public partial class ListDialogActivityResult : OneOfBase<List<ListDialogActivityDto>, EntityNotFound, EntityDeleted> { }
+
+internal sealed class ListDialogActivityQueryHandler : IRequestHandler<ListDialogActivityQuery, ListDialogActivityResult>
+{
+    private readonly IDialogDbContext _db;
+    private readonly IMapper _mapper;
+
+    public ListDialogActivityQueryHandler(IDialogDbContext db, IMapper mapper)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
+    }
+
+    public async Task<ListDialogActivityResult> Handle(ListDialogActivityQuery request, CancellationToken cancellationToken)
+    {
+        var dialog = await _db.Dialogs
+            .Include(x => x.Activities)
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(x => x.Id == request.DialogId, 
+                cancellationToken: cancellationToken);
+
+        if (dialog is null)
+        {
+            return new EntityNotFound<DialogEntity>(request.DialogId);
+        }
+
+        return _mapper.Map<List<ListDialogActivityDto>>(dialog.Activities);
+    }
+}

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/DialogActivities/Queries/List/ListDialogActivityQuery.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/DialogActivities/Queries/List/ListDialogActivityQuery.cs
@@ -14,7 +14,7 @@ public sealed class ListDialogActivityQuery : IRequest<ListDialogActivityResult>
 }
 
 [GenerateOneOf]
-public partial class ListDialogActivityResult : OneOfBase<List<ListDialogActivityDto>, EntityNotFound, EntityDeleted> { }
+public partial class ListDialogActivityResult : OneOfBase<List<ListDialogActivityDto>, EntityNotFound> { }
 
 internal sealed class ListDialogActivityQueryHandler : IRequestHandler<ListDialogActivityQuery, ListDialogActivityResult>
 {

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/DialogActivities/Queries/List/MappingProfile.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/DialogActivities/Queries/List/MappingProfile.cs
@@ -1,0 +1,14 @@
+using AutoMapper;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Activities;
+
+namespace Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.DialogActivities.Queries.List;
+
+public class MappingProfile : Profile
+{
+    public MappingProfile()
+    {
+        CreateMap<DialogActivity, ListDialogActivityDto>()
+            .ForMember(dest => dest.Type, opt => opt.MapFrom(src => src.TypeId))
+            .ForMember(dest => dest.DialogDeletedAt, opt => opt.MapFrom(src => src.Dialog.DeletedAt));
+    }
+}

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/DialogActivities/Queries/List/MappingProfile.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/DialogActivities/Queries/List/MappingProfile.cs
@@ -9,6 +9,6 @@ public class MappingProfile : Profile
     {
         CreateMap<DialogActivity, ListDialogActivityDto>()
             .ForMember(dest => dest.Type, opt => opt.MapFrom(src => src.TypeId))
-            .ForMember(dest => dest.DialogDeletedAt, opt => opt.MapFrom(src => src.Dialog.DeletedAt));
+            .ForMember(dest => dest.DeletedAt, opt => opt.MapFrom(src => src.Dialog.DeletedAt));
     }
 }

--- a/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/DialogActivity/GetDialogActivityEndpoint.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/DialogActivity/GetDialogActivityEndpoint.cs
@@ -1,0 +1,29 @@
+using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.DialogActivities.Queries.Get;
+using FastEndpoints;
+using MediatR;
+
+namespace Digdir.Domain.Dialogporten.WebApi.Endpoints.V1.ServiceOwner.DialogActivity;
+
+public class GetDialogActivityEndpoint : Endpoint<GetDialogActivityQuery>
+{
+    private readonly ISender _sender;
+
+    public GetDialogActivityEndpoint(ISender sender)
+    {
+        _sender = sender ?? throw new ArgumentNullException(nameof(sender));
+    }
+
+    public override void Configure()
+    {
+        Get("dialogs/{dialogId}/activities/{activityId}");
+        Group<ServiceOwnerGroup>();
+    }
+
+    public override async Task HandleAsync(GetDialogActivityQuery req, CancellationToken ct)
+    {
+        var result = await _sender.Send(req, ct);
+        await result.Match(
+            dto => SendOkAsync(dto, ct),
+            notFound => this.NotFoundAsync(notFound, ct));
+    }
+}

--- a/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/DialogActivity/ListDialogActivityEndpoint.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/DialogActivity/ListDialogActivityEndpoint.cs
@@ -24,7 +24,6 @@ public class ListDialogActivityEndpoint : Endpoint<ListDialogActivityQuery>
         var result = await _sender.Send(req, ct);
         await result.Match(
             dto => SendOkAsync(dto, ct),
-            notFound => this.NotFoundAsync(notFound, ct),
-            deleted => this.GoneAsync(deleted, ct));
+            notFound => this.NotFoundAsync(notFound, ct));
     }
 }

--- a/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/DialogActivity/ListDialogActivityEndpoint.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/DialogActivity/ListDialogActivityEndpoint.cs
@@ -1,0 +1,30 @@
+using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.DialogActivities.Queries.List;
+using FastEndpoints;
+using MediatR;
+
+namespace Digdir.Domain.Dialogporten.WebApi.Endpoints.V1.ServiceOwner.DialogActivity;
+
+public class ListDialogActivityEndpoint : Endpoint<ListDialogActivityQuery>
+{
+    private readonly ISender _sender;
+
+    public ListDialogActivityEndpoint(ISender sender)
+    {
+        _sender = sender ?? throw new ArgumentNullException(nameof(sender));
+    }
+
+    public override void Configure()
+    {
+        Get("dialogs/{dialogId}/activities");
+        Group<ServiceOwnerGroup>();
+    }
+
+    public override async Task HandleAsync(ListDialogActivityQuery req, CancellationToken ct)
+    {
+        var result = await _sender.Send(req, ct);
+        await result.Match(
+            dto => SendOkAsync(dto, ct),
+            notFound => this.NotFoundAsync(notFound, ct),
+            deleted => this.GoneAsync(deleted, ct));
+    }
+}


### PR DESCRIPTION
Skal vi ha med deleted-info om parent dialog her? 

Har mapped `element.dialog.DeletedAt` til en property `DialogDeletedAt` på DTOen
For lista blir det kanskje litt weird å ha den på alle:

```json
[
    {
        "id": "59178a01-9617-3d76-93ae-4586beb6ab25",
        "createdAt": "2023-08-21T09:07:09.3361090Z",
        "type": "Submission",
        "dialogDeletedAt": "2023-08-21T09:10:35.2590080Z"
    },
    {
        "id": "59178a01-9617-3d76-93b4-6845191b68cc",
        "createdAt": "2023-08-21T09:07:09.3361090Z",
        "type": "Submission",
        "dialogDeletedAt": "2023-08-21T09:10:35.2590080Z"
    }
]
```

Kan ev. flytte activities et nivå ned? 

```json
{
    "dialogDeletedAt": "2023-08-21T09:10:35.2590080Z",
    "activities": [
        {
            "id": "59178a01-9617-3d76-93ae-4586beb6ab25",
            "createdAt": "2023-08-21T09:07:09.3361090Z",
            "type": "Submission"
        },
        {
            "id": "59178a01-9617-3d76-93b4-6845191b68cc",
            "createdAt": "2023-08-21T09:07:09.3361090Z",
            "type": "Submission"
        }
    ]
}

```

Ka du tru? 