### PR TITLE
Populer DialogEntity.Org fra token eller http/distributedcache

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Application/Common/Extensions/ClaimsPrincipalExtensions.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Common/Extensions/ClaimsPrincipalExtensions.cs
@@ -14,9 +14,13 @@ public static class ClaimsPrincipalExtensions
     private const string IdClaim = "ID";
     private const char IdDelimiter = ':';
     private const string IdPrefix = "0192";
+    private const string OrgClaim = "urn:altinn:org";
 
     public static bool TryGetOrgNumber(this ClaimsPrincipal claimsPrincipal, [NotNullWhen(true)] out string? orgNumber)
         => claimsPrincipal.FindFirst(ConsumerClaim).TryGetOrgNumber(out orgNumber);
+
+    public static bool TryGetOrgShortName(this ClaimsPrincipal claimsPrincipal, [NotNullWhen(true)] out string? orgShortName)
+        => claimsPrincipal.FindFirst(OrgClaim).TryGetOrgShortName(out orgShortName);
 
     public static bool TryGetOrgNumber(this Claim? consumerClaim, [NotNullWhen(true)] out string? orgNumber)
     {
@@ -53,6 +57,16 @@ public static class ClaimsPrincipalExtensions
         return orgNumber is not null;
     }
 
+    public static bool TryGetOrgShortName(this Claim? orgClaim, [NotNullWhen(true)] out string? orgShortName)
+    {
+        orgShortName = orgClaim?.Value;
+
+        return orgShortName is not null;
+    }
+
     internal static bool TryGetOrgNumber(this IUser user, [NotNullWhen(true)] out string? orgNumber) =>
         user.GetPrincipal().TryGetOrgNumber(out orgNumber);
+
+    internal static bool TryGetOrgShortName(this IUser user, [NotNullWhen(true)] out string? orgShortName) =>
+        user.GetPrincipal().TryGetOrgShortName(out orgShortName);
 }

--- a/src/Digdir.Domain.Dialogporten.Application/Common/Extensions/ClaimsPrincipalExtensions.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Common/Extensions/ClaimsPrincipalExtensions.cs
@@ -19,9 +19,6 @@ public static class ClaimsPrincipalExtensions
     public static bool TryGetOrgNumber(this ClaimsPrincipal claimsPrincipal, [NotNullWhen(true)] out string? orgNumber)
         => claimsPrincipal.FindFirst(ConsumerClaim).TryGetOrgNumber(out orgNumber);
 
-    public static bool TryGetOrgShortName(this ClaimsPrincipal claimsPrincipal, [NotNullWhen(true)] out string? orgShortName)
-        => claimsPrincipal.FindFirst(OrgClaim).TryGetOrgShortName(out orgShortName);
-
     public static bool TryGetOrgNumber(this Claim? consumerClaim, [NotNullWhen(true)] out string? orgNumber)
     {
         orgNumber = null;
@@ -56,6 +53,9 @@ public static class ClaimsPrincipalExtensions
 
         return orgNumber is not null;
     }
+
+    public static bool TryGetOrgShortName(this ClaimsPrincipal claimsPrincipal, [NotNullWhen(true)] out string? orgShortName)
+        => claimsPrincipal.FindFirst(OrgClaim).TryGetOrgShortName(out orgShortName);
 
     public static bool TryGetOrgShortName(this Claim? orgClaim, [NotNullWhen(true)] out string? orgShortName)
     {

--- a/src/Digdir.Domain.Dialogporten.Application/Common/IUserService.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Common/IUserService.cs
@@ -25,7 +25,7 @@ internal sealed class UserService : IUserService
     {
         _user = user ?? throw new ArgumentNullException(nameof(user));
         _resourceRegistry = resourceRegistry ?? throw new ArgumentNullException(nameof(resourceRegistry));
-        _organizationRegistry = organizationRegistry;
+        _organizationRegistry = organizationRegistry ?? throw new ArgumentNullException(nameof(organizationRegistry));
     }
 
     public async Task<bool> CurrentUserIsOwner(string serviceResource, CancellationToken cancellationToken)

--- a/src/Digdir.Domain.Dialogporten.Application/Externals/IOrganizationRegistry.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Externals/IOrganizationRegistry.cs
@@ -1,0 +1,6 @@
+namespace Digdir.Domain.Dialogporten.Application.Externals;
+
+public interface IOrganizationRegistry
+{
+    Task<string?> GetOrgShortName(string orgNumber, CancellationToken cancellationToken);
+}

--- a/src/Digdir.Domain.Dialogporten.Domain/Dialogs/Entities/DialogEntity.cs
+++ b/src/Digdir.Domain.Dialogporten.Domain/Dialogs/Entities/DialogEntity.cs
@@ -24,9 +24,7 @@ public class DialogEntity :
     public DateTimeOffset UpdatedAt { get; set; }
     public bool Deleted { get; set; }
     public DateTimeOffset? DeletedAt { get; set; }
-
-    // TODO: Hent dette fra token?
-    public string Org { get; set; } = "DummyOrg";
+    public string Org { get; set; } = null!;
     public string ServiceResource { get; set; } = null!;
     public string Party { get; set; } = null!;
     public int? Progress { get; set; }
@@ -41,7 +39,7 @@ public class DialogEntity :
     public DialogStatus.Values StatusId { get; set; }
     public DialogStatus Status { get; set; } = null!;
 
-    // === Principal relationships === 
+    // === Principal relationships ===
     [AggregateChild]
     public List<DialogContent> Content { get; set; } = new();
     [AggregateChild]

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/OrganizationRegistry/OrganizationRegistryClient.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/OrganizationRegistry/OrganizationRegistryClient.cs
@@ -40,14 +40,14 @@ public class OrganizationRegistryClient : IOrganizationRegistry
         var response = await _client
             .GetFromJsonAsync<OrganizationRegistryResponse>(searchEndpoint, cancellationToken) ?? throw new UnreachableException();
 
-        var orgShortNameByOrgDetails = response
+        var orgShortNameByOrgNumber = response
             .Orgs
             .ToDictionary(
                 pair => pair.Value.Orgnr,
                 pair => pair.Key
             );
 
-        return orgShortNameByOrgDetails;
+        return orgShortNameByOrgNumber;
     }
 
     private sealed class OrganizationRegistryResponse

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/OrganizationRegistry/OrganizationRegistryClient.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/OrganizationRegistry/OrganizationRegistryClient.cs
@@ -1,0 +1,66 @@
+using System.Diagnostics;
+using System.Net.Http.Json;
+using Digdir.Domain.Dialogporten.Application.Externals;
+using Digdir.Domain.Dialogporten.Infrastructure.Common.Extensions;
+using Microsoft.Extensions.Caching.Distributed;
+
+namespace Digdir.Domain.Dialogporten.Infrastructure.Altinn.OrganizationRegistry;
+
+public class OrganizationRegistryClient : IOrganizationRegistry
+{
+    private const string OrgShortNameReferenceCacheKey = "OrgShortNameReference";
+    private static readonly DistributedCacheEntryOptions _oneDayCacheDuration = new() { AbsoluteExpiration = DateTimeOffset.UtcNow.AddDays(1) };
+    private static readonly DistributedCacheEntryOptions _zeroCacheDuration = new() { AbsoluteExpiration = DateTimeOffset.MinValue };
+
+    private readonly IDistributedCache _cache;
+    private readonly HttpClient _client;
+
+    public OrganizationRegistryClient(HttpClient client, IDistributedCache cache)
+    {
+        _client = client ?? throw new ArgumentNullException(nameof(client));
+        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+    }
+    public async Task<string?> GetOrgShortName(string orgNumber, CancellationToken cancellationToken)
+    {
+        var orgShortNameByOrgNumber = await _cache.GetOrAddAsync(
+            OrgShortNameReferenceCacheKey,
+            GetOrgShortNameByOrgNumber,
+            CacheOptionsFactory,
+            cancellationToken: cancellationToken);
+        orgShortNameByOrgNumber.TryGetValue(orgNumber, out var orgShortName);
+        return orgShortName;
+    }
+
+    private static DistributedCacheEntryOptions? CacheOptionsFactory(Dictionary<string, string>? orgShortNameByOrgNumber) =>
+        orgShortNameByOrgNumber is not null ? _oneDayCacheDuration : _zeroCacheDuration;
+
+    private async Task<Dictionary<string, string>> GetOrgShortNameByOrgNumber(CancellationToken cancellationToken)
+    {
+        const string searchEndpoint = "orgs/altinn-orgs.json";
+        var response = await _client
+            .GetFromJsonAsync<OrganizationRegistryResponse>(searchEndpoint, cancellationToken);
+
+        var orgShortNameByOrgDetails = response!
+            .Orgs
+            .ToDictionary(
+                pair => pair.Value.Orgnr,
+                pair => pair.Key
+            );
+
+        return orgShortNameByOrgDetails;
+    }
+
+    private sealed class OrganizationRegistryResponse
+    {
+        public required IDictionary<string, OrganizationDetails> Orgs { get; set; }
+    }
+
+    private sealed class OrganizationDetails
+    {
+        public IDictionary<string, string>? Name { get; init; }
+        public string? Logo { get; init; }
+        public required string Orgnr { get; init; }
+        public string? Homepage { get; init; }
+        public IList<string>? Environments { get; init; }
+    }
+}

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/OrganizationRegistry/OrganizationRegistryClient.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/OrganizationRegistry/OrganizationRegistryClient.cs
@@ -38,9 +38,9 @@ public class OrganizationRegistryClient : IOrganizationRegistry
     {
         const string searchEndpoint = "orgs/altinn-orgs.json";
         var response = await _client
-            .GetFromJsonAsync<OrganizationRegistryResponse>(searchEndpoint, cancellationToken);
+            .GetFromJsonAsync<OrganizationRegistryResponse>(searchEndpoint, cancellationToken) ?? throw new UnreachableException();
 
-        var orgShortNameByOrgDetails = response!
+        var orgShortNameByOrgDetails = response
             .Orgs
             .ToDictionary(
                 pair => pair.Value.Orgnr,
@@ -52,7 +52,7 @@ public class OrganizationRegistryClient : IOrganizationRegistry
 
     private sealed class OrganizationRegistryResponse
     {
-        public required IDictionary<string, OrganizationDetails> Orgs { get; set; }
+        public required IDictionary<string, OrganizationDetails> Orgs { get; init; }
     }
 
     private sealed class OrganizationDetails

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/OrganizationRegistry/OrganizationRegistryClient.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/OrganizationRegistry/OrganizationRegistryClient.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Caching.Distributed;
 
 namespace Digdir.Domain.Dialogporten.Infrastructure.Altinn.OrganizationRegistry;
 
-public class OrganizationRegistryClient : IOrganizationRegistry
+internal class OrganizationRegistryClient : IOrganizationRegistry
 {
     private const string OrgShortNameReferenceCacheKey = "OrgShortNameReference";
     private static readonly DistributedCacheEntryOptions _oneDayCacheDuration = new() { AbsoluteExpiration = DateTimeOffset.UtcNow.AddDays(1) };

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/ResourceRegistry/LocalDevelopmentResourceRegistry.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/ResourceRegistry/LocalDevelopmentResourceRegistry.cs
@@ -1,7 +1,7 @@
 ﻿using Digdir.Domain.Dialogporten.Application.Externals;
 using Microsoft.EntityFrameworkCore;
 
-namespace Digdir.Domain.Dialogporten.Infrastructure.Altinn.Registry;
+namespace Digdir.Domain.Dialogporten.Infrastructure.Altinn.ResourceRegistry;
 
 internal sealed class LocalDevelopmentResourceRegistry : IResourceRegistry
 {

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/ResourceRegistry/ResourceRegistryClient.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/ResourceRegistry/ResourceRegistryClient.cs
@@ -1,11 +1,11 @@
-﻿using Digdir.Domain.Dialogporten.Application.Externals;
+﻿using System.Diagnostics;
+using System.Net.Http.Json;
+using Digdir.Domain.Dialogporten.Application.Externals;
 using Digdir.Domain.Dialogporten.Domain.Common;
 using Digdir.Domain.Dialogporten.Infrastructure.Common.Extensions;
 using Microsoft.Extensions.Caching.Distributed;
-using System.Diagnostics;
-using System.Net.Http.Json;
 
-namespace Digdir.Domain.Dialogporten.Infrastructure.Altinn.Registry;
+namespace Digdir.Domain.Dialogporten.Infrastructure.Altinn.ResourceRegistry;
 
 internal sealed class ResourceRegistryClient : IResourceRegistry
 {

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/InfrastructureExtensions.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/InfrastructureExtensions.cs
@@ -89,7 +89,7 @@ public static class InfrastructureExtensions
             .AddPolicyHandlerFromRegistry(PollyPolicy.DefaultHttpRetryPolicy);
 
         services.AddHttpClient<IOrganizationRegistry, OrganizationRegistryClient>((services, client) =>
-                client.BaseAddress = services.GetRequiredService<IOptions<InfrastructureSettings>>().Value.AltinnCDN.BaseUri)
+                client.BaseAddress = services.GetRequiredService<IOptions<InfrastructureSettings>>().Value.AltinnCdn.BaseUri)
             .AddPolicyHandlerFromRegistry(PollyPolicy.DefaultHttpRetryPolicy);
 
         services.AddHttpClient<IAltinnAuthorization, AltinnAuthorizationClient>((services, client) =>

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/InfrastructureSettings.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/InfrastructureSettings.cs
@@ -10,7 +10,7 @@ public sealed class InfrastructureSettings
 
     public required string DialogDbConnectionString { get; init; }
     public required AltinnPlatformSettings Altinn { get; init; }
-    public required AltinnCDNPlatformSettings AltinnCDN { get; init; }
+    public required AltinnCdnPlatformSettings AltinnCdn { get; init; }
     public required MaskinportenSettings Maskinporten { get; init; }
 }
 
@@ -20,7 +20,7 @@ public sealed class AltinnPlatformSettings
     public required string SubscriptionKey { get; init; }
 }
 
-public sealed class AltinnCDNPlatformSettings
+public sealed class AltinnCdnPlatformSettings
 {
     public required Uri BaseUri { get; init; }
 }
@@ -29,7 +29,7 @@ internal sealed class InfrastructureSettingsValidator : AbstractValidator<Infras
 {
     public InfrastructureSettingsValidator(
         IValidator<AltinnPlatformSettings> altinnPlatformSettingsValidator,
-        IValidator<AltinnCDNPlatformSettings> altinnCDNPlatformSettingsValidator,
+        IValidator<AltinnCdnPlatformSettings> altinnCdnPlatformSettingsValidator,
         IValidator<MaskinportenSettings> maskinportenSettingsValidator)
     {
         RuleFor(x => x.DialogDbConnectionString)
@@ -39,9 +39,9 @@ internal sealed class InfrastructureSettingsValidator : AbstractValidator<Infras
             .NotEmpty()
             .SetValidator(altinnPlatformSettingsValidator);
 
-        RuleFor(x => x.AltinnCDN)
+        RuleFor(x => x.AltinnCdn)
             .NotEmpty()
-            .SetValidator(altinnCDNPlatformSettingsValidator);
+            .SetValidator(altinnCdnPlatformSettingsValidator);
 
         RuleFor(x => x.Maskinporten)
             .NotEmpty()
@@ -57,9 +57,9 @@ internal sealed class AltinnPlatformSettingsValidator : AbstractValidator<Altinn
     }
 }
 
-internal sealed class AltinnCDNPlatformSettingsValidator : AbstractValidator<AltinnCDNPlatformSettings>
+internal sealed class AltinnCdnPlatformSettingsValidator : AbstractValidator<AltinnCdnPlatformSettings>
 {
-    public AltinnCDNPlatformSettingsValidator()
+    public AltinnCdnPlatformSettingsValidator()
     {
         RuleFor(x => x.BaseUri).NotEmpty().IsValidUri();
     }

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/InfrastructureSettings.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/InfrastructureSettings.cs
@@ -10,6 +10,7 @@ public sealed class InfrastructureSettings
 
     public required string DialogDbConnectionString { get; init; }
     public required AltinnPlatformSettings Altinn { get; init; }
+    public required AltinnCDNPlatformSettings AltinnCDN { get; init; }
     public required MaskinportenSettings Maskinporten { get; init; }
 }
 
@@ -19,10 +20,16 @@ public sealed class AltinnPlatformSettings
     public required string SubscriptionKey { get; init; }
 }
 
+public sealed class AltinnCDNPlatformSettings
+{
+    public required Uri BaseUri { get; init; }
+}
+
 internal sealed class InfrastructureSettingsValidator : AbstractValidator<InfrastructureSettings>
 {
     public InfrastructureSettingsValidator(
         IValidator<AltinnPlatformSettings> altinnPlatformSettingsValidator,
+        IValidator<AltinnCDNPlatformSettings> altinnCDNPlatformSettingsValidator,
         IValidator<MaskinportenSettings> maskinportenSettingsValidator)
     {
         RuleFor(x => x.DialogDbConnectionString)
@@ -31,6 +38,10 @@ internal sealed class InfrastructureSettingsValidator : AbstractValidator<Infras
         RuleFor(x => x.Altinn)
             .NotEmpty()
             .SetValidator(altinnPlatformSettingsValidator);
+
+        RuleFor(x => x.AltinnCDN)
+            .NotEmpty()
+            .SetValidator(altinnCDNPlatformSettingsValidator);
 
         RuleFor(x => x.Maskinporten)
             .NotEmpty()
@@ -41,6 +52,14 @@ internal sealed class InfrastructureSettingsValidator : AbstractValidator<Infras
 internal sealed class AltinnPlatformSettingsValidator : AbstractValidator<AltinnPlatformSettings>
 {
     public AltinnPlatformSettingsValidator()
+    {
+        RuleFor(x => x.BaseUri).NotEmpty().IsValidUri();
+    }
+}
+
+internal sealed class AltinnCDNPlatformSettingsValidator : AbstractValidator<AltinnCDNPlatformSettings>
+{
+    public AltinnCDNPlatformSettingsValidator()
     {
         RuleFor(x => x.BaseUri).NotEmpty().IsValidUri();
     }

--- a/src/Digdir.Domain.Dialogporten.WebApi/appsettings.Development.json
+++ b/src/Digdir.Domain.Dialogporten.WebApi/appsettings.Development.json
@@ -27,9 +27,6 @@
     "Altinn": {
       "BaseUri": "https://platform.tt02.altinn.no/",
       "SubscriptionKey": "TODO: Add to local secrets"
-    },
-    "AltinnCDN": {
-      "BaseUri": "https://altinncdn.no/"
     }
   },
   "Application": {

--- a/src/Digdir.Domain.Dialogporten.WebApi/appsettings.Development.json
+++ b/src/Digdir.Domain.Dialogporten.WebApi/appsettings.Development.json
@@ -20,13 +20,16 @@
       "Scope": "altinn:events.publish altinn:events.publish.admin",
 
       // --------------------------
-      // Any additional settings are specific for the selected client definition type. 
+      // Any additional settings are specific for the selected client definition type.
       // See below for examples using other types.
       "EncodedJwk": "TODO: Add to local secrets"
     },
     "Altinn": {
       "BaseUri": "https://platform.tt02.altinn.no/",
       "SubscriptionKey": "TODO: Add to local secrets"
+    },
+    "AltinnCDN": {
+      "BaseUri": "https://altinncdn.no/"
     }
   },
   "Application": {

--- a/src/Digdir.Domain.Dialogporten.WebApi/appsettings.Development.json
+++ b/src/Digdir.Domain.Dialogporten.WebApi/appsettings.Development.json
@@ -27,6 +27,9 @@
     "Altinn": {
       "BaseUri": "https://platform.tt02.altinn.no/",
       "SubscriptionKey": "TODO: Add to local secrets"
+    },
+    "AltinnCdn": {
+      "BaseUri": "https://altinncdn.no/"
     }
   },
   "Application": {

--- a/src/Digdir.Domain.Dialogporten.WebApi/appsettings.json
+++ b/src/Digdir.Domain.Dialogporten.WebApi/appsettings.json
@@ -7,5 +7,10 @@
       "System.Net.Http.HttpClient": "Information"
     }
   },
+  "Infrastructure": {
+    "AltinnCdn": {
+      "BaseUri": "https://altinncdn.no/"
+    }
+  },
   "AllowedHosts": "*"
 }


### PR DESCRIPTION
Fix #293

-Populerer Org på DialogEntity fra token hvis det eksisterer
-Henter Org verdi fra altinncdn eller distributedcache hvis det ikke eksisterer i token

Co-authored by Are Almaas, Magnus Sandgren