### PR TITLE
ci: avoid failing on warnings from deployment

### DIFF
--- a/.github/workflows/action-deploy-apps.yml
+++ b/.github/workflows/action-deploy-apps.yml
@@ -84,7 +84,7 @@ jobs:
           deploymentMode: Incremental
           deploymentName: "dp-be-${{ inputs.environment }}-web-api-migration-job-${{ inputs.gitShortSha }}"
           region: ${{ inputs.region }}
-          failOnStdErr: true
+          failOnStdErr: false
           additionalArguments: "${{inputs.dryRun && '--what-if'}}"
           parameters: ./.azure/applications/web-api-migration-job/${{ inputs.environment }}.bicepparam
 
@@ -156,7 +156,7 @@ jobs:
           deploymentMode: Incremental
           deploymentName: dp-be-${{ inputs.environment }}-${{ matrix.name }}-${{ inputs.gitShortSha }}
           region: ${{ inputs.region }}
-          failOnStdErr: true
+          failOnStdErr: false
           additionalArguments: "${{inputs.dryRun && '--what-if'}}"
           parameters: ./.azure/applications/${{ matrix.name }}/${{ inputs.environment }}.bicepparam
 

--- a/.github/workflows/action-deploy-infra.yml
+++ b/.github/workflows/action-deploy-infra.yml
@@ -97,7 +97,7 @@ jobs:
           deploymentMode: Incremental
           deploymentName: dp-be-${{ inputs.environment }}-${{ inputs.gitShortSha }}
           region: ${{ inputs.region }}
-          failOnStdErr: true
+          failOnStdErr: false
           additionalArguments: "${{ inputs.dryRun && '--what-if' }}"
           parameters: ./.azure/infrastructure/${{ inputs.environment }}.bicepparam
 


### PR DESCRIPTION

<img width="888" alt="image" src="https://github.com/digdir/dialogporten/assets/1777366/70c6fabb-8d0e-4376-b3b5-e744d6e58244">

Deployments are failing because of warnings about Bicep cli upgrades. That's a tad too harsh.. But there doesn't seem to be a way to disable just those types of warnings so we rather skip failing on warnings. Need to add a different build step to catch these warning instead. Like a validation deployment or something similar. 

https://github.com/Azure/arm-deploy/issues/126