### PR TITLE
fix: Change IfMatchDialogRevision to Revision in DTO

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/Get/GetDialogDto.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/Get/GetDialogDto.cs
@@ -11,7 +11,7 @@ namespace Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.Dialogs.Que
 public sealed class GetDialogDto
 {
     public Guid Id { get; set; }
-    public Guid IfMatchDialogRevision { get; set; }
+    public Guid Revision { get; set; }
     public string Org { get; set; } = null!;
     public string ServiceResource { get; set; } = null!;
     public string Party { get; set; } = null!;

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/Get/MappingProfile.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/Get/MappingProfile.cs
@@ -12,7 +12,7 @@ internal sealed class MappingProfile : Profile
     public MappingProfile()
     {
         CreateMap<DialogEntity, GetDialogDto>()
-            .ForMember(dest => dest.IfMatchDialogRevision, opt => opt.MapFrom(src => src.Revision))
+            .ForMember(dest => dest.Revision, opt => opt.MapFrom(src => src.Revision))
             .ForMember(dest => dest.Status, opt => opt.MapFrom(src => src.StatusId));
 
         CreateMap<DialogActivity, GetDialogDialogActivityDto>()

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/Get/GetDialogDto.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/Get/GetDialogDto.cs
@@ -11,7 +11,7 @@ namespace Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialog
 public sealed class GetDialogDto
 {
     public Guid Id { get; set; }
-    public Guid IfMatchDialogRevision { get; set; }
+    public Guid Revision { get; set; }
     public string Org { get; set; } = null!;
     public string ServiceResource { get; set; } = null!;
     public string Party { get; set; } = null!;

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/Get/MappingProfile.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/Get/MappingProfile.cs
@@ -12,7 +12,7 @@ internal sealed class MappingProfile : Profile
     public MappingProfile()
     {
         CreateMap<DialogEntity, GetDialogDto>()
-            .ForMember(dest => dest.IfMatchDialogRevision, opt => opt.MapFrom(src => src.Revision))
+            .ForMember(dest => dest.Revision, opt => opt.MapFrom(src => src.Revision))
             .ForMember(dest => dest.Status, opt => opt.MapFrom(src => src.StatusId));
 
         CreateMap<DialogActivity, GetDialogDialogActivityDto>()

--- a/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/EndUser/Dialogs/GetDialogEndpoint.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/EndUser/Dialogs/GetDialogEndpoint.cs
@@ -36,7 +36,7 @@ public class GetDialogEndpoint : Endpoint<GetDialogQuery, GetDialogDto>
         await result.Match(
             dto =>
             {
-                HttpContext.Response.Headers.ETag = dto.IfMatchDialogRevision.ToString();
+                HttpContext.Response.Headers.ETag = dto.Revision.ToString();
                 return SendOkAsync(dto, ct);
             },
             notFound => this.NotFoundAsync(notFound, ct),

--- a/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/Dialogs/GetDialogEndpoint.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/Dialogs/GetDialogEndpoint.cs
@@ -36,7 +36,7 @@ public class GetDialogEndpoint : Endpoint<GetDialogQuery, GetDialogDto>
         await result.Match(
             dto =>
             {
-                HttpContext.Response.Headers.ETag = dto.IfMatchDialogRevision.ToString();
+                HttpContext.Response.Headers.ETag = dto.Revision.ToString();
                 return SendOkAsync(dto, ct);
             },
             notFound => this.NotFoundAsync(notFound, ct));


### PR DESCRIPTION
The field indication dialog revision should be called "Revision" in the DTO, and only be called "IfMatchDialogRevision" in the commands.