### PR TITLE
docs: remove spacing

### DIFF
--- a/.github/ISSUE_TEMPLATE/ny-endring-av-funksjonalitet.md
+++ b/.github/ISSUE_TEMPLATE/ny-endring-av-funksjonalitet.md
@@ -5,7 +5,6 @@ title: ''
 labels: ''
 assignees: ''
 projects: ['digdir/7']
-
 ---
 
 ### Introduksjon


### PR DESCRIPTION
Remove unneeded spacing. This is mostly in order to force a re-deployment until we have fixed the dependencies in workflow