### PR TITLE
More search tests + fix body searching

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/List/ListDialogQuery.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/List/ListDialogQuery.cs
@@ -91,6 +91,7 @@ internal sealed class ListDialogQueryHandler : IRequestHandler<ListDialogQuery, 
             .WhereIf(request.VisibleBefore.HasValue, x => x.VisibleFrom <= request.VisibleBefore)
             .WhereIf(request.Search is not null, x =>
                 x.Title!.Localizations.AsQueryable().Any(searchExpression) ||
+                x.Body!.Localizations.AsQueryable().Any(searchExpression) ||
                 x.SearchTags.Any(x => x.Value == request.Search!.ToLower()) ||
                 x.SenderName!.Localizations.AsQueryable().Any(searchExpression)
             )

--- a/tests/k6/common/console.js
+++ b/tests/k6/common/console.js
@@ -1,0 +1,26 @@
+var originalLog = console.log;
+
+function customDir(obj) {
+    var seen = [];
+
+    var replacer = function(key, value) {
+      if (typeof value === "object" && value !== null) {
+        if (seen.indexOf(value) !== -1) {
+          return "[Circular]";
+        }
+        seen.push(value);
+      }
+      return value;
+    };
+
+    var stringified = JSON.stringify(obj, replacer, 2);
+    originalLog(stringified);
+}
+
+export var customConsole = {
+  log: originalLog,
+  dir: customDir,
+  // You can manually add other console methods if needed, such as warn, error, etc.
+  warn: console.warn,
+  error: console.error
+};

--- a/tests/k6/common/describe.js
+++ b/tests/k6/common/describe.js
@@ -18,8 +18,7 @@ export function describe(name, fn) {
         if (error.expected) {
             errmsg += ` expected:${error.expected} actual:${error.actual}`;
         }
-        
-        console.error(errmsg);
+        console.warn(errmsg);
       }
     });
   

--- a/tests/k6/common/dialog.js
+++ b/tests/k6/common/dialog.js
@@ -1,0 +1,147 @@
+import { customConsole as console } from './console.js';
+
+export function setTitle(dialog, title, language = "nb_NO") {
+    if (typeof title !== "string") {
+        throw new Error("Invalid title provided.");
+    }
+
+    dialog.title = dialog.title || [];
+    const index = dialog.title.findIndex(t => t.cultureCode === language);
+    
+    if (index !== -1) {
+        dialog.title[index].value = title;
+    } else {
+        dialog.title.push({ cultureCode: language, value: title });
+    }
+}
+
+export function setBody(dialog, body, language = "nb_NO") {
+    if (typeof body !== "string") {
+        throw new Error("Invalid body provided.");
+    }
+
+    dialog.body = dialog.body || [];
+    const index = dialog.body.findIndex(t => t.cultureCode === language);
+    
+    if (index !== -1) {
+        dialog.body[index].value = body;
+    } else {
+        dialog.body.push({ cultureCode: language, value: body });
+    }
+}
+
+export function setSearchTags(dialog, searchTags) {
+    if (!Array.isArray(searchTags) || searchTags.some(tag => typeof tag !== "string")) {
+        throw new Error("Invalid search tags provided.");
+    }
+    let tags = [];
+    searchTags.forEach((t) => {
+        tags.push({ "value": t });
+    })
+
+    dialog.searchTags = tags;
+}
+
+export function setSenderName(dialog, senderName, language = "nb_NO") {
+    if (typeof senderName !== "string") {
+        throw new Error("Invalid sender name provided.");
+    }
+
+    dialog.senderName = dialog.senderName || [];
+    const index = dialog.senderName.findIndex(b => b.cultureCode === language);
+
+    if (index !== -1) {
+        dialog.senderName[index].value = senderName;
+    } else {
+        dialog.senderName.push({ cultureCode: language, value: senderName });
+    }
+}
+
+export function setStatus(dialog, status) {
+    const validStatuses = ["unspecified", "inprogress", "waiting", "signing", "cancelled", "completed"];
+    
+    if (!validStatuses.includes(status)) {
+        throw new Error("Invalid status provided.");
+    }
+
+    dialog.status = status;
+}
+
+export function setExtendedStatus(dialog, extendedStatus) {
+    if (!isValidURI(extendedStatus)) {
+        throw new Error("Invalid extended status provided.");
+    }
+
+    dialog.extendedStatus = extendedStatus;
+}
+
+export function setServiceResource(dialog, serviceResource) {
+    if (typeof serviceResource !== "string" || !serviceResource.startsWith("urn:altinn:resource:")) {
+        throw new Error("Invalid service resource provided.");
+    }
+
+    dialog.serviceResource = serviceResource;
+}
+
+export function setParty(dialog, party) {
+    const partyRegex = /^\/(org\/\d{9}|person\/\d{11})$/;
+    
+    if (!partyRegex.test(party)) {
+        throw new Error("Invalid party provided.");
+    }
+
+    dialog.party = party;
+}
+
+export function setDueAt(dialog, dueAt) {
+    if (dueAt instanceof Date) {
+        dueAt = dateToUTCString(dueAt);
+    }
+
+    if (!validateUTCDate(dueAt)) {
+        throw new Error("Invalid dueAt date provided: " + dueAt);
+    }
+
+    dialog.dueAt = dueAt;
+}
+
+export function setExpiresAt(dialog, expiresAt) {
+    if (expiresAt instanceof Date) {
+        expiresAt = dateToUTCString(expiresAt);
+    }
+
+    if (!validateUTCDate(expiresAt)) {
+        throw new Error("Invalid expiresAt date provided: " + expiresAt);
+    }
+
+    dialog.expiresAt = expiresAt;
+}
+
+export function setVisibleFrom(dialog, visibleFrom) {
+    if (visibleFrom instanceof Date) {
+        visibleFrom = dateToUTCString(visibleFrom);
+    }
+
+    if (!validateUTCDate(visibleFrom)) {
+        throw new Error("Invalid visibleFrom date provided:" + visibleFrom);
+    }
+
+    dialog.visibleFrom = visibleFrom;
+}
+
+function dateToUTCString(date) {
+    let dateStr = date.toISOString();
+    const ms = ('000' + date.getUTCMilliseconds()).slice(-3);
+    return dateStr.substr(0, 20) + ms + '0000' + 'Z';
+}
+
+function validateUTCDate(date) {
+    const dateRegex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{7}Z$/;
+    return dateRegex.test(date);
+}
+
+function isValidURI(uri) {
+    // A basic regex for RFC 2396 URI validation
+    var pattern = /^([a-zA-Z][a-zA-Z0-9+-\.]*:)(\/\/[^/?#]*)?([^?#]*)(\?[^#]*)?(#.*)?$/;
+    return pattern.test(uri);
+}

--- a/tests/k6/common/k6chai.js
+++ b/tests/k6/common/k6chai.js
@@ -1,1 +1,57 @@
-export { default as chai, expect } from 'https://jslib.k6.io/k6chaijs/4.3.4.3/index.js';
+
+import { default as chai, expect } from 'https://jslib.k6.io/k6chaijs/4.3.4.3/index.js';
+
+function expectStatusFor(response) {
+    return {
+        to: {
+            equal(expectedStatus) {
+
+                try {
+                    expect(response.status, "response status").to.equal(expectedStatus);
+                }
+                catch (e) {
+                    let errorDetails = "";
+                    try {
+                        if (response.body) {
+                            let body = response.json();
+                            if (body["errors"]) {
+                                errorDetails = ", errorDetails: " + JSON.stringify(body["errors"]);
+                            }
+                        }
+                    } catch (e) {};
+
+                    e.message += errorDetails;
+                    throw e;
+                }
+            }
+        },
+    };
+}
+
+
+chai.use(function(chai, utils) {
+    chai.Assertion.addMethod('hasLocalizedText', function(expectedValue, cultureCode) {
+      const obj = this._obj; // current object under assertion
+  
+      // Ensure the current object is an array (i.e., the 'name' property in your case)
+      new chai.Assertion(obj).to.be.an('array');
+  
+      let foundItem;
+      if (cultureCode) {
+        // Check if an item with the specified cultureCode and value exists
+        foundItem = obj.find(item => item.cultureCode.toLowerCase() === cultureCode.toLowerCase() && item.value === expectedValue);
+      } else {
+        // Check if any item with the specified value exists
+        foundItem = obj.find(item => item.value === expectedValue);
+      }
+  
+      // Assertion
+      this.assert(
+        foundItem !== undefined,
+        `expected #{this} to have a localized text of ${expectedValue}${cultureCode ? ` with culture code ${cultureCode}` : ''}`,
+        `expected #{this} not to have a localized text of ${expectedValue}${cultureCode ? ` with culture code ${cultureCode}` : ''}`
+      );
+    });
+  });
+
+export { chai, expect, expectStatusFor }

--- a/tests/k6/common/request.js
+++ b/tests/k6/common/request.js
@@ -44,21 +44,32 @@ function getEnduserRequestParams(params = null, tokenOptions = null) {
     return resolveParams(defaultParams, params);
 }
 
+function maybeStringifyBody(maybeObject) {
+    if (typeof maybeObject !== "string") {
+        return JSON.stringify(maybeObject);
+    }
+
+    return maybeObject;
+}
+
 export function getSO(url, params = null, tokenOptions = null) {
     return http.get(baseUrlServiceOwner + url, getServiceOwnerRequestParams(params, tokenOptions))
 }
 
 export function postSO(url, body, params = null, tokenOptions = null) {
+    body = maybeStringifyBody(body);
     params = extend(true, {}, params, { headers: { 'Content-Type': 'application/json' }});
     return http.post(baseUrlServiceOwner + url, body, getServiceOwnerRequestParams(params, tokenOptions));
 }
 
 export function putSO(url, body, params = null, tokenOptions = null) {
+    body = maybeStringifyBody(body);
     params = extend(true, {}, params, { headers: { 'Content-Type': 'application/json' }});
     return http.put(baseUrlServiceOwner + url, body, getServiceOwnerRequestParams(params, tokenOptions));
 }
 
 export function patchSO(url, body, params = null, tokenOptions = null) {
+    body = maybeStringifyBody(body);
     params = extend(true, {}, params, { headers: { 'Content-Type': 'application/json' }});
     return http.patch(baseUrlServiceOwner + url, body, getServiceOwnerRequestParams(params, tokenOptions));
 }
@@ -72,16 +83,19 @@ export function getEU(url, params = null, tokenOptions = null) {
 }
 
 export function postEU(url, body, params = null, tokenOptions = null) {
+    body = maybeStringifyBody(body);
     params = extend(true, {}, params, { headers: { 'Content-Type': 'application/json' }});
     return http.post(baseUrlEndUser + url, body, getEnduserRequestParams(params, tokenOptions));
 }
 
 export function putEU(url, body, params = null, tokenOptions = null) {
+    body = maybeStringifyBody(body);
     params = extend(true, {}, params, { headers: { 'Content-Type': 'application/json' }});
     return http.put(baseUrlEndUser + url, body, getEnduserRequestParams(params, tokenOptions));
 }
 
 export function patchEU(url, body, params = null, tokenOptions = null) {
+    body = maybeStringifyBody(body);
     params = extend(true, {}, params, { headers: { 'Content-Type': 'application/json' }});
     return http.patch(baseUrlEndUser + url, body, getEnduserRequestParams(params, tokenOptions));
 }

--- a/tests/k6/common/testimports.js
+++ b/tests/k6/common/testimports.js
@@ -1,6 +1,7 @@
-export { chai, expect } from './k6chai.js';
+export { chai, expect, expectStatusFor } from './k6chai.js';
 export { uuidv4 } from './uuid.js';
 export { describe } from './describe.js';
+export { customConsole  } from './console.js';
 export { getServiceOwnerTokenFromGenerator, getEnduserTokenFromGenerator } from './token.js';
 export { 
     getEU,
@@ -10,3 +11,16 @@ export {
     patchSO,
     deleteSO
 } from './request.js';
+export {
+    setTitle,
+    setBody,
+    setSearchTags,
+    setSenderName,
+    setStatus,
+    setExtendedStatus,
+    setServiceResource,
+    setParty,
+    setDueAt,
+    setExpiresAt,
+    setVisibleFrom
+} from './dialog.js';

--- a/tests/k6/tests/enduser/all-tests.js
+++ b/tests/k6/tests/enduser/all-tests.js
@@ -1,4 +1,4 @@
-﻿// This file is generated, see "scripts" directory
+// This file is generated, see "scripts" directory
 
 
 export default function() {

--- a/tests/k6/tests/serviceowner/all-tests.js
+++ b/tests/k6/tests/serviceowner/all-tests.js
@@ -1,4 +1,4 @@
-﻿// This file is generated, see "scripts" directory
+// This file is generated, see "scripts" directory
 import { default as authentication } from './authentication.js';
 import { default as authorization } from './authorization.js';
 import { default as dialogCreateInvalidActionCount } from './dialogCreateInvalidActionCount.js';

--- a/tests/k6/tests/serviceowner/authorization.js
+++ b/tests/k6/tests/serviceowner/authorization.js
@@ -1,4 +1,4 @@
-import { describe, expect, getSO, postSO, putSO, patchSO, deleteSO, uuidv4 } from '../../common/testimports.js'
+import { describe, expect, expectStatusFor, getSO, postSO, putSO, patchSO, deleteSO } from '../../common/testimports.js'
 import { default as dialogToInsert } from './testdata/01-create-dialog.js';
 
 export default function () {
@@ -14,8 +14,7 @@ export default function () {
     let activityId = null; // known after successful insert
    
     let expectEither = function (statusCodeSuccess, statusCodeFailure, r, shouldSucceed) {
-        if (r.status == 400) console.warn(r.body);
-        expect(r.status, 'response status').to.equal(shouldSucceed ? statusCodeSuccess : statusCodeFailure);
+        expectStatusFor(r).to.equal(shouldSucceed ? statusCodeSuccess : statusCodeFailure);
     }
 
     let permutations = [
@@ -28,7 +27,7 @@ export default function () {
         let logSuffix = shouldSucceed ? "valid serviceowner" : "invalid serviceowner"
 
         describe(`${logPrefix} dialog create as ${logSuffix}`, () => {
-            let r = postSO('dialogs', JSON.stringify(dialog), null, tokenOptions);
+            let r = postSO('dialogs', dialog, null, tokenOptions);
             expectEither(201, 403, r, shouldSucceed);
             if (r.status == 201) {
                 dialogId = r.json();
@@ -51,12 +50,12 @@ export default function () {
                     "value": "https://vg.no"
                 }
             ];
-            let r = patchSO('dialogs/' + dialogId, JSON.stringify(patchDocument), null, tokenOptions);
+            let r = patchSO('dialogs/' + dialogId, patchDocument, null, tokenOptions);
             expectEither(204, 404, r, shouldSucceed);
         });
     
         describe(`${logPrefix} updating dialog as ${logSuffix}`, () => {
-            let r = putSO('dialogs/' + dialogId, JSON.stringify(dialog), null, tokenOptions);
+            let r = putSO('dialogs/' + dialogId, dialog, null, tokenOptions);
             expectEither(204, 404, r, shouldSucceed);
         });
     
@@ -81,12 +80,12 @@ export default function () {
         });
     
         describe(`${logPrefix} posting dialog element as ${logSuffix}`, () => {            
-            let r = postSO('dialogs/' + dialogId + "/elements", JSON.stringify(dialogElement), null, tokenOptions);
+            let r = postSO('dialogs/' + dialogId + "/elements", dialogElement, null, tokenOptions);
             expectEither(201, 404, r, shouldSucceed); 
         });
     
         describe(`${logPrefix} putting dialog element as ${logSuffix}`, () => {
-            let r = putSO('dialogs/' + dialogId + "/elements/" + dialogElementId, JSON.stringify(dialogElement), null, tokenOptions);
+            let r = putSO('dialogs/' + dialogId + "/elements/" + dialogElementId, dialogElement, null, tokenOptions);
             expectEither(204, 404, r, shouldSucceed);
         });
     
@@ -109,7 +108,7 @@ export default function () {
         });
 
         describe(`${logPrefix} posting activity as ${logSuffix}`, () => {
-            let r = postSO('dialogs/' + dialogId + "/activities", JSON.stringify(activity), null, tokenOptions);
+            let r = postSO('dialogs/' + dialogId + "/activities", activity, null, tokenOptions);
             expectEither(201, 404, r, shouldSucceed);
         });
     

--- a/tests/k6/tests/serviceowner/dialogCreateInvalidActionCount.js
+++ b/tests/k6/tests/serviceowner/dialogCreateInvalidActionCount.js
@@ -4,7 +4,7 @@ import { default as dialogToInsert } from './testdata/01-create-dialog.js';
 export default function () {
 
     let expectGuiActionErrorResponseForDialog = function(dialog) {
-        let r = postSO('dialogs', JSON.stringify(dialog));
+        let r = postSO('dialogs', dialog);
         expect(r.status, 'response status').to.equal(400);
         expect(r, 'response').to.have.validJsonBody();
         expect(r.json(), 'reponse').to.have.property('errors');

--- a/tests/k6/tests/serviceowner/dialogCreatePatchDelete.js
+++ b/tests/k6/tests/serviceowner/dialogCreatePatchDelete.js
@@ -8,7 +8,7 @@ export default function () {
     let newApiActionEndpointUrl = null;
 
     describe('Perform dialog create', () => {
-        let r = postSO('dialogs', JSON.stringify(dialogToInsert()));
+        let r = postSO('dialogs', dialogToInsert());
         expect(r.status, 'response status').to.equal(201);
         expect(r, 'response').to.have.validJsonBody();
         expect(r.json(), 'response json').to.match(/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/)
@@ -39,7 +39,7 @@ export default function () {
                 "value": newApiActionEndpointUrl
             }
         ];
-        let r = patchSO('dialogs/' + dialogId, JSON.stringify(patchDocument));
+        let r = patchSO('dialogs/' + dialogId, patchDocument);
         expect(r.status, 'response status').to.equal(204);
     });
 

--- a/tests/k6/tests/serviceowner/dialogSearch.js
+++ b/tests/k6/tests/serviceowner/dialogSearch.js
@@ -1,10 +1,179 @@
-import { describe, expect, getSO } from '../../common/testimports.js'
+import { 
+    customConsole as console,
+    describe, expect, expectStatusFor,
+    getSO,
+    uuidv4,
+    setTitle,
+    setBody,
+    setSearchTags,
+    setSenderName,
+    setStatus,
+    setExtendedStatus,
+    setServiceResource,
+    setParty,
+    setDueAt,
+    setExpiresAt,
+    setVisibleFrom, 
+    postSO,
+    putSO,
+    deleteSO } from '../../common/testimports.js'
+
+import { default as dialogToInsert } from './testdata/01-create-dialog.js';
 
 export default function () {
-    describe('Perform simple dialog search', () => {
+
+    let dialogs = [];
+    let dialogIds = [];
+    
+    let titleToSearchFor = uuidv4();    
+    let bodyToSearchFor = uuidv4();
+    let searchTagsToSearchFor = [ uuidv4(), uuidv4() ];
+    let extendedStatusToSearchFor = "status:" + uuidv4();
+    let secondExtendedStatusToSearchFor = "status:" + uuidv4();
+    let senderNameToSearchFor = uuidv4()
+    let titleForDueAtItem = uuidv4();
+    let titleForExpiresAtItem = uuidv4();
+    let titleForVisibleFromItem = uuidv4();
+    let titleForUpdatedItem = uuidv4();
+    let titleForLastItem = uuidv4();
+
+    describe('Arrange: Create some dialogs to test against', () => {
+
+        for (let i = 0; i < 20; i++) {
+            let d = dialogToInsert();
+            setTitle(d, "e2e-test-dialog #" + (i+1), "nn_NO");
+            dialogs.push(d);
+        }
+
+        let d = -1;        
+        setTitle(dialogs[++d], titleToSearchFor);
+        setBody(dialogs[++d], bodyToSearchFor);
+        setSearchTags(dialogs[++d], searchTagsToSearchFor);
+        setStatus(dialogs[++d], "signing");
+        setExtendedStatus(dialogs[++d], extendedStatusToSearchFor);
+        
+        setSenderName(dialogs[++d], senderNameToSearchFor);
+        setExtendedStatus(dialogs[d], secondExtendedStatusToSearchFor);
+
+        setServiceResource(dialogs[++d], "urn:altinn:resource:ttd-altinn-events-automated-tests"); // Note! We assume that this exists!
+        setParty(dialogs[++d], "/person/07874299582");
+        
+        setTitle(dialogs[++d], titleForDueAtItem);
+        setDueAt(dialogs[d], new Date("2033-12-07T10:13:00Z"));
+        
+        setTitle(dialogs[++d], titleForExpiresAtItem);
+        setExpiresAt(dialogs[d], new Date("2034-03-07T10:13:00Z"));
+
+        setTitle(dialogs[++d], titleForVisibleFromItem);
+        setVisibleFrom(dialogs[d], new Date("2031-03-07T10:13:00Z"));
+
+        setTitle(dialogs[dialogs.length-1], titleForLastItem);
+
+        dialogs.forEach((d) => {
+            let r = postSO("dialogs", d);
+            expectStatusFor(r).to.equal(201);
+            dialogIds.push(r.json());
+        });
+
+        let penultimateDialog = dialogs[dialogs.length-2];
+        let penultimateDialogId = dialogIds[dialogIds.length-2];
+        setTitle(penultimateDialog, titleForUpdatedItem);
+        let r = putSO("dialogs/" + penultimateDialogId, penultimateDialog);
+        expectStatusFor(r).to.equal(204);
+
+    });
+
+    describe('Perform simple dialog list', () => {
         let r = getSO('dialogs');
-        expect(r.status, 'response status').to.equal(200);
+        expectStatusFor(r).to.equal(200);
         expect(r, 'response').to.have.validJsonBody();
-        expect(r.json(), 'response json').to.have.property("items").with.lengthOf.at.least(1);
-    });    
+        expect(r.json(), 'response json').to.have.property("items").with.lengthOf.at.least(10);
+    });
+
+    describe('Perform search for title', () => {
+        let r = getSO('dialogs/?Search=' + titleToSearchFor);
+        expectStatusFor(r).to.equal(200);
+        expect(r, 'response').to.have.validJsonBody();
+        expect(r.json(), 'response json').to.have.property("items").with.lengthOf(1);
+    });
+
+    describe('Perform search for body', () => {
+        let r = getSO('dialogs/?Search=' + bodyToSearchFor);
+        expectStatusFor(r).to.equal(200);
+        expect(r, 'response').to.have.validJsonBody();
+        expect(r.json(), 'response json').to.have.property("items").with.lengthOf(1);
+    });
+
+    describe('Perform search for sender name', () => {
+        let r = getSO('dialogs/?Search=' + senderNameToSearchFor);
+        expectStatusFor(r).to.equal(200);
+        expect(r, 'response').to.have.validJsonBody();
+        expect(r.json(), 'response json').to.have.property("items").with.lengthOf(1);
+    });
+
+    describe('Perform search for extended status', () => {
+        let r = getSO('dialogs/?ExtendedStatus=' + extendedStatusToSearchFor + "&ExtendedStatus=" + secondExtendedStatusToSearchFor);
+        expectStatusFor(r).to.equal(200);
+        expect(r, 'response').to.have.validJsonBody();
+        expect(r.json(), 'response json').to.have.property("items").with.lengthOf(2);
+    });
+
+    describe('Perform with limit', () => {
+        let r = getSO('dialogs/?Limit=3');
+        expectStatusFor(r).to.equal(200);
+        expect(r, 'response').to.have.validJsonBody();
+        expect(r.json(), 'response json').to.have.property("items").with.lengthOf(3);
+        expect(r.json(), 'response json').to.have.property("hasNextPage").to.be.true;
+        expect(r.json(), 'response json').to.have.property("continuationToken");
+
+        let r2 = getSO('dialogs/?Limit=3&ContinuationToken=' + r.json().continuationToken);
+        expectStatusFor(r2).to.equal(200);
+        expect(r2, 'response').to.have.validJsonBody();
+        expect(r2.json(), 'response json').to.have.property("items").with.lengthOf(3);
+
+        // Check that we get other ids in the continuation call
+        let allIds = r.json().items.concat(r2.json().items).map((item) => item.id);
+        expect(allIds.some((id, i) => allIds.indexOf(id) !== i)).to.be.false;
+    });
+
+    describe('Perform with custom orderBy', () => {
+        let r = getSO('dialogs/?Limit=3&OrderBy=dueAt,updatedAt,createdAt');
+        expectStatusFor(r).to.equal(200);
+        expect(r, 'response').to.have.validJsonBody();
+        expect(r.json(), 'response json').to.have.property("items").with.lengthOf(3);
+        console.dir({
+            titleForDueAtItem: titleForDueAtItem,
+            titleForUpdatedItem: titleForUpdatedItem,
+            titleForLastItem: titleForLastItem
+        });
+        let ids = [];
+        r.json().items.forEach((i) => ids.push([i.title, i.dueAt, i.updatedAt, i.createdAt]));
+        console.dir(ids);
+        console.dir(r.json().items);
+
+        expect(r.json().items[0], 'first dialog').to.have.property("title").that.hasLocalizedText(titleForDueAtItem);
+        expect(r.json().items[1], 'second dialog').to.have.property("title").that.hasLocalizedText(titleForUpdatedItem);
+        expect(r.json().items[2], 'third dialog').to.have.property("title").that.hasLocalizedText(titleForLastItem);
+    });
+
+
+    // TODO: check
+        // - limit
+    // - order (multiple fields)
+    // - pagination
+    // - filter by party
+    // - filter by service resource
+    // - filter by status
+    // - filter by extended status
+    // - filter by after
+
+
+
+    describe("Cleanup", () => {
+        dialogIds.forEach((d) => {
+            let r = deleteSO("dialogs/" + d);
+            expect(r.status, 'response status').to.equal(204);
+        });
+    });
+
 }

--- a/tests/k6/tests/serviceowner/performance/createremove-no-delay.js
+++ b/tests/k6/tests/serviceowner/performance/createremove-no-delay.js
@@ -14,7 +14,7 @@ export function setup() {
 export default function(paramsWithToken) {
     let dialogId = null;
     describe('create dialog', () => {
-        let r = postSO('dialogs', JSON.stringify(dialogToInsert()), paramsWithToken);   
+        let r = postSO('dialogs', dialogToInsert(), paramsWithToken);   
         expect(r.status, 'response status').to.equal(201);
         dialogId = r.json();
     });

--- a/tests/k6/tests/serviceowner/testdata/01-create-dialog.js
+++ b/tests/k6/tests/serviceowner/testdata/01-create-dialog.js
@@ -5,14 +5,27 @@ export default function () {
 
     // Note! We assume that "super-simple-service" exists and is owned by 991825827
     return {
-        "serviceResource": "urn:altinn:resource:super-simple-service",
-        "party": "/org/991825827",
-        "status": "waiting",
-        "dueAt": "2023-11-25T06:37:54.2920190Z",
+        "serviceResource": "urn:altinn:resource:super-simple-service", // urn starting with urn:altinn:resource:
+        "party": "/org/991825827", // or /person/<11 digits>
+        "status": "unspecified", // valid values: unspecified, inprogress, waiting, signing, cancelled, completed
+        "extendedStatus": "urn:any/valid/uri",
+        "dueAt": "2033-11-25T06:37:54.2920190Z", // must be UTC
+        "expiresAt": "2053-11-25T06:37:54.2920190Z", // must be UTC
+        "visibleFrom": "2032-11-25T06:37:54.2920190Z", // must be UTC
+        "searchTags": [ 
+            { "value": "something searchable" },
+            { "value": "something else searchable" }
+        ],
         "title": [
             {
                 "cultureCode": "nb_NO",
-                "value": "Et eksempel på en tittel - due at 3"
+                "value": "Et eksempel på en tittel"
+            }   
+        ],
+        "body": [
+            {
+                "cultureCode": "nb_NO",
+                "value": "Et eksempel på en body"
             }
         ],
         "apiActions": [


### PR DESCRIPTION
* Adds utility functions
  * For manipulating dialog DTOs before submitting (`setTitle`, `setExtendedStatus` etc)
  * `console.dir` for printing objects (not implemented in Goja/K6)
  * `expectStatusFor(respo).to.equal(200)` as shorthand for `expect(response, "response status").to.equal(200)`, which also displays additional info if an error details reponse 
  * Added `hasLocalizedText` extension to Chai, eg. `expect(r.json().items[0], 'first dialog').to.have.property("title").that.hasLocalizedText("some title", "nb_NO");  /* cultureCode optional */`
* Handles serialization of DTOs in request.js, if necessary (no need to remember it at callsite)
* Add search in "body" in dialogs (will be replaced in #215)
