### PR TITLE
chroe: Use webhook sink URL for events in test

### DIFF
--- a/src/Digdir.Domain.Dialogporten.WebApi/appsettings.test.json
+++ b/src/Digdir.Domain.Dialogporten.WebApi/appsettings.test.json
@@ -20,12 +20,12 @@
       "Scope": "altinn:events.publish altinn:events.publish.admin",
 
       // --------------------------
-      // Any additional settings are specific for the selected client definition type. 
+      // Any additional settings are specific for the selected client definition type.
       // See below for examples using other types.
       "EncodedJwk": "TODO: Add to local secrets"
     },
     "Altinn": {
-      "BaseUri": "https://platform.tt02.altinn.no/",
+      "BaseUri": "Secret webhook sink URL in source key vault",
       "SubscriptionKey": "TODO: Add to local secrets"
     }
   },


### PR DESCRIPTION
Changing test environment base URI for Altinn so that we don't push events to tt02 from two environments now that staging is up and running.

The URL is in the source key vault.