### PR TITLE
chore(Dockerfiles): avoid busting cache on each build

### DIFF
--- a/src/Digdir.Domain.Dialogporten.ChangeDataCapture/Dockerfile
+++ b/src/Digdir.Domain.Dialogporten.ChangeDataCapture/Dockerfile
@@ -1,16 +1,20 @@
-﻿FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+﻿FROM mcr.microsoft.com/dotnet/aspnet:8.0@sha256:3ff67792728179308c4bf06799d8b45d155c60fddc347acf69465a496d9a20b8 AS base
 WORKDIR /app
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0@sha256:7ef41132b2ebe6166bde36b7ba2f0d302e10307c3e0523a4539643a77233f56d AS build
 WORKDIR /src
 
-COPY ["src/**/*.csproj", "./"]
-RUN for file in $(ls *.csproj); do mkdir -p src/${file%.*}/ && mv $file src/${file%.*}/; done
+# Main project
+COPY ["src/Digdir.Domain.Dialogporten.ChangeDataCapture/Digdir.Domain.Dialogporten.ChangeDataCapture.csproj", "src/Digdir.Domain.Dialogporten.ChangeDataCapture/"]
+# Dependencies 
+COPY ["src/Digdir.Domain.Dialogporten.Domain/Digdir.Domain.Dialogporten.Domain.csproj", "src/Digdir.Domain.Dialogporten.Domain/"]
+COPY ["src/Digdir.Library.Entity.Abstractions/Digdir.Library.Entity.Abstractions.csproj", "src/Digdir.Library.Entity.Abstractions/"]
+# Restore
 RUN dotnet restore "src/Digdir.Domain.Dialogporten.ChangeDataCapture/Digdir.Domain.Dialogporten.ChangeDataCapture.csproj"
-
-COPY . .
-
-WORKDIR "/src/src/Digdir.Domain.Dialogporten.ChangeDataCapture"
+# Copy source
+COPY ["src/", "."]
+# Publish
+WORKDIR "/src/Digdir.Domain.Dialogporten.ChangeDataCapture"
 RUN dotnet publish "Digdir.Domain.Dialogporten.ChangeDataCapture.csproj" -c Release -o /app/publish /p:UseAppHost=false
 
 FROM base AS final

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/MigrationBundle.dockerfile
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/MigrationBundle.dockerfile
@@ -1,16 +1,21 @@
-﻿FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+﻿FROM mcr.microsoft.com/dotnet/aspnet:8.0@sha256:3ff67792728179308c4bf06799d8b45d155c60fddc347acf69465a496d9a20b8 AS base
 WORKDIR /app
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0@sha256:7ef41132b2ebe6166bde36b7ba2f0d302e10307c3e0523a4539643a77233f56d AS build
 WORKDIR /src
 
-COPY ["src/**/*.csproj", "./"]
-RUN for file in $(ls *.csproj); do mkdir -p src/${file%.*}/ && mv $file src/${file%.*}/; done
+# Main project
+COPY ["src/Digdir.Domain.Dialogporten.Infrastructure/Digdir.Domain.Dialogporten.Infrastructure.csproj", "src/Digdir.Domain.Dialogporten.Infrastructure/"]
+# Dependencies 
+COPY ["src/Digdir.Domain.Dialogporten.Domain/Digdir.Domain.Dialogporten.Domain.csproj", "src/Digdir.Domain.Dialogporten.Domain/"]
+COPY ["src/Digdir.Library.Entity.Abstractions/Digdir.Library.Entity.Abstractions.csproj", "src/Digdir.Library.Entity.Abstractions/"]
+COPY ["src/Digdir.Library.Entity.EntityFrameworkCore/Digdir.Library.Entity.EntityFrameworkCore.csproj", "src/Digdir.Library.Entity.EntityFrameworkCore/"]
+# Restore
 RUN dotnet restore "src/Digdir.Domain.Dialogporten.Infrastructure/Digdir.Domain.Dialogporten.Infrastructure.csproj"
+# Copy source
+COPY ["src/", "."]
 
-COPY . .
-
-WORKDIR "/src/src/Digdir.Domain.Dialogporten.Infrastructure"
+WORKDIR "/src/Digdir.Domain.Dialogporten.Infrastructure"
 RUN mkdir -p /app/publish
 RUN dotnet tool install --global dotnet-ef --version 7.0.14
 ENV PATH $PATH:/root/.dotnet/tools

--- a/src/Digdir.Domain.Dialogporten.Service/Dockerfile
+++ b/src/Digdir.Domain.Dialogporten.Service/Dockerfile
@@ -1,16 +1,23 @@
-﻿FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+﻿FROM mcr.microsoft.com/dotnet/aspnet:8.0@sha256:3ff67792728179308c4bf06799d8b45d155c60fddc347acf69465a496d9a20b8 AS base
 WORKDIR /app
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0@sha256:7ef41132b2ebe6166bde36b7ba2f0d302e10307c3e0523a4539643a77233f56d AS build
 WORKDIR /src
 
-COPY ["src/**/*.csproj", "./"]
-RUN for file in $(ls *.csproj); do mkdir -p src/${file%.*}/ && mv $file src/${file%.*}/; done
+# Main project
+COPY ["src/Digdir.Domain.Dialogporten.Service/Digdir.Domain.Dialogporten.Service.csproj", "src/Digdir.Domain.Dialogporten.Service/"]
+# Dependencies 
+COPY ["src/Digdir.Domain.Dialogporten.Application/Digdir.Domain.Dialogporten.Application.csproj", "src/Digdir.Domain.Dialogporten.Application/"]
+COPY ["src/Digdir.Domain.Dialogporten.Domain/Digdir.Domain.Dialogporten.Domain.csproj", "src/Digdir.Domain.Dialogporten.Domain/"]
+COPY ["src/Digdir.Library.Entity.Abstractions/Digdir.Library.Entity.Abstractions.csproj", "src/Digdir.Library.Entity.Abstractions/"]
+COPY ["src/Digdir.Library.Entity.EntityFrameworkCore/Digdir.Library.Entity.EntityFrameworkCore.csproj", "src/Digdir.Library.Entity.EntityFrameworkCore/"]
+COPY ["src/Digdir.Domain.Dialogporten.Infrastructure/Digdir.Domain.Dialogporten.Infrastructure.csproj", "src/Digdir.Domain.Dialogporten.Infrastructure/"]
+# Restore
 RUN dotnet restore "src/Digdir.Domain.Dialogporten.Service/Digdir.Domain.Dialogporten.Service.csproj"
-
-COPY . .
-
-WORKDIR "/src/src/Digdir.Domain.Dialogporten.Service"
+# Copy rest of source
+COPY ["src/", "/src/"]
+# Publish
+WORKDIR "/src/Digdir.Domain.Dialogporten.Service"
 RUN dotnet publish "Digdir.Domain.Dialogporten.Service.csproj" -c Release -o /app/publish /p:UseAppHost=false
 
 FROM base AS final

--- a/src/Digdir.Domain.Dialogporten.WebApi/Dockerfile
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Dockerfile
@@ -1,18 +1,25 @@
-﻿FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+﻿FROM mcr.microsoft.com/dotnet/aspnet:8.0@sha256:3ff67792728179308c4bf06799d8b45d155c60fddc347acf69465a496d9a20b8 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0@sha256:7ef41132b2ebe6166bde36b7ba2f0d302e10307c3e0523a4539643a77233f56d AS build
 WORKDIR /src
 
-COPY ["src/**/*.csproj", "./"]
-RUN for file in $(ls *.csproj); do mkdir -p src/${file%.*}/ && mv $file src/${file%.*}/; done
+# Main project
+COPY ["src/Digdir.Domain.Dialogporten.WebApi/Digdir.Domain.Dialogporten.WebApi.csproj", "src/Digdir.Domain.Dialogporten.WebApi/"]
+# Dependencies 
+COPY ["src/Digdir.Domain.Dialogporten.Application/Digdir.Domain.Dialogporten.Application.csproj", "src/Digdir.Domain.Dialogporten.Application/"]
+COPY ["src/Digdir.Domain.Dialogporten.Domain/Digdir.Domain.Dialogporten.Domain.csproj", "src/Digdir.Domain.Dialogporten.Domain/"]
+COPY ["src/Digdir.Library.Entity.Abstractions/Digdir.Library.Entity.Abstractions.csproj", "src/Digdir.Library.Entity.Abstractions/"]
+COPY ["src/Digdir.Library.Entity.EntityFrameworkCore/Digdir.Library.Entity.EntityFrameworkCore.csproj", "src/Digdir.Library.Entity.EntityFrameworkCore/"]
+COPY ["src/Digdir.Domain.Dialogporten.Infrastructure/Digdir.Domain.Dialogporten.Infrastructure.csproj", "src/Digdir.Domain.Dialogporten.Infrastructure/"]
+# Restore
 RUN dotnet restore "src/Digdir.Domain.Dialogporten.WebApi/Digdir.Domain.Dialogporten.WebApi.csproj"
-
-COPY . .
-
-WORKDIR "/src/src/Digdir.Domain.Dialogporten.WebApi"
+# Copy source
+COPY ["src/", "."]
+# Publish
+WORKDIR "/src/Digdir.Domain.Dialogporten.WebApi"
 RUN dotnet publish "Digdir.Domain.Dialogporten.WebApi.csproj" -c Release -o /app/publish /p:UseAppHost=false
 
 FROM base AS final

--- a/src/Digdir.Tool.Dialogporten.MigrationVerifier/Dockerfile
+++ b/src/Digdir.Tool.Dialogporten.MigrationVerifier/Dockerfile
@@ -1,16 +1,17 @@
-﻿FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+﻿FROM mcr.microsoft.com/dotnet/aspnet:8.0@sha256:3ff67792728179308c4bf06799d8b45d155c60fddc347acf69465a496d9a20b8 AS base
 WORKDIR /app
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0@sha256:7ef41132b2ebe6166bde36b7ba2f0d302e10307c3e0523a4539643a77233f56d AS build
 WORKDIR /src
 
-COPY ["src/**/*.csproj", "./"]
-RUN for file in $(ls *.csproj); do mkdir -p src/${file%.*}/ && mv $file src/${file%.*}/; done
+# Main project
+COPY ["src/Digdir.Tool.Dialogporten.MigrationVerifier/Digdir.Tool.Dialogporten.MigrationVerifier.csproj", "src/Digdir.Tool.Dialogporten.MigrationVerifier/"]
+# Restore
 RUN dotnet restore "src/Digdir.Tool.Dialogporten.MigrationVerifier/Digdir.Tool.Dialogporten.MigrationVerifier.csproj"
-
-COPY . .
-
-WORKDIR "/src/src/Digdir.Tool.Dialogporten.MigrationVerifier"
+# Copy rest of source
+COPY ["src/", "/src/"]
+# Publish
+WORKDIR "/src/Digdir.Tool.Dialogporten.MigrationVerifier"
 RUN dotnet publish "Digdir.Tool.Dialogporten.MigrationVerifier.csproj" -c Release -o /app/publish /p:UseAppHost=false
 
 FROM base AS final


### PR DESCRIPTION
Issue: #325 

- Mistenker at det er dette som forårsaker at vi må restore for hvert bygg. Tror ikke string interpolation er så godt støttet. Med denne er vi mer verbose, men også mer eksplisitt på hva vi drar inn i Dockerfilen. Kan også optimaliseres med å kun kopiere inn relevante prosjekter istedenfor hele `src`-mappen. 
- Satte også `sha` til hvert image slik at vi vet at vi bruker samme versjon av `8.0` inntil vi velger å oppgradere det på et tidspunkt