### PR TITLE
fix: UpdateDialogEvent created when dialog element is deleted or updated

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Domain/Dialogs/Entities/DialogEntity.cs
+++ b/src/Digdir.Domain.Dialogporten.Domain/Dialogs/Entities/DialogEntity.cs
@@ -72,12 +72,13 @@ public class DialogEntity :
 
     public void OnUpdate(AggregateNode self, DateTimeOffset utcNow)
     {
-        var shouldProduceEvent = self.IsDirectlyModified()
-            || self.Children.Any(x =>
-                !x.IsChanged<DialogElement>()
-                && !x.IsChanged<DialogSearchTag>()
-                && !x.IsChanged<DialogContent>());
+        var changedChildren = self.Children.Where(x =>
+            x.State != AggregateNodeState.Unchanged &&
+            x.Entity is not DialogElement &&
+            x.Entity is not DialogSearchTag &&
+            x.Entity is not DialogActivity);
 
+        var shouldProduceEvent = self.IsDirectlyModified() || changedChildren.Any();
         if (shouldProduceEvent)
         {
             _domainEvents.Add(new DialogUpdatedDomainEvent(Id, ServiceResource, Party));

--- a/src/Digdir.Domain.Dialogporten.Domain/Dialogs/Entities/Elements/DialogElement.cs
+++ b/src/Digdir.Domain.Dialogporten.Domain/Dialogs/Entities/Elements/DialogElement.cs
@@ -1,4 +1,5 @@
-﻿using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Actions;
+﻿using System.Diagnostics;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Actions;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Activities;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Events.DialogElements;
 using Digdir.Domain.Dialogporten.Domain.Localizations;
@@ -49,9 +50,17 @@ public class DialogElement : IEntity, IAggregateChangedHandler, IEventPublisher
 
     public void OnDelete(AggregateNode self, DateTimeOffset utcNow)
     {
+        var dialog = self.Parents.First().Entity as DialogEntity;
+
+        if (dialog is null)
+        {
+            // ?????
+            throw new UnreachableException();
+        }
+
         _domainEvents.Add(new DialogElementDeletedDomainEvent(
-            DialogId, Id, Dialog.ServiceResource,
-            Dialog.Party, RelatedDialogElementId, Type));
+            DialogId, Id, dialog.ServiceResource,
+            dialog.Party, RelatedDialogElementId, Type));
     }
 
     public void SoftDelete()

--- a/src/Digdir.Domain.Dialogporten.Domain/Dialogs/Entities/Elements/DialogElement.cs
+++ b/src/Digdir.Domain.Dialogporten.Domain/Dialogs/Entities/Elements/DialogElement.cs
@@ -50,13 +50,9 @@ public class DialogElement : IEntity, IAggregateChangedHandler, IEventPublisher
 
     public void OnDelete(AggregateNode self, DateTimeOffset utcNow)
     {
-        var dialog = self.Parents.First().Entity as DialogEntity;
-
-        if (dialog is null)
-        {
-            // ?????
-            throw new UnreachableException();
-        }
+        var dialog = (DialogEntity?)self.Parents
+            .FirstOrDefault(x => x.Entity is DialogEntity dialog && dialog.Id == DialogId)
+            ?.Entity ?? throw new UnreachableException("Expected there to be a parent dialog when deleting a dialog element.");
 
         _domainEvents.Add(new DialogElementDeletedDomainEvent(
             DialogId, Id, dialog.ServiceResource,

--- a/src/Digdir.Library.Entity.Abstractions/Features/Aggregate/AggregateNode.cs
+++ b/src/Digdir.Library.Entity.Abstractions/Features/Aggregate/AggregateNode.cs
@@ -3,7 +3,7 @@
 namespace Digdir.Library.Entity.Abstractions.Features.Aggregate;
 
 /// <summary>
-/// Represents a node in an aggregate tree. 
+/// Represents a node in an aggregate tree.
 /// </summary>
 public abstract class AggregateNode
 {
@@ -23,9 +23,9 @@ public abstract class AggregateNode
     public IReadOnlyCollection<AggregateNodeProperty> ModifiedProperties => _modifiedProperties;
 
     /// <summary>
-    /// A collection of modified children. A child node is modified if it itself 
-    /// is modified, or one of its children are modified. Modified in this 
-    /// context meens added, modified, or deleted. 
+    /// A collection of modified children. A child node is modified if it itself
+    /// is modified, or one of its children are modified. Modified in this
+    /// context meens added, modified, or deleted.
     /// </summary>
     public IReadOnlyCollection<AggregateNode> Children => _children;
 
@@ -83,16 +83,6 @@ public abstract class AggregateNode
             null, nodeArguments, null)!;
         return node;
     }
-
-    /// <summary>
-    /// Checks whether the entity has changed its state for a specified type.
-    /// </summary>
-    /// <typeparam name="T">The type to check against.</typeparam>
-    /// <returns>
-    /// <c>true</c> if the entity is of the specified type and its state is not <see cref="AggregateNodeState.Unchanged"/>;
-    /// otherwise, <c>false</c>.
-    /// </returns>
-    public bool IsChanged<T>() => Entity is T && State is not AggregateNodeState.Unchanged;
 
     /// <summary>
     /// Convenience method to check if the state of the node is <see cref="AggregateNodeState.Modified"/> and not by a child node.

--- a/src/Digdir.Library.Entity.EntityFrameworkCore/Features/Aggregate/AggregateExtensions.cs
+++ b/src/Digdir.Library.Entity.EntityFrameworkCore/Features/Aggregate/AggregateExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System.Diagnostics;
 using System.Reflection;
 using Digdir.Library.Entity.Abstractions.Features.Aggregate;
-using Digdir.Library.Entity.Abstractions.Features.SoftDeletable;
 using Digdir.Library.Entity.Abstractions.Features.Updatable;
 using Digdir.Library.Entity.Abstractions.Features.Versionable;
 using Digdir.Library.Entity.EntityFrameworkCore.Features.SoftDeletable;
@@ -217,12 +216,11 @@ internal static class AggregateExtensions
         foreach (var childForeignKey in parentEntry.Metadata.FindAggregateChildren())
         {
             var childNav = parentEntry.Navigation(childForeignKey.PrincipalToDependent!.Name);
-            if (!childNav.IsLoaded)
-            {
-                Console.WriteLine($"{childNav.Metadata.Name} not loaded .. loading ...");
-                // Alternativ 1: Throw!
-                // Alternativ 2: Log Warning!
-            }
+            // if (!childNav.IsLoaded)
+            // {
+            //     // Alternativ 1: Throw!
+            //     // Alternativ 2: Log Warning!
+            // }
             await childNav.LoadAsync(cancellationToken);
             var currentValues = childNav.Metadata.IsCollection
                 ? childNav.CurrentValue as IEnumerable<object> ?? Enumerable.Empty<object>()

--- a/src/Digdir.Library.Entity.EntityFrameworkCore/Features/Aggregate/AggregateExtensions.cs
+++ b/src/Digdir.Library.Entity.EntityFrameworkCore/Features/Aggregate/AggregateExtensions.cs
@@ -217,11 +217,12 @@ internal static class AggregateExtensions
         foreach (var childForeignKey in parentEntry.Metadata.FindAggregateChildren())
         {
             var childNav = parentEntry.Navigation(childForeignKey.PrincipalToDependent!.Name);
-            //if (!childNav.IsLoaded)
-            //{
-            //    // Alternativ 1: Throw!
-            //    // Alternativ 2: Log Warning!
-            //}
+            if (!childNav.IsLoaded)
+            {
+                Console.WriteLine($"{childNav.Metadata.Name} not loaded .. loading ...");
+                // Alternativ 1: Throw!
+                // Alternativ 2: Log Warning!
+            }
             await childNav.LoadAsync(cancellationToken);
             var currentValues = childNav.Metadata.IsCollection
                 ? childNav.CurrentValue as IEnumerable<object> ?? Enumerable.Empty<object>()

--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/Common/Events/DomainEventsTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/Common/Events/DomainEventsTests.cs
@@ -161,7 +161,7 @@ public class DomainEventsTests(DialogApplication application) : ApplicationColle
     }
 
     // Throws NRE on parent Dialog
-    [Fact(Skip = "This is currently broken, will be fixed/rewritten in https://github.com/digdir/dialogporten/pull/406")]
+    [Fact]
     public async Task Creates_CloudEvents_When_Deleting_DialogElement()
     {
         // Arrange
@@ -201,8 +201,7 @@ public class DomainEventsTests(DialogApplication application) : ApplicationColle
             cloudEvent.Type == CloudEventTypes.Get(nameof(DialogElementDeletedDomainEvent)));
     }
 
-    // Creates DialogUpdatedDomainEvent instead of DialogDeletedDomainEvent
-    [Fact(Skip = "This is currently broken, will be fixed/rewritten in https://github.com/digdir/dialogporten/pull/406")]
+    [Fact]
     public async Task Creates_CloudEvents_When_Dialog_Deleted()
     {
         // Arrange

--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/Common/Events/DomainEventsTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/Common/Events/DomainEventsTests.cs
@@ -199,6 +199,9 @@ public class DomainEventsTests(DialogApplication application) : ApplicationColle
 
         cloudEvents.Should().ContainSingle(cloudEvent =>
             cloudEvent.Type == CloudEventTypes.Get(nameof(DialogElementDeletedDomainEvent)));
+
+        cloudEvents.Should().NotContain(cloudEvent =>
+            cloudEvent.Type == CloudEventTypes.Get(nameof(DialogElementUpdatedDomainEvent)));
     }
 
     [Fact]

--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/Common/Events/DomainEventsTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/Common/Events/DomainEventsTests.cs
@@ -153,8 +153,8 @@ public class DomainEventsTests(DialogApplication application) : ApplicationColle
         cloudEvents.Should().OnlyContain(cloudEvent => cloudEvent.Resource == createDialogCommand.ServiceResource);
         cloudEvents.Should().OnlyContain(cloudEvent => cloudEvent.Subject == createDialogCommand.Party);
 
-        // cloudEvents.Should().NotContain(cloudEvent =>
-        //     cloudEvent.Type == CloudEventTypes.Get(nameof(DialogUpdatedDomainEvent)));
+        cloudEvents.Should().NotContain(cloudEvent =>
+            cloudEvent.Type == CloudEventTypes.Get(nameof(DialogUpdatedDomainEvent)));
 
         cloudEvents.Should().ContainSingle(cloudEvent =>
             cloudEvent.Type == CloudEventTypes.Get(nameof(DialogElementUpdatedDomainEvent)));


### PR DESCRIPTION
* When deleting or updating a DialogElement, DialogUpdatedEvents where created.
* When deleting Element, NRE  was thrown. The parent dialog was not present (Element orphaned by EF Core), manually getting parent from aggregate tree