### PR TITLE
ci: queue jobs on main

### DIFF
--- a/.github/workflows/ci-cd-main.yml
+++ b/.github/workflows/ci-cd-main.yml
@@ -6,7 +6,8 @@ on:
     branches: [main]
     paths-ignore:
       - "tests/k6/**"
-
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
 jobs:
   generate-git-short-sha:
     name: Generate git short sha


### PR DESCRIPTION
Ensure that we only run one workflow at the time when running the main workflow to avoid potential conflicts and race conditions