### PR TITLE
chore: update the dotnet runtime and SDK version in Dockerfiles

### DIFF
--- a/src/Digdir.Domain.Dialogporten.ChangeDataCapture/Dockerfile
+++ b/src/Digdir.Domain.Dialogporten.ChangeDataCapture/Dockerfile
@@ -1,7 +1,7 @@
-﻿FROM mcr.microsoft.com/dotnet/aspnet:8.0@sha256:3ff67792728179308c4bf06799d8b45d155c60fddc347acf69465a496d9a20b8 AS base
+﻿FROM mcr.microsoft.com/dotnet/aspnet:8.0.3@sha256:9470bf16cb8566951dfdb89d49a4de73ceb31570b3cdb59059af44fe53b19547 AS base
 WORKDIR /app
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0@sha256:4b684e6c74ab8dff26ac54c79d8242b1dd05aba06c367de2b583bad79fd6399b AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0.202@sha256:aabbef174ecb15ef9047574ae2d45a82479e670f62c0a1ad1fa6d623ee19e623 AS build
 WORKDIR /src
 
 # Main project

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/MigrationBundle.dockerfile
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/MigrationBundle.dockerfile
@@ -1,7 +1,7 @@
-﻿FROM mcr.microsoft.com/dotnet/aspnet:8.0@sha256:3ff67792728179308c4bf06799d8b45d155c60fddc347acf69465a496d9a20b8 AS base
+﻿FROM mcr.microsoft.com/dotnet/aspnet:8.0.3@sha256:9470bf16cb8566951dfdb89d49a4de73ceb31570b3cdb59059af44fe53b19547 AS base
 WORKDIR /app
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0@sha256:4b684e6c74ab8dff26ac54c79d8242b1dd05aba06c367de2b583bad79fd6399b AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0.202@sha256:aabbef174ecb15ef9047574ae2d45a82479e670f62c0a1ad1fa6d623ee19e623 AS build
 WORKDIR /src
 
 # Main project

--- a/src/Digdir.Domain.Dialogporten.Service/Dockerfile
+++ b/src/Digdir.Domain.Dialogporten.Service/Dockerfile
@@ -1,7 +1,7 @@
-﻿FROM mcr.microsoft.com/dotnet/aspnet:8.0@sha256:3ff67792728179308c4bf06799d8b45d155c60fddc347acf69465a496d9a20b8 AS base
+﻿FROM mcr.microsoft.com/dotnet/aspnet:8.0.3@sha256:9470bf16cb8566951dfdb89d49a4de73ceb31570b3cdb59059af44fe53b19547 AS base
 WORKDIR /app
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0@sha256:4b684e6c74ab8dff26ac54c79d8242b1dd05aba06c367de2b583bad79fd6399b AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0.202@sha256:aabbef174ecb15ef9047574ae2d45a82479e670f62c0a1ad1fa6d623ee19e623 AS build
 WORKDIR /src
 
 # Main project

--- a/src/Digdir.Domain.Dialogporten.WebApi/Dockerfile
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Dockerfile
@@ -1,8 +1,8 @@
-﻿FROM mcr.microsoft.com/dotnet/aspnet:8.0@sha256:3ff67792728179308c4bf06799d8b45d155c60fddc347acf69465a496d9a20b8 AS base
+﻿FROM mcr.microsoft.com/dotnet/aspnet:8.0.3@sha256:9470bf16cb8566951dfdb89d49a4de73ceb31570b3cdb59059af44fe53b19547 AS base
 WORKDIR /app
 EXPOSE 8080
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0@sha256:4b684e6c74ab8dff26ac54c79d8242b1dd05aba06c367de2b583bad79fd6399b AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0.202@sha256:aabbef174ecb15ef9047574ae2d45a82479e670f62c0a1ad1fa6d623ee19e623 AS build
 WORKDIR /src
 # Main project
 COPY ["src/Digdir.Domain.Dialogporten.WebApi/Digdir.Domain.Dialogporten.WebApi.csproj", "src/Digdir.Domain.Dialogporten.WebApi/"]


### PR DESCRIPTION
Ref this renovate PR: https://github.com/digdir/dialogporten/pull/543

To make it even more transparent as to what version we are using, we nail down the patch and sha instead of major and minor. 

We should probably use the `global.json` to specify the version in the Dockerfile eventually. 