### PR TITLE
fix: remove main-tag when tagging docker images

### DIFF
--- a/.github/workflows/action-publish.yml
+++ b/.github/workflows/action-publish.yml
@@ -63,7 +63,6 @@ jobs:
           file: ${{ matrix.dockerfile }}
           push: true
           tags: |
-            ${{ steps.meta.outputs.tags }},
             ${{ env.DOCKER_IMAGE_BASE_NAME }}${{ matrix.imageName }}:${{ inputs.version }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=${{ matrix.imageName }}

--- a/.github/workflows/ci-cd-main.yml
+++ b/.github/workflows/ci-cd-main.yml
@@ -6,7 +6,6 @@ on:
     branches: [main]
     paths-ignore:
       - "tests/k6/**" # ignore changes to k6 tests
-      - "CHANGELOG.md" # ignore changes to changelog. This will effectively skip the workflow if a release is made
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}

--- a/.github/workflows/ci-cd-staging.yml
+++ b/.github/workflows/ci-cd-staging.yml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - "v*.*.*"
-    paths-ignore:
-      - "tests/k6/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}


### PR DESCRIPTION
<img width="537" alt="image" src="https://github.com/digdir/dialogporten/assets/1777366/d65fe5f7-26f2-4f33-a18c-8bff03ab88ec">

- We don't want to overwrite the `main`-tag of the docker image each time a publish happens in either branch. 
- Fix some workflow issues for staging