### PR TITLE
chore: Temp debugging, log Slack Webhook URL

### DIFF
--- a/src/Digdir.Tool.Dialogporten.SlackNotifier/External/Slack/SlackClient.cs
+++ b/src/Digdir.Tool.Dialogporten.SlackNotifier/External/Slack/SlackClient.cs
@@ -10,10 +10,19 @@ internal sealed class SlackClient : ISlackClient
 
     public SlackClient(HttpClient httpClient, IOptions<SlackOptions> slackOptions)
     {
-        _httpClient = httpClient;
-        _slackOptions = slackOptions;
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _slackOptions = slackOptions ?? throw new ArgumentNullException(nameof(slackOptions));
     }
 
-    public Task SendAsync(SlackRequestDto message, CancellationToken cancellationToken) =>
-        _httpClient.PostAsJsonAsync(_slackOptions.Value.WebhookUrl, message, cancellationToken);
+    public async Task SendAsync(SlackRequestDto message, CancellationToken cancellationToken)
+    {
+        // TEMP DEBUG
+        Console.WriteLine($"Slack WebhookURL: {_slackOptions.Value.WebhookUrl}");
+        if (!Uri.TryCreate(_slackOptions.Value.WebhookUrl, UriKind.Absolute, out var uri))
+        {
+            return;
+        }
+
+        await _httpClient.PostAsJsonAsync(uri, message, cancellationToken);
+    }
 }

--- a/src/Digdir.Tool.Dialogporten.SlackNotifier/Features/AzureAlertToSlackForwarder/ForwardAlertToSlack.cs
+++ b/src/Digdir.Tool.Dialogporten.SlackNotifier/Features/AzureAlertToSlackForwarder/ForwardAlertToSlack.cs
@@ -31,6 +31,7 @@ internal sealed class ForwardAlertToSlack
             ExceptionReport = appInsightsResponses.ToAsciiTableExceptionReport(),
             Link = azureAlertRequest.ToQueryLink()
         }, cancellationToken);
+
         return req.CreateResponse(HttpStatusCode.OK);
     }
 }


### PR DESCRIPTION
The Slack notifier function throws "invalid URI" once in a while, attempting to figure out what/why