### PR TITLE
chore: remove unused param from migration job

### DIFF
--- a/.azure/applications/web-api-migration-job/staging.bicepparam
+++ b/.azure/applications/web-api-migration-job/staging.bicepparam
@@ -3,8 +3,7 @@ using './main.bicep'
 param environment = 'staging'
 param location = 'norwayeast'
 param imageTag = readEnvironmentVariable('IMAGE_TAG')
-param containerAppEnvironmentName = readEnvironmentVariable('CONTAINER_APP_ENVIRONMENT_NAME')
 
 //secrets
+param containerAppEnvironmentName = readEnvironmentVariable('CONTAINER_APP_ENVIRONMENT_NAME')
 param adoConnectionStringSecretUri = readEnvironmentVariable('ADO_CONNECTION_STRING_SECRET_URI')
-param redisName = readEnvironmentVariable('REDIS_NAME')

--- a/.azure/applications/web-api-migration-job/test.bicepparam
+++ b/.azure/applications/web-api-migration-job/test.bicepparam
@@ -2,8 +2,8 @@ using './main.bicep'
 
 param environment = 'test'
 param location = 'norwayeast'
+param imageTag = readEnvironmentVariable('IMAGE_TAG')
 
 //secrets
-param imageTag = readEnvironmentVariable('IMAGE_TAG')
 param containerAppEnvironmentName = readEnvironmentVariable('CONTAINER_APP_ENVIRONMENT_NAME')
 param adoConnectionStringSecretUri = readEnvironmentVariable('ADO_CONNECTION_STRING_SECRET_URI')


### PR DESCRIPTION
Reformatting and remove `REDIS_NAME` from `staging.bicepparam`