### PR TITLE
ci: use new fine grained PAT for release-please

### DIFF
--- a/.github/workflows/ci-cd-main.yml
+++ b/.github/workflows/ci-cd-main.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: google-github-actions/release-please-action@v4
         id: release
         with:
-          token: ${{ secrets.GH_TOKEN_RELEASE_PLEASE_TEST }}
+          token: ${{ secrets.RELEASE_PLEASE_PAT }}
           release-type: simple
 
   generate-git-short-sha:


### PR DESCRIPTION
A new fine grained PAT was generated in the digdir organization. Using that instead of my personal PAT. 