### PR TITLE
fix(azure): rename connection string key for redis

### DIFF
--- a/.azure/infrastructure/main.bicep
+++ b/.azure/infrastructure/main.bicep
@@ -198,10 +198,10 @@ module postgresConnectionStringAppConfig '../modules/appConfiguration/upsertKeyV
 
 module redisConnectionStringAppConfig '../modules/appConfiguration/upsertKeyValue.bicep' = {
   scope: resourceGroup
-  name: 'AppConfig_Add_DialogRedisConnectionString'
+  name: 'AppConfig_Add_Redis_ConnectionString'
   params: {
     configStoreName: appConfiguration.outputs.name
-    key: 'Infrastructure:DialogRedisConnectionString'
+    key: 'Infrastructure:Redis:ConnectionString'
     value: redis.outputs.connectionStringSecretUri
     keyValueType: 'keyVaultReference'
   }


### PR DESCRIPTION
Related to https://github.com/digdir/dialogporten/issues/275

Ref new cleaner entries in appsettings: https://github.com/digdir/dialogporten/pull/527/files#diff-c6838c6aab1b032787194ad73ad63002ecd89d413a405fc7b6315572bfd97417