### PR TITLE
fix: restrict container apps to apim ip

### DIFF
--- a/.azure/applications/web-api-eu/main.bicep
+++ b/.azure/applications/web-api-eu/main.bicep
@@ -6,6 +6,8 @@ param imageTag string
 param environment string
 @minLength(3)
 param location string
+@minLength(3)
+param apimIp string
 
 @minLength(3)
 @secure()
@@ -64,6 +66,7 @@ module containerApp '../../modules/containerApp/main.bicep' = {
     location: location
     envVariables: containerAppEnvVars
     containerAppEnvId: containerAppEnvironment.id
+    apimIp: apimIp
   }
 }
 

--- a/.azure/applications/web-api-eu/staging.bicepparam
+++ b/.azure/applications/web-api-eu/staging.bicepparam
@@ -2,6 +2,7 @@ using './main.bicep'
 
 param environment = 'staging'
 param location = 'norwayeast'
+param apimIp = '51.13.86.131'
 param imageTag = readEnvironmentVariable('IMAGE_TAG')
 
 // secrets

--- a/.azure/applications/web-api-eu/test.bicepparam
+++ b/.azure/applications/web-api-eu/test.bicepparam
@@ -2,6 +2,7 @@ using './main.bicep'
 
 param environment = 'test'
 param location = 'norwayeast'
+param apimIp = '51.120.88.69'
 param imageTag = readEnvironmentVariable('IMAGE_TAG')
 
 // secrets

--- a/.azure/applications/web-api-so/main.bicep
+++ b/.azure/applications/web-api-so/main.bicep
@@ -6,6 +6,8 @@ param imageTag string
 param environment string
 @minLength(3)
 param location string
+@minLength(3)
+param apimIp string
 
 @minLength(3)
 @secure()
@@ -68,6 +70,7 @@ module containerApp '../../modules/containerApp/main.bicep' = {
     location: location
     envVariables: containerAppEnvVars
     containerAppEnvId: containerAppEnvironment.id
+    apimIp: apimIp
   }
 }
 

--- a/.azure/applications/web-api-so/staging.bicepparam
+++ b/.azure/applications/web-api-so/staging.bicepparam
@@ -2,6 +2,7 @@ using './main.bicep'
 
 param environment = 'staging'
 param location = 'norwayeast'
+param apimIp = '51.13.86.131'
 param imageTag = readEnvironmentVariable('IMAGE_TAG')
 
 // secrets

--- a/.azure/applications/web-api-so/test.bicepparam
+++ b/.azure/applications/web-api-so/test.bicepparam
@@ -2,6 +2,7 @@ using './main.bicep'
 
 param environment = 'test'
 param location = 'norwayeast'
+param apimIp = '51.120.88.69'
 param imageTag = readEnvironmentVariable('IMAGE_TAG')
 
 // secrets

--- a/.azure/modules/containerApp/main.bicep
+++ b/.azure/modules/containerApp/main.bicep
@@ -3,6 +3,7 @@ param envVariables array = []
 param port int = 8080
 param name string
 param image string
+param apimIp string
 
 param containerAppEnvId string
 
@@ -30,7 +31,13 @@ var probes = [
 var ingress = {
   targetPort: port
   external: true
-  ipSecurityRestrictions: []
+  ipSecurityRestrictions: [
+    {
+      name: 'apim'
+      action: 'Allow'
+      ipAddressRange: apimIp
+    }
+  ]
 }
 
 resource containerApp 'Microsoft.App/containerApps@2023-05-01' = {


### PR DESCRIPTION
APIM is set up and we want to restrict incoming requests to the APIM IP to close them down for public access. 