### PR TITLE
fix: Allow for 2 seconds clock skew in token validation

### DIFF
--- a/src/Digdir.Domain.Dialogporten.WebApi/Common/Authentication/AuthenticationBuilderExtensions.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Common/Authentication/AuthenticationBuilderExtensions.cs
@@ -38,7 +38,7 @@ internal static class AuthenticationBuilderExtensions
                     ValidateAudience = false,
                     RequireExpirationTime = true,
                     ValidateLifetime = true,
-                    ClockSkew = TimeSpan.Zero
+                    ClockSkew = TimeSpan.FromSeconds(2)
                 };
 
                 options.Events = new JwtBearerEvents


### PR DESCRIPTION
Due to slightly mismatched clocks, tokens from the tokengenerator (or other sources) might create tokens that are not yet valid (when validation `iat` claim) in Dialogporten. We can alleviate this by allowing for 2 seconds of skew.