### PR TITLE
bug: Fix EnduserId validation message when searching

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/Search/SearchDialogQueryValidator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/Search/SearchDialogQueryValidator.cs
@@ -22,7 +22,7 @@ internal sealed class SearchDialogQueryValidator : AbstractValidator<SearchDialo
 
         RuleFor(x => x)
             .Must(x => NorwegianPersonIdentifier.IsValid(x.EndUserId!) || SystemUserIdentifier.IsValid(x.EndUserId))
-            .WithMessage($"'{{PropertyName}}' must be a valid end user identifier. It should match the format '{NorwegianPersonIdentifier.Prefix}{{norwegian f-nr/d-nr}} or '{SystemUserIdentifier.Prefix}{{uuid}}\"")
+            .WithMessage($"'{nameof(SearchDialogQuery.EndUserId)}' must be a valid end user identifier. It should match the format '{NorwegianPersonIdentifier.Prefix}{{norwegian f-nr/d-nr}} or '{SystemUserIdentifier.Prefix}{{uuid}}\"")
             .Must(x => !x.ServiceResource.IsNullOrEmpty() || !x.Party.IsNullOrEmpty())
             .WithMessage($"Either '{nameof(SearchDialogQuery.ServiceResource)}' or '{nameof(SearchDialogQuery.Party)}' must be specified if '{nameof(SearchDialogQuery.EndUserId)}' is provided.")
             .When(x => x.EndUserId is not null);


### PR DESCRIPTION
Når det når det søkes med feil EndUserId-filtrering på SO-APIet er propertynavnet blankt

![CleanShot 2024-01-26 at 21 15 08@2x](https://github.com/digdir/dialogporten/assets/5313373/23100b9a-1a59-47ab-91d2-e1ecdd56a7cd)
