### PR TITLE
ci: fix concurrency issues in release-prs

### DIFF
--- a/.github/workflows/action-deploy-apps.yml
+++ b/.github/workflows/action-deploy-apps.yml
@@ -42,7 +42,7 @@ on:
 concurrency:
   # Existing runs are cancelled if someone repeatedly commits to their own Pull Request (PR). However, it does not stop others' dry runs or actual deployments from the main branch.
   # Also, the cancellation does not occur on merges to the main branch. Therefore, if multiple merges to main are performed simultaneously, they will just be queued up.
-  group: ${{ github.workflow }}-${{ inputs.environment }}-${{ github.ref_name }}-${{ inputs.dryRun }}
+  group: deploy-apps-${{ inputs.environment }}-${{ github.ref_name }}-${{ inputs.dryRun }}
   # if the dryrun input is true, we want to cancel any running deployments in order to not block the pipeline e.g for environment approvals
   cancel-in-progress: ${{ inputs.dryRun }}
 jobs:

--- a/.github/workflows/action-deploy-infra.yml
+++ b/.github/workflows/action-deploy-infra.yml
@@ -44,7 +44,7 @@ on:
 concurrency:
   # Existing runs are cancelled if someone repeatedly commits to their own Pull Request (PR). However, it does not stop others' dry runs or actual deployments from the main branch.
   # Also, the cancellation does not occur on merges to the main branch. Therefore, if multiple merges to main are performed simultaneously, they will just be queued up.
-  group: ${{ github.workflow }}-${{ inputs.environment }}-${{ github.ref_name }}-${{ inputs.dryRun }}
+  group: deploy-infrastructure-${{ inputs.environment }}-${{ github.ref_name }}-${{ inputs.dryRun }}
   # if the dryrun input is true, we want to cancel any running deployments in order to not block the pipeline e.g for environment approvals
   cancel-in-progress: ${{ inputs.dryRun }}
 jobs:


### PR DESCRIPTION
Fixes an issue where infra and app deployment shared the same concurrency group. One cancelling the other. 

![image](https://github.com/digdir/dialogporten/assets/1777366/c27c0d66-6314-4dad-9603-8380e6615259)
 