### PR TITLE
chore: Match Azure Redis version locally

### DIFF
--- a/docker-compose-no-webapi.yml
+++ b/docker-compose-no-webapi.yml
@@ -32,7 +32,7 @@ services:
       retries: 5
   
   dialogporten-redis:
-    image: redis:7.0-alpine
+    image: redis:6.0-alpine
     restart: always
     ports:
       - "6379:6379"


### PR DESCRIPTION
Azure Redis is on version 6.0