### PR TITLE
suggestion: validate purge command input

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Purge/PurgeDialogCommand.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Purge/PurgeDialogCommand.cs
@@ -12,12 +12,12 @@ using OneOf.Types;
 namespace Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialogs.Commands.Purge;
 public sealed class PurgeDialogCommand : IRequest<PurgeDialogResult>
 {
-    public Guid Id { get; set; }
+    public Guid DialogId { get; set; }
     public Guid? IfMatchDialogRevision { get; set; }
 }
 
 [GenerateOneOf]
-public partial class PurgeDialogResult : OneOfBase<Success, EntityNotFound, ConcurrencyError>;
+public partial class PurgeDialogResult : OneOfBase<Success, EntityNotFound, ConcurrencyError, ValidationError>;
 
 internal sealed class PurgeDialogCommandHandler : IRequestHandler<PurgeDialogCommand, PurgeDialogResult>
 {
@@ -43,11 +43,11 @@ internal sealed class PurgeDialogCommandHandler : IRequestHandler<PurgeDialogCom
             .Include(x => x.Elements)
             .Include(x => x.Activities)
             .Where(x => resourceIds.Contains(x.ServiceResource))
-            .FirstOrDefaultAsync(x => x.Id == request.Id, cancellationToken);
+            .FirstOrDefaultAsync(x => x.Id == request.DialogId, cancellationToken);
 
         if (dialog is null)
         {
-            return new EntityNotFound<DialogEntity>(request.Id);
+            return new EntityNotFound<DialogEntity>(request.DialogId);
         }
 
         _db.Dialogs.HardRemove(dialog);

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Purge/PurgeDialogCommandValidator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Purge/PurgeDialogCommandValidator.cs
@@ -1,0 +1,13 @@
+using FluentValidation;
+
+namespace Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialogs.Commands.Purge;
+
+internal sealed class PurgeDialogCommandValidator : AbstractValidator<PurgeDialogCommand>
+{
+    public PurgeDialogCommandValidator()
+    {
+        RuleFor(x => x.DialogId)
+            .NotEqual(default(Guid));
+
+    }
+}

--- a/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/Dialogs/PurgeDialogEndpoint.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/Dialogs/PurgeDialogEndpoint.cs
@@ -87,6 +87,5 @@ public class PurgeDialogRequestBinder : IRequestBinder<PurgeDialogRequest>
             DialogId = dialogId,
             IfMatchDialogRevision = revisionFound ? revision : null
         });
-
     }
 }

--- a/src/Digdir.Library.Entity.EntityFrameworkCore/Features/Aggregate/AggregateExtensions.cs
+++ b/src/Digdir.Library.Entity.EntityFrameworkCore/Features/Aggregate/AggregateExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System.Diagnostics;
 using System.Reflection;
 using Digdir.Library.Entity.Abstractions.Features.Aggregate;
-using Digdir.Library.Entity.Abstractions.Features.SoftDeletable;
 using Digdir.Library.Entity.Abstractions.Features.Updatable;
 using Digdir.Library.Entity.Abstractions.Features.Versionable;
 using Digdir.Library.Entity.EntityFrameworkCore.Features.SoftDeletable;

--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/Common/Events/DomainEventsTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/Common/Events/DomainEventsTests.cs
@@ -242,7 +242,7 @@ public class DomainEventsTests(DialogApplication application) : ApplicationColle
         // Act
         var purgeCommand = new PurgeDialogCommand
         {
-            Id = dialogId
+            DialogId = dialogId
         };
 
         await Application.Send(purgeCommand);
@@ -273,7 +273,7 @@ public class DomainEventsTests(DialogApplication application) : ApplicationColle
         // Act
         var purgeCommand = new PurgeDialogCommand
         {
-            Id = dialogId
+            DialogId = dialogId
         };
 
         await Application.Send(purgeCommand);

--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/Dialogs/Commands/PurgeDialogTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/Dialogs/Commands/PurgeDialogTests.cs
@@ -21,7 +21,7 @@ public class PurgeDialogTests(DialogApplication application) : ApplicationCollec
         createResponse.TryPickT0(out _, out _).Should().BeTrue();
 
         // Act
-        var purgeCommand = new PurgeDialogCommand { Id = expectedDialogId };
+        var purgeCommand = new PurgeDialogCommand { DialogId = expectedDialogId };
         var purgeResponse = await Application.Send(purgeCommand);
 
         // Assert
@@ -47,7 +47,7 @@ public class PurgeDialogTests(DialogApplication application) : ApplicationCollec
         createResponse.TryPickT0(out _, out _).Should().BeTrue();
 
         // Act
-        var purgeCommand = new PurgeDialogCommand { Id = expectedDialogId, IfMatchDialogRevision = Guid.NewGuid() };
+        var purgeCommand = new PurgeDialogCommand { DialogId = expectedDialogId, IfMatchDialogRevision = Guid.NewGuid() };
         var purgeResponse = await Application.Send(purgeCommand);
 
         // Assert
@@ -61,7 +61,7 @@ public class PurgeDialogTests(DialogApplication application) : ApplicationCollec
         var expectedDialogId = Guid.NewGuid();
         var createCommand = DialogGenerator.GenerateFakeDialog(id: expectedDialogId);
         await Application.Send(createCommand);
-        var purgeCommand = new PurgeDialogCommand { Id = expectedDialogId };
+        var purgeCommand = new PurgeDialogCommand { DialogId = expectedDialogId };
         await Application.Send(purgeCommand);
 
         // Act


### PR DESCRIPTION
This validates the GUID input on purge commands so that we get a 400 error, instead of 500, when posting bad GUIDs.
(The error will always say "DialogId cannot be 00000...", and not "invalid JSON"  .. but better than nothing)