### PR TITLE
fix(azure): use SSL port for redis in connection string

### DIFF
--- a/.azure/modules/redis/main.bicep
+++ b/.azure/modules/redis/main.bicep
@@ -40,7 +40,7 @@ module redisConnectionString '../keyvault/upsertSecret.bicep' = {
     destKeyVaultName: environmentKeyVaultName
     secretName: 'dialogportenRedisConnectionString'
     // disable public access? Use vnet here maybe?
-    secretValue: '${redis.properties.hostName}:${redis.properties.port},password=${redis.properties.accessKeys.primaryKey},ssl=True,abortConnect=False'
+    secretValue: '${redis.properties.hostName}:${redis.properties.sslPort},password=${redis.properties.accessKeys.primaryKey},ssl=True,abortConnect=False'
   }
 }
 


### PR DESCRIPTION
We have disabled non SSL port for Redis, so have to use the sslPort.