### PR TITLE
ci: refactor and add manual dispatch version

### DIFF
--- a/.github/workflows/action-deploy-infra.yml
+++ b/.github/workflows/action-deploy-infra.yml
@@ -35,6 +35,11 @@ on:
         description: "Current version to use as tag"
         required: true
         type: string
+      ref:
+        description: "The branch or tag ref to deploy. Using default checkout ref if not provided."
+        required: false
+        default: ${{ github.ref }}
+        type: string
 
 concurrency:
   # Existing runs are cancelled if someone repeatedly commits to their own Pull Request (PR). However, it does not stop others' dry runs or actual deployments from the main branch.
@@ -53,6 +58,8 @@ jobs:
     steps:
       - name: "Checkout GitHub Action"
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: OIDC Login to Azure Public Cloud
         uses: azure/login@v1

--- a/.github/workflows/ci-cd-main.yml
+++ b/.github/workflows/ci-cd-main.yml
@@ -55,7 +55,7 @@ jobs:
         generate-git-short-sha,
         build-and-test,
       ]
-    if: ${{ always() && !failure() && !cancelled() && needs.check-for-changes.outputs.hasBackendChanges == 'true' }}
+    if: ${{ needs.check-for-changes.outputs.hasBackendChanges == 'true' }}
     secrets:
       GCR_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
     with:
@@ -64,9 +64,8 @@ jobs:
 
   deploy-infra-test:
     name: Deploy infra to test
-    needs:
-      [get-current-version, check-for-changes, generate-git-short-sha, publish]
-    if: ${{ always() && !failure() && !cancelled() && needs.check-for-changes.outputs.hasAzureChanges == 'true' }}
+    needs: [get-current-version, check-for-changes, generate-git-short-sha]
+    if: ${{ needs.check-for-changes.outputs.hasAzureChanges == 'true' }}
     uses: ./.github/workflows/action-deploy-infra.yml
     secrets:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
@@ -87,6 +86,7 @@ jobs:
         get-current-version,
         check-for-changes,
         generate-git-short-sha,
+        publish,
         deploy-infra-test,
       ]
     if: ${{ always() && !failure() && !cancelled() && needs.check-for-changes.outputs.hasBackendChanges == 'true' }}
@@ -109,8 +109,8 @@ jobs:
 
   deploy-slack-notifier-test:
     name: Deploy slack notifier (test)
-    needs: [check-for-changes, deploy-apps-test]
-    if: ${{ always() && !failure() && !cancelled() && needs.check-for-changes.outputs.hasSlackNotifierChanges == 'true' }}
+    needs: [check-for-changes]
+    if: ${{ needs.check-for-changes.outputs.hasSlackNotifierChanges == 'true' }}
     uses: ./.github/workflows/action-deploy-function.yml
     secrets:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}

--- a/.github/workflows/ci-cd-staging.yml
+++ b/.github/workflows/ci-cd-staging.yml
@@ -48,7 +48,9 @@ jobs:
 
   deploy-apps-staging:
     name: Deploy apps to staging
-    needs: [get-current-version, publish]
+    needs:
+      [get-current-version, check-for-changes, deploy-infra-staging, publish]
+    if: ${{ always() && !failure() && !cancelled() && needs.check-for-changes.outputs.hasBackendChanges == 'true' }}
     uses: ./.github/workflows/action-deploy-apps.yml
     secrets:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}

--- a/.github/workflows/dispatch-infrastructure.yml
+++ b/.github/workflows/dispatch-infrastructure.yml
@@ -12,6 +12,11 @@ on:
           - test
           - staging
           - prod
+      version:
+        description: "Version to deploy. Needs to be a git tag"
+        required: true
+        type: string
+
 # todo: take version as param?
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
@@ -39,4 +44,5 @@ jobs:
     with:
       environment: ${{ inputs.environment }}
       region: norwayeast
-      version: ${{ needs.get-current-version.outputs.version }}-${{ needs.generate-git-short-sha.outputs.gitShortSha }}
+      version: ${{ needs.get-current-version.outputs.version }}
+      ref: "refs/tags/${{ inputs.version }}"

--- a/.github/workflows/dispatch-infrastructure.yml
+++ b/.github/workflows/dispatch-infrastructure.yml
@@ -26,13 +26,9 @@ jobs:
     name: Generate git short sha
     uses: ./.github/workflows/action-generate-git-short-sha.yml
 
-  get-current-version:
-    name: Get current version
-    uses: ./.github/workflows/action-get-current-version.yml
-
   deploy-infra-test:
     name: Deploy infra to test
-    needs: [generate-git-short-sha, get-current-version]
+    needs: [generate-git-short-sha]
     uses: ./.github/workflows/action-deploy-infra.yml
     secrets:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
@@ -44,5 +40,5 @@ jobs:
     with:
       environment: ${{ inputs.environment }}
       region: norwayeast
-      version: ${{ needs.get-current-version.outputs.version }}
+      version: ${{ inputs.version }}
       ref: "refs/tags/${{ inputs.version }}"


### PR DESCRIPTION
* Add version as a input value for deploying to infrastructure
* Refactor the dependencies for deploying code and infrastructure. This  makes sure that infrastructure is always deployed before backend code. If there are no changes in Azure, the backend code will still be deployed. 