### PR TITLE
Feature/add dialog element post delete put

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Application/Common/ReturnTypes/EntityNotFound.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Common/ReturnTypes/EntityNotFound.cs
@@ -5,7 +5,7 @@ namespace Digdir.Domain.Dialogporten.Application.Common.ReturnTypes;
 public record EntityNotFound<T>(IEnumerable<object> Keys) : EntityNotFound(typeof(T).Name, Keys)
 {
     public EntityNotFound(IEnumerable<Guid> keys) : this(keys.Cast<object>()) { }
-    public EntityNotFound(Guid keys) : this(new object[] { keys }) { }
+    public EntityNotFound(Guid key) : this(new object[] { key }) { }
 }
 
 public record EntityNotFound(string Name, IEnumerable<object> Keys)

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/DialogElements/Queries/Get/GetDialogElementQuery.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/DialogElements/Queries/Get/GetDialogElementQuery.cs
@@ -13,7 +13,7 @@ namespace Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.DialogEleme
 public sealed class GetDialogElementQuery : IRequest<GetDialogElementResult>
 {
     public Guid DialogId { get; set; }
-    public Guid DialogElementId { get; set; }
+    public Guid ElementId { get; set; }
 }
 
 [GenerateOneOf]
@@ -36,7 +36,7 @@ internal sealed class GetDialogElementQueryHandler : IRequestHandler<GetDialogEl
         CancellationToken cancellationToken)
     {
         Expression<Func<DialogEntity, IEnumerable<DialogElement>>> elementFilter = dialog =>
-            dialog.Elements.Where(x => x.Id == request.DialogElementId);
+            dialog.Elements.Where(x => x.Id == request.ElementId);
         
         var dialog = await _dbContext.Dialogs
             .Include(elementFilter)
@@ -61,7 +61,7 @@ internal sealed class GetDialogElementQueryHandler : IRequestHandler<GetDialogEl
 
         if (element is null)
         {
-            return new EntityNotFound<DialogElement>(request.DialogElementId);
+            return new EntityNotFound<DialogElement>(request.ElementId);
         }
         
         var dto = _mapper.Map<GetDialogElementDto>(element);

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/Get/GetDialogQuery.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/Get/GetDialogQuery.cs
@@ -12,7 +12,7 @@ namespace Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.Dialogs.Que
 
 public sealed class GetDialogQuery : IRequest<GetDialogResult>
 {
-    public Guid Id { get; set; }
+    public Guid DialogId { get; set; }
 }
 
 [GenerateOneOf]
@@ -65,21 +65,21 @@ internal sealed class GetDialogQueryHandler : IRequestHandler<GetDialogQuery, Ge
             .Where(x => !x.VisibleFrom.HasValue || x.VisibleFrom < _clock.UtcNowOffset)
             .IgnoreQueryFilters()
             .AsNoTracking()
-            .FirstOrDefaultAsync(x => x.Id == request.Id, cancellationToken);
+            .FirstOrDefaultAsync(x => x.Id == request.DialogId, cancellationToken);
 
         if (dialog is null)
         {
-            return new EntityNotFound<DialogEntity>(request.Id);
+            return new EntityNotFound<DialogEntity>(request.DialogId);
         }
 
         if (dialog.Deleted)
         {
-            return new EntityDeleted<DialogEntity>(request.Id);
+            return new EntityDeleted<DialogEntity>(request.DialogId);
         }
 
         if ((dialog.ReadAt ?? DateTimeOffset.MinValue) < dialog.UpdatedAt)
         {
-            dialog.ReadAt = await UpdateReadAt(request.Id, cancellationToken);
+            dialog.ReadAt = await UpdateReadAt(request.DialogId, cancellationToken);
         }
 
         var dto = _mapper.Map<GetDialogDto>(dialog);

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/DialogElements/Queries/Get/GetDialogElementQuery.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/DialogElements/Queries/Get/GetDialogElementQuery.cs
@@ -13,7 +13,7 @@ namespace Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialog
 public sealed class GetDialogElementQuery : IRequest<GetDialogElementResult>
 {
     public Guid DialogId { get; set; }
-    public Guid DialogElementId { get; set; }
+    public Guid ElementId { get; set; }
 }
 
 [GenerateOneOf]
@@ -36,7 +36,7 @@ internal sealed class GetDialogElementQueryHandler : IRequestHandler<GetDialogEl
         CancellationToken cancellationToken)
     {
         Expression<Func<DialogEntity, IEnumerable<DialogElement>>> elementFilter = dialog =>
-            dialog.Elements.Where(x => x.Id == request.DialogElementId);
+            dialog.Elements.Where(x => x.Id == request.ElementId);
         
         var dialog = await _dbContext.Dialogs
             .Include(elementFilter)
@@ -56,7 +56,7 @@ internal sealed class GetDialogElementQueryHandler : IRequestHandler<GetDialogEl
 
         if (element is null)
         {
-            return new EntityNotFound<DialogElement>(request.DialogElementId);
+            return new EntityNotFound<DialogElement>(request.ElementId);
         }
         
         return _mapper.Map<GetDialogElementDto>(element);

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/MappingProfile.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/MappingProfile.cs
@@ -48,7 +48,10 @@ internal sealed class MappingProfile : Profile
             .ForMember(dest => dest.TypeId, opt => opt.MapFrom(src => src.Type));
 
         // To support json patch
-        CreateMap<GetDialogDto, UpdateDialogDto>();
+        CreateMap<GetDialogDto, UpdateDialogDto>()
+            // Remove all existing activities, since this list is append only and
+            // existing activities should not be considered in the update request.
+            .ForMember(dest => dest.Activities, opt => opt.Ignore());
         CreateMap<GetDialogDialogActivityDto, UpdateDialogDialogActivityDto>();
         CreateMap<GetDialogDialogApiActionDto, UpdateDialogDialogApiActionDto>();
         CreateMap<GetDialogDialogApiActionEndpointDto, UpdateDialogDialogApiActionEndpointDto>();

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/UpdateDialogCommand.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/UpdateDialogCommand.cs
@@ -155,7 +155,7 @@ internal sealed class UpdateDialogCommandHandler : IRequestHandler<UpdateDialogC
         {
             _domainContext.AddError(
                 nameof(UpdateDialogDto.Activities), 
-                $"Entity '{nameof(DialogActivity)}' with the following key(s) allready exists: ({string.Join(", ", existingIds)}).");
+                $"Entity '{nameof(DialogActivity)}' with the following key(s) already exists: ({string.Join(", ", existingIds)}).");
         }
 
         _eventPublisher.Publish(newDialogActivities.Select(x => new DialogActivityCreatedDomainEvent(dialog.Id, x.CreateId())));
@@ -224,7 +224,7 @@ internal sealed class UpdateDialogCommandHandler : IRequestHandler<UpdateDialogC
         var existingIds = await _db.GetExistingIds(elements, cancellationToken);
         if (existingIds.Any())
         {
-            _domainContext.AddError(nameof(UpdateDialogDto.Elements), $"Entity '{nameof(DialogElement)}' with the following key(s) allready exists: ({string.Join(", ", existingIds)}).");
+            _domainContext.AddError(nameof(UpdateDialogDto.Elements), $"Entity '{nameof(DialogElement)}' with the following key(s) already exists: ({string.Join(", ", existingIds)}).");
         }
 
         _db.DialogElements.AddRange(elements);

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/UpdateDialogDto.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/UpdateDialogDto.cs
@@ -80,7 +80,7 @@ public sealed class UpdateDialogDialogGuiActionDto
     public List<LocalizationDto> Title { get; set; } = new();
 }
 
-public sealed class UpdateDialogDialogElementDto
+public class UpdateDialogDialogElementDto
 {
     public Guid? Id { get; set; }
     public Uri? Type { get; set; }

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/Get/GetDialogQuery.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/Get/GetDialogQuery.cs
@@ -11,7 +11,7 @@ namespace Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialog
 
 public sealed class GetDialogQuery : IRequest<GetDialogResult>
 {
-    public Guid Id { get; set; }
+    public Guid DialogId { get; set; }
 }
 
 [GenerateOneOf]
@@ -50,11 +50,11 @@ internal sealed class GetDialogQueryHandler : IRequestHandler<GetDialogQuery, Ge
             .IgnoreQueryFilters()
             .AsNoTracking()
             .ProjectTo<GetDialogDto>(_mapper.ConfigurationProvider)
-            .FirstOrDefaultAsync(x => x.Id == request.Id, cancellationToken);
+            .FirstOrDefaultAsync(x => x.Id == request.DialogId, cancellationToken);
 
         if (dialog is null)
         {
-            return new EntityNotFound<DialogEntity>(request.Id);
+            return new EntityNotFound<DialogEntity>(request.DialogId);
         }
 
         return dialog;

--- a/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/EndUser/Dialog/GetDialogEndpoint.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/EndUser/Dialog/GetDialogEndpoint.cs
@@ -15,7 +15,7 @@ public class GetDialogEndpoint : Endpoint<GetDialogQuery>
 
     public override void Configure()
     {
-        Get("dialogs/{id}");
+        Get("dialogs/{dialogId}");
         Group<EndUserGroup>();
     }
 

--- a/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/EndUser/DialogElement/GetDialogElementEndpoint.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/EndUser/DialogElement/GetDialogElementEndpoint.cs
@@ -15,7 +15,7 @@ public class GetDialogElementEndpoint : Endpoint<GetDialogElementQuery>
 
     public override void Configure()
     {
-        Get("dialogs/{dialogId}/dialogelements/{dialogElementId}");
+        Get("dialogs/{dialogId}/elements/{elementId}");
         Group<EndUserGroup>();
     }
 

--- a/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/EndUser/DialogElement/ListDialogElementEndpoint.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/EndUser/DialogElement/ListDialogElementEndpoint.cs
@@ -15,7 +15,7 @@ public class ListDialogElementEndpoint : Endpoint<ListDialogElementQuery>
 
     public override void Configure()
     {
-        Get("dialogs/{dialogId}/dialogelements");
+        Get("dialogs/{dialogId}/elements");
         Group<EndUserGroup>();
     }
 

--- a/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/Dialog/DeleteDialogEndpoint.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/Dialog/DeleteDialogEndpoint.cs
@@ -16,13 +16,13 @@ public sealed class DeleteDialogEndpoint : Endpoint<DeleteDialogRequest>
 
     public override void Configure()
     {
-        Delete("dialogs/{id}");
+        Delete("dialogs/{dialogId}");
         Group<ServiceOwnerGroup>();
     }
 
     public override async Task HandleAsync(DeleteDialogRequest req, CancellationToken ct)
     {
-        var command = new DeleteDialogCommand { Id = req.Id, ETag = req.ETag };
+        var command = new DeleteDialogCommand { Id = req.DialogId, ETag = req.ETag };
         var result = await _sender.Send(command, ct);
         await result.Match(
             success => SendNoContentAsync(ct),
@@ -33,7 +33,7 @@ public sealed class DeleteDialogEndpoint : Endpoint<DeleteDialogRequest>
 
 public sealed class DeleteDialogRequest
 {
-    public Guid Id { get; set; }
+    public Guid DialogId { get; set; }
 
     [FromHeader(headerName: Constants.IfMatch, isRequired: false)]
     public Guid? ETag { get; set; }

--- a/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/Dialog/DialogsController.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/Dialog/DialogsController.cs
@@ -43,10 +43,6 @@ public sealed class DialogsController : ControllerBase
             return NotFound(HttpContext.ResponseBuilder(StatusCodes.Status404NotFound, entityNotFound.ToValidationResults()));
         }
 
-        // Remove all existing activities, since this list is append only and
-        // existing activities should not be considered in the patch request.
-        dialog.Activities.Clear();
-
         var updateDialogDto = _mapper.Map<UpdateDialogDto>(dialog);
         patchDocument.ApplyTo(updateDialogDto, ModelState);
         if (!ModelState.IsValid)

--- a/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/Dialog/DialogsController.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/Dialog/DialogsController.cs
@@ -30,14 +30,14 @@ public sealed class DialogsController : ControllerBase
     }
 
     [AllowAnonymous]
-    [HttpPatch("{id}")]
+    [HttpPatch("{dialogId}")]
     public async Task<IActionResult> Patch(
-        [FromRoute] Guid id,
+        [FromRoute] Guid dialogId,
         [FromHeader(Name = Constants.IfMatch)] Guid? etag,
         [FromBody] JsonPatchDocument<UpdateDialogDto> patchDocument,
         CancellationToken ct)
     {
-        var dialogQueryResult = await _sender.Send(new GetDialogQuery { Id = id }, ct);
+        var dialogQueryResult = await _sender.Send(new GetDialogQuery { DialogId = dialogId }, ct);
         if (dialogQueryResult.TryPickT1(out var entityNotFound, out var dialog))
         {
             return NotFound(HttpContext.ResponseBuilder(StatusCodes.Status404NotFound, entityNotFound.ToValidationResults()));
@@ -54,7 +54,7 @@ public sealed class DialogsController : ControllerBase
             return BadRequest(ModelState);
         }
 
-        var command = new UpdateDialogCommand { Id = id, ETag = etag, Dto = updateDialogDto };
+        var command = new UpdateDialogCommand { Id = dialogId, ETag = etag, Dto = updateDialogDto };
         var result = await _sender.Send(command, ct);
         return result.Match(
             success => (IActionResult)NoContent(),

--- a/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/Dialog/GetDialogEndpoint.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/Dialog/GetDialogEndpoint.cs
@@ -15,7 +15,7 @@ public class GetDialogEndpoint : Endpoint<GetDialogQuery>
 
     public override void Configure()
     {
-        Get("dialogs/{id}");
+        Get("dialogs/{dialogId}");
         Group<ServiceOwnerGroup>();
     }
 

--- a/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/Dialog/UpdateDialogEndpoint.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/Dialog/UpdateDialogEndpoint.cs
@@ -16,13 +16,13 @@ public sealed class UpdateDialogEndpoint : Endpoint<UpdateDialogRequest>
 
     public override void Configure()
     {
-        Put("dialogs/{id}");
+        Put("dialogs/{dialogId}");
         Group<ServiceOwnerGroup>();
     }
 
     public override async Task HandleAsync(UpdateDialogRequest req, CancellationToken ct)
     {
-        var command = new UpdateDialogCommand { Id = req.Id, ETag = req.ETag, Dto = req.Dto };
+        var command = new UpdateDialogCommand { Id = req.DialogId, ETag = req.ETag, Dto = req.Dto };
         var updateDialogResult = await _sender.Send(command, ct);
         await updateDialogResult.Match(
             success => SendNoContentAsync(ct),
@@ -35,7 +35,7 @@ public sealed class UpdateDialogEndpoint : Endpoint<UpdateDialogRequest>
 
 public sealed class UpdateDialogRequest
 {
-    public Guid Id { get; set; }
+    public Guid DialogId { get; set; }
 
     [FromBody]
     public UpdateDialogDto Dto { get; set; } = null!;

--- a/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/DialogActivity/CreateDialogActivityEndpoint.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/DialogActivity/CreateDialogActivityEndpoint.cs
@@ -27,7 +27,7 @@ public sealed class CreateDialogActivityEndpoint : Endpoint<CreateDialogActivity
 
     public override async Task HandleAsync(CreateDialogActivityRequest request, CancellationToken ct)
     {
-        var dialogQueryResult = await _sender.Send(new GetDialogQuery {Id = request.DialogId}, ct);
+        var dialogQueryResult = await _sender.Send(new GetDialogQuery {DialogId = request.DialogId}, ct);
         if (dialogQueryResult.TryPickT1(out var entityNotFound, out var dialog))
         {
            await this.NotFoundAsync(entityNotFound, cancellationToken: ct);

--- a/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/DialogElement/CreateDialogElementEndpoint.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/DialogElement/CreateDialogElementEndpoint.cs
@@ -16,7 +16,7 @@ public sealed class CreateDialogActivityEndpoint : Endpoint<CreateDialogElementR
     public CreateDialogActivityEndpoint(ISender sender, IMapper mapper)
     {
         _sender = sender ?? throw new ArgumentNullException(nameof(sender));
-        _mapper = mapper;
+        _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
     }
 
     public override void Configure()

--- a/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/DialogElement/CreateDialogElementEndpoint.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/DialogElement/CreateDialogElementEndpoint.cs
@@ -1,0 +1,67 @@
+using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialogs.Queries.Get;
+using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialogs.Commands.Update;
+using Digdir.Domain.Dialogporten.WebApi.Common;
+using FastEndpoints;
+using MediatR;
+using Medo;
+using IMapper = AutoMapper.IMapper;
+
+namespace Digdir.Domain.Dialogporten.WebApi.Endpoints.V1.ServiceOwner.DialogElement;
+
+public sealed class CreateDialogActivityEndpoint : Endpoint<CreateDialogElementRequest>
+{
+    private readonly IMapper _mapper;
+    private readonly ISender _sender;
+
+    public CreateDialogActivityEndpoint(ISender sender, IMapper mapper)
+    {
+        _sender = sender ?? throw new ArgumentNullException(nameof(sender));
+        _mapper = mapper;
+    }
+
+    public override void Configure()
+    {
+        Post("dialogs/{dialogId}/elements");
+        Group<ServiceOwnerGroup>();
+    }
+
+    public override async Task HandleAsync(CreateDialogElementRequest request, CancellationToken ct)
+    {
+        var dialogQueryResult = await _sender.Send(new GetDialogQuery {Id = request.DialogId}, ct);
+        if (dialogQueryResult.TryPickT1(out var entityNotFound, out var dialog))
+        {
+           await this.NotFoundAsync(entityNotFound, cancellationToken: ct);
+           return;
+        }
+
+        // Remove all existing activities, since this list is append only and
+        // existing activities should not be considered in the new update request.
+        dialog.Activities.Clear();
+        
+        var updateDialogDto = _mapper.Map<UpdateDialogDto>(dialog);
+
+        request.Id = !request.Id.HasValue || request.Id.Value == default
+            ? Uuid7.NewUuid7().ToGuid()
+            : request.Id; 
+        
+        updateDialogDto.Elements.Add(request);
+
+        var updateDialogCommand = new UpdateDialogCommand {Id = request.DialogId, ETag = request.ETag, Dto = updateDialogDto};
+        
+        var result = await _sender.Send(updateDialogCommand, ct);
+        await result.Match(
+            success => SendCreatedAtAsync<GetDialogElementEndpoint>(new {request.Id}, request.Id, cancellation: ct),
+            notFound => this.NotFoundAsync(notFound, ct),
+            validationError => this.BadRequestAsync(validationError, ct),
+            domainError => this.UnprocessableEntityAsync(domainError, ct),
+            concurrencyError => this.PreconditionFailed(cancellationToken: ct));
+    }
+}
+
+public sealed class CreateDialogElementRequest : UpdateDialogDialogElementDto
+{
+    public Guid DialogId { get; set; }
+    
+    [FromHeader(headerName: Constants.IfMatch, isRequired: false)]
+    public Guid? ETag { get; set; }
+}

--- a/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/DialogElement/CreateDialogElementEndpoint.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/DialogElement/CreateDialogElementEndpoint.cs
@@ -34,10 +34,6 @@ public sealed class CreateDialogActivityEndpoint : Endpoint<CreateDialogElementR
             return;
         }
 
-        // Remove all existing activities, since this list is append only and
-        // existing activities should not be considered in the new update request.
-        dialog.Activities.Clear();
-
         var updateDialogDto = _mapper.Map<UpdateDialogDto>(dialog);
 
         request.Id = !request.Id.HasValue || request.Id.Value == default

--- a/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/DialogElement/DeleteDialogElementEndpoint.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/DialogElement/DeleteDialogElementEndpoint.cs
@@ -1,0 +1,72 @@
+using Digdir.Domain.Dialogporten.Application.Common.ReturnTypes;
+using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialogs.Commands.Update;
+using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialogs.Queries.Get;
+using Digdir.Domain.Dialogporten.WebApi.Common;
+using FastEndpoints;
+using MediatR;
+using IMapper = AutoMapper.IMapper;
+
+namespace Digdir.Domain.Dialogporten.WebApi.Endpoints.V1.ServiceOwner.DialogElement;
+
+public sealed class DeleteDialogActivityEndpoint : Endpoint<DeleteDialogElementRequest>
+{
+    private readonly IMapper _mapper;
+    private readonly ISender _sender;
+
+    public DeleteDialogActivityEndpoint(ISender sender, IMapper mapper)
+    {
+        _sender = sender ?? throw new ArgumentNullException(nameof(sender));
+        _mapper = mapper;
+    }
+
+    public override void Configure()
+    {
+        Delete("dialogs/{dialogId}/elements/{elementId}");
+        Group<ServiceOwnerGroup>();
+    }
+
+    public override async Task HandleAsync(DeleteDialogElementRequest request, CancellationToken ct)
+    {
+        var dialogQueryResult = await _sender.Send(new GetDialogQuery {DialogId = request.DialogId}, ct);
+        if (dialogQueryResult.TryPickT1(out var entityNotFound, out var dialog))
+        {
+            await this.NotFoundAsync(entityNotFound, cancellationToken: ct);
+            return;
+        }
+
+        // Remove all existing activities, since this list is append only and
+        // existing activities should not be considered in the new update request.
+        dialog.Activities.Clear();
+
+        var updateDialogDto = _mapper.Map<UpdateDialogDto>(dialog);
+
+        var dialogElement = updateDialogDto.Elements.SingleOrDefault(x => x.Id == request.ElementId);
+        if (dialogElement is null)
+        {
+            await this.NotFoundAsync(new EntityNotFound<Domain.Dialogs.Entities.DialogElements.DialogElement>(request.ElementId), cancellationToken: ct);
+            return;
+        }
+        
+        updateDialogDto.Elements.Remove(dialogElement);
+
+        var updateDialogCommand = new UpdateDialogCommand
+            {Id = request.DialogId, ETag = request.ETag, Dto = updateDialogDto};
+
+        var result = await _sender.Send(updateDialogCommand, ct);
+        await result.Match(
+            success => SendNoContentAsync(ct),
+            notFound => this.NotFoundAsync(notFound, ct),
+            validationError => this.BadRequestAsync(validationError, ct),
+            domainError => this.UnprocessableEntityAsync(domainError, ct),
+            concurrencyError => this.PreconditionFailed(cancellationToken: ct));
+    }
+}
+
+public sealed class DeleteDialogElementRequest 
+{
+    public Guid DialogId { get; set; }
+    public Guid ElementId { get; set; }
+
+    [FromHeader(headerName: Constants.IfMatch, isRequired: false)]
+    public Guid? ETag { get; set; }
+}

--- a/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/DialogElement/DeleteDialogElementEndpoint.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/DialogElement/DeleteDialogElementEndpoint.cs
@@ -16,7 +16,7 @@ public sealed class DeleteDialogActivityEndpoint : Endpoint<DeleteDialogElementR
     public DeleteDialogActivityEndpoint(ISender sender, IMapper mapper)
     {
         _sender = sender ?? throw new ArgumentNullException(nameof(sender));
-        _mapper = mapper;
+        _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
     }
 
     public override void Configure()

--- a/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/DialogElement/DeleteDialogElementEndpoint.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/DialogElement/DeleteDialogElementEndpoint.cs
@@ -40,7 +40,7 @@ public sealed class DeleteDialogActivityEndpoint : Endpoint<DeleteDialogElementR
 
         var updateDialogDto = _mapper.Map<UpdateDialogDto>(dialog);
 
-        var dialogElement = updateDialogDto.Elements.SingleOrDefault(x => x.Id == request.ElementId);
+        var dialogElement = updateDialogDto.Elements.FirstOrDefault(x => x.Id == request.ElementId);
         if (dialogElement is null)
         {
             await this.NotFoundAsync(new EntityNotFound<Domain.Dialogs.Entities.DialogElements.DialogElement>(request.ElementId), cancellationToken: ct);

--- a/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/DialogElement/GetDialogElementEndpoint.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/DialogElement/GetDialogElementEndpoint.cs
@@ -15,7 +15,7 @@ public class GetDialogElementEndpoint : Endpoint<GetDialogElementQuery>
 
     public override void Configure()
     {
-        Get("dialogs/{dialogId}/dialogelements/{dialogElementId}");
+        Get("dialogs/{dialogId}/elements/{elementId}");
         Group<ServiceOwnerGroup>();
     }
 

--- a/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/DialogElement/ListDialogElementEndpoint.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/DialogElement/ListDialogElementEndpoint.cs
@@ -15,7 +15,7 @@ public class ListDialogElementEndpoint : Endpoint<ListDialogElementQuery>
 
     public override void Configure()
     {
-        Get("dialogs/{dialogId}/dialogelements");
+        Get("dialogs/{dialogId}/elements");
         Group<ServiceOwnerGroup>();
     }
 

--- a/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/DialogElement/UpdateDialogElementEndpoint.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/DialogElement/UpdateDialogElementEndpoint.cs
@@ -44,14 +44,16 @@ public sealed class UpdateDialogActivityEndpoint : Endpoint<UpdateDialogElementR
         var dialogElement = updateDialogDto.Elements.SingleOrDefault(x => x.Id == request.ElementId);
         if (dialogElement is null)
         {
-            await this.NotFoundAsync(new EntityNotFound<Domain.Dialogs.Entities.DialogElements.DialogElement>(request.ElementId), cancellationToken: ct);
+            await this.NotFoundAsync(
+                new EntityNotFound<Domain.Dialogs.Entities.DialogElements.DialogElement>(request.ElementId),
+                cancellationToken: ct);
             return;
         }
 
         updateDialogDto.Elements.Remove(dialogElement);
-        
-        var updateDialogDialogActivityDto = MapToUpdateDto(request);
-        updateDialogDto.Elements.Add(updateDialogDialogActivityDto);
+
+        var updateDialogElementDto = MapToUpdateDto(request);
+        updateDialogDto.Elements.Add(updateDialogElementDto);
 
         var updateDialogCommand = new UpdateDialogCommand
             {Id = request.DialogId, ETag = request.ETag, Dto = updateDialogDto};
@@ -65,31 +67,26 @@ public sealed class UpdateDialogActivityEndpoint : Endpoint<UpdateDialogElementR
             concurrencyError => this.PreconditionFailed(cancellationToken: ct));
     }
 
-    private static UpdateDialogDialogElementDto MapToUpdateDto(UpdateDialogElementRequest request)
+    private static UpdateDialogDialogElementDto MapToUpdateDto(UpdateDialogElementRequest request) => new()
     {
-        var updateDialogDialogElementDto = new UpdateDialogDialogElementDto
-        {
-            Id = request.ElementId,
-            Type = request.Type,
-            AuthorizationAttribute = request.AuthorizationAttribute,
-            RelatedDialogElementId = request.RelatedDialogElementId,
-            DisplayName = request.DisplayName,
-            Urls = request.Urls
-        };
-        
-        return updateDialogDialogElementDto;
-    }
+        Id = request.ElementId,
+        Type = request.Type,
+        AuthorizationAttribute = request.AuthorizationAttribute,
+        RelatedDialogElementId = request.RelatedDialogElementId,
+        DisplayName = request.DisplayName,
+        Urls = request.Urls
+    };
 }
 
 public sealed class UpdateDialogElementRequest
 {
     public Guid DialogId { get; set; }
-    
+
     public Guid ElementId { get; set; }
-    
+
     [FromHeader(headerName: Constants.IfMatch, isRequired: false)]
     public Guid? ETag { get; set; }
-    
+
     public Uri? Type { get; set; }
     public string? AuthorizationAttribute { get; set; }
 

--- a/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/DialogElement/UpdateDialogElementEndpoint.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/DialogElement/UpdateDialogElementEndpoint.cs
@@ -1,0 +1,100 @@
+using Digdir.Domain.Dialogporten.Application.Common.ReturnTypes;
+using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Localizations;
+using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialogs.Commands.Update;
+using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialogs.Queries.Get;
+using Digdir.Domain.Dialogporten.WebApi.Common;
+using FastEndpoints;
+using MediatR;
+using IMapper = AutoMapper.IMapper;
+
+namespace Digdir.Domain.Dialogporten.WebApi.Endpoints.V1.ServiceOwner.DialogElement;
+
+public sealed class UpdateDialogActivityEndpoint : Endpoint<UpdateDialogElementRequest>
+{
+    private readonly IMapper _mapper;
+    private readonly ISender _sender;
+
+    public UpdateDialogActivityEndpoint(ISender sender, IMapper mapper)
+    {
+        _sender = sender ?? throw new ArgumentNullException(nameof(sender));
+        _mapper = mapper;
+    }
+
+    public override void Configure()
+    {
+        Put("dialogs/{dialogId}/elements/{elementId}");
+        Group<ServiceOwnerGroup>();
+    }
+
+    public override async Task HandleAsync(UpdateDialogElementRequest request, CancellationToken ct)
+    {
+        var dialogQueryResult = await _sender.Send(new GetDialogQuery {DialogId = request.DialogId}, ct);
+        if (dialogQueryResult.TryPickT1(out var entityNotFound, out var dialog))
+        {
+            await this.NotFoundAsync(entityNotFound, cancellationToken: ct);
+            return;
+        }
+
+        // Remove all existing activities, since this list is append only and
+        // existing activities should not be considered in the new update request.
+        dialog.Activities.Clear();
+
+        var updateDialogDto = _mapper.Map<UpdateDialogDto>(dialog);
+
+        var dialogElement = updateDialogDto.Elements.SingleOrDefault(x => x.Id == request.ElementId);
+        if (dialogElement is null)
+        {
+            await this.NotFoundAsync(new EntityNotFound<Domain.Dialogs.Entities.DialogElements.DialogElement>(request.ElementId), cancellationToken: ct);
+            return;
+        }
+
+        updateDialogDto.Elements.Remove(dialogElement);
+        
+        var updateDialogDialogActivityDto = MapToUpdateDto(request);
+        updateDialogDto.Elements.Add(updateDialogDialogActivityDto);
+
+        var updateDialogCommand = new UpdateDialogCommand
+            {Id = request.DialogId, ETag = request.ETag, Dto = updateDialogDto};
+
+        var result = await _sender.Send(updateDialogCommand, ct);
+        await result.Match(
+            success => SendNoContentAsync(ct),
+            notFound => this.NotFoundAsync(notFound, ct),
+            validationError => this.BadRequestAsync(validationError, ct),
+            domainError => this.UnprocessableEntityAsync(domainError, ct),
+            concurrencyError => this.PreconditionFailed(cancellationToken: ct));
+    }
+
+    private static UpdateDialogDialogElementDto MapToUpdateDto(UpdateDialogElementRequest request)
+    {
+        var updateDialogDialogElementDto = new UpdateDialogDialogElementDto
+        {
+            Id = request.ElementId,
+            Type = request.Type,
+            AuthorizationAttribute = request.AuthorizationAttribute,
+            RelatedDialogElementId = request.RelatedDialogElementId,
+            DisplayName = request.DisplayName,
+            Urls = request.Urls
+        };
+        
+        return updateDialogDialogElementDto;
+    }
+}
+
+public sealed class UpdateDialogElementRequest
+{
+    public Guid DialogId { get; set; }
+    
+    public Guid ElementId { get; set; }
+    
+    [FromHeader(headerName: Constants.IfMatch, isRequired: false)]
+    public Guid? ETag { get; set; }
+    
+    public Uri? Type { get; set; }
+    public string? AuthorizationAttribute { get; set; }
+
+    public Guid? RelatedDialogElementId { get; set; }
+
+    public List<LocalizationDto> DisplayName { get; set; } = new();
+    public List<UpdateDialogDialogElementUrlDto> Urls { get; set; } = new();
+}

--- a/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/DialogElement/UpdateDialogElementEndpoint.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/DialogElement/UpdateDialogElementEndpoint.cs
@@ -17,7 +17,7 @@ public sealed class UpdateDialogActivityEndpoint : Endpoint<UpdateDialogElementR
     public UpdateDialogActivityEndpoint(ISender sender, IMapper mapper)
     {
         _sender = sender ?? throw new ArgumentNullException(nameof(sender));
-        _mapper = mapper;
+        _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
     }
 
     public override void Configure()
@@ -37,7 +37,7 @@ public sealed class UpdateDialogActivityEndpoint : Endpoint<UpdateDialogElementR
 
         var updateDialogDto = _mapper.Map<UpdateDialogDto>(dialog);
 
-        var dialogElement = updateDialogDto.Elements.SingleOrDefault(x => x.Id == request.ElementId);
+        var dialogElement = updateDialogDto.Elements.FirstOrDefault(x => x.Id == request.ElementId);
         if (dialogElement is null)
         {
             await this.NotFoundAsync(

--- a/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/DialogElement/UpdateDialogElementEndpoint.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/DialogElement/UpdateDialogElementEndpoint.cs
@@ -35,10 +35,6 @@ public sealed class UpdateDialogActivityEndpoint : Endpoint<UpdateDialogElementR
             return;
         }
 
-        // Remove all existing activities, since this list is append only and
-        // existing activities should not be considered in the new update request.
-        dialog.Activities.Clear();
-
         var updateDialogDto = _mapper.Map<UpdateDialogDto>(dialog);
 
         var dialogElement = updateDialogDto.Elements.SingleOrDefault(x => x.Id == request.ElementId);

--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/Dialogs/Queries/GetDialogTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/Dialogs/Queries/GetDialogTests.cs
@@ -32,7 +32,7 @@ public class GetDialogTests : ApplicationCollectionFixture
         var createCommandResponse = await Application.Send(createDialogCommand);
 
         // Act
-        var response = await Application.Send(new GetDialogQuery { Id = createCommandResponse.AsT0.Value });
+        var response = await Application.Send(new GetDialogQuery { DialogId = createCommandResponse.AsT0.Value });
 
         // Assert
         response.TryPickT0(out var result, out var _).Should().BeTrue();
@@ -159,7 +159,7 @@ public class GetDialogTests : ApplicationCollectionFixture
         var createCommandResponse = await Application.Send(createCommand);
 
         // Act
-        var response = await Application.Send(new GetDialogQuery { Id = createCommandResponse.AsT0.Value });
+        var response = await Application.Send(new GetDialogQuery { DialogId = createCommandResponse.AsT0.Value });
 
         // Assert
         response.TryPickT0(out var result, out var _).Should().BeTrue();


### PR DESCRIPTION
* Adds POST/PUT/DELETE for dialog elements
* Cleans up url paths and parameter names
  * Removes "dialog", `/dialogelements/{dialogElementId}` => `/elements/{elementId}`
  * Changes `id` to `dialogId` for all endpoints, this gives us better grouping/sorting in Swagger
* Misc typos/variable name changes
* Postman collection updated

<img src="https://github.com/digdir/dialogporten/assets/5313373/b877ec0a-bb0a-4578-9fec-38fecaa9fa63" width="500">


