### PR TITLE
ci(azure): avoid ARM deployment conflicts for apps

### DIFF
--- a/.github/workflows/action-deploy-apps.yml
+++ b/.github/workflows/action-deploy-apps.yml
@@ -119,6 +119,8 @@ jobs:
     # needs: deploy-migration-job
     strategy:
       fail-fast: true
+      # to ensure that the bicep commands doesn't conflict with eachother, we need to set the max-parallel to 1
+      max-parallel: 1
       matrix:
         include:
           - name: web-api-eu


### PR DESCRIPTION
Getting this error when trying to deploy apps:
https://github.com/digdir/dialogporten/actions/runs/8170065128/job/22338884530
```shell
Error: ERROR: {"status":"Failed","error":{"code":"DeploymentFailed",
"target":"/subscriptions/***/resourceGroups/***/providers/Microsoft.Resources/deployments/dp-be-test-web-api-eu-1.0.4-2a8fa76",
"message":"At least one resource deployment operation failed. Please list deployment operations for details. Please see https://aka.ms/arm-deployment-operations for usage details.",
"details":
[{"code":"Conflict",
"message":"The resource '/subscriptions/***/resourceGroups/***/providers/Microsoft.Cache/Redis/***' 
is busy processing a previous update request or is undergoing system maintenance.  
As such, it is currently unable to accept the update request.  
Please try again later.\r\nRequestID=4f32c560-a4bf-43b2-a87b-a2d727f68448"}]}}
```
There are two apps trying to update policies for the Redis-instance, and since we cannot allow two deployment operations at once, we need to run the deployment in sequence 👎

It might also be this issue, but let's try to set max-parallel and see what happens. https://github.com/Azure/bicep-types-az/issues/1760

If the case is that it is this issue 👆 We would need to click-ops that part until it is fixed..