### PR TITLE
fix(release-please): use correct gh token

### DIFF
--- a/.github/workflows/ci-cd-main.yml
+++ b/.github/workflows/ci-cd-main.yml
@@ -10,6 +10,10 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   release-please:
     name: Release please
@@ -18,7 +22,7 @@ jobs:
       - uses: google-github-actions/release-please-action@v4
         id: release
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_TOKEN_RELEASE_PLEASE }}
           release-type: simple
 
   generate-git-short-sha:


### PR DESCRIPTION
The GITHUB_TOKEN will not be able to trigger any github action runs, therefore we need to create a custom PAT to use. 

https://github.com/google-github-actions/release-please-action?tab=readme-ov-file#github-credentials