### PR TITLE
fix: shorten secret name for container app job

### DIFF
--- a/.azure/modules/containerAppJob/main.bicep
+++ b/.azure/modules/containerAppJob/main.bicep
@@ -16,7 +16,7 @@ resource job 'Microsoft.App/jobs@2023-05-01' = {
       secrets: [
         {
           // todo: move this and refactor into adding this somewhere else
-          name: 'dialogdbconnectionstringsecreturi'
+          name: 'dbconnectionstring'
           keyVaultUrl: adoConnectionStringSecretUri
           identity: 'System'
         }
@@ -36,7 +36,7 @@ resource job 'Microsoft.App/jobs@2023-05-01' = {
           env: [
             {
               name: 'Infrastructure__DialogDbConnectionString'
-              secretRef: 'dialogdbconnectionstringsecreturi'
+              secretRef: 'dbconnectionstring'
             }
           ]
           image: image

--- a/.github/tools/README.md
+++ b/.github/tools/README.md
@@ -1,6 +1,6 @@
 # Tools
 
-`.github/tools/containerAppJobVerifier.sh` is used to verify the status of a container application job. It checks if the job has completed successfully or not.
+`.github/tools/containerAppJobVerifier.sh` is used to verify the status of a container application job. It checks if the job has completed successfully or not
 
 `.github/tools/pwdGenerator.ps1` is used to generate passwords.
 


### PR DESCRIPTION
`Secret names cannot be longer than 20. Please shorten dialogdbconnectionstringsecreturi`

🤷