### PR TITLE
fix(azure): avoid naming issue for secrets

### DIFF
--- a/.azure/modules/keyvault/copySecrets.bicep
+++ b/.azure/modules/keyvault/copySecrets.bicep
@@ -26,7 +26,7 @@ resource srcKeyVaultResource 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
 }
 
 module secrets 'upsertSecret.bicep' = [for key in environmentKeys: if (key.isEnvironmentKey) {
-    name: '${take(key.value, 58)}-${take(uniqueString(key.value), 6)}'
+    name: '${take(key.value, 57)}-${take(uniqueString(key.value), 6)}'
     scope: resourceGroup(destKeyVaultSubId, destKeyVaultRGName)
     params: {
         destKeyVaultName: destKeyVaultName

--- a/.azure/modules/keyvault/copySecrets.bicep
+++ b/.azure/modules/keyvault/copySecrets.bicep
@@ -26,7 +26,7 @@ resource srcKeyVaultResource 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
 }
 
 module secrets 'upsertSecret.bicep' = [for key in environmentKeys: if (key.isEnvironmentKey) {
-	name: '${take(key.value, 58)}-${take(uniqueString(key.value), 6)}'
+    name: '${take(key.value, 58)}-${take(uniqueString(key.value), 6)}'
     scope: resourceGroup(destKeyVaultSubId, destKeyVaultRGName)
     params: {
         destKeyVaultName: destKeyVaultName

--- a/.azure/modules/keyvault/copySecrets.bicep
+++ b/.azure/modules/keyvault/copySecrets.bicep
@@ -1,5 +1,5 @@
 // Source
-param srcKeyVaultKeys array
+param srcKeyVaultKeys array 
 param srcKeyVaultName string
 param srcKeyVaultRGNName string = resourceGroup().name
 param srcKeyVaultSubId string = subscription().subscriptionId
@@ -14,27 +14,23 @@ param destKeyVaultSubId string = subscription().subscriptionId
 param secretPrefix string
 param removeSecretPrefix bool = true
 
-var environmentKeys = [
-  for key in srcKeyVaultKeys: {
+var environmentKeys = [for key in srcKeyVaultKeys: {
     isEnvironmentKey: startsWith(key, secretPrefix)
     value: removeSecretPrefix ? replace(key, secretPrefix, '') : key
     fullName: key
-  }
-]
+}]
 
 resource srcKeyVaultResource 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
-  name: srcKeyVaultName
-  scope: resourceGroup(srcKeyVaultSubId, srcKeyVaultRGNName)
+	name: srcKeyVaultName
+    scope: resourceGroup(srcKeyVaultSubId, srcKeyVaultRGNName)
 }
 
-module secrets 'upsertSecret.bicep' = [
-  for key in environmentKeys: if (key.isEnvironmentKey) {
-    name: '${take(key.value, 58)}-${take(uniqueString(key.value), 6)}'
+module secrets 'upsertSecret.bicep' = [for key in environmentKeys: if (key.isEnvironmentKey) {
+	name: '${take(key.value, 58)}-${take(uniqueString(key.value), 6)}'
     scope: resourceGroup(destKeyVaultSubId, destKeyVaultRGName)
     params: {
-      destKeyVaultName: destKeyVaultName
-      secretName: key.value
-      secretValue: srcKeyVaultResource.getSecret(key.fullName)
+        destKeyVaultName: destKeyVaultName
+        secretName: key.value
+        secretValue: srcKeyVaultResource.getSecret(key.fullName)
     }
-  }
-]
+}]

--- a/.azure/modules/keyvault/copySecrets.bicep
+++ b/.azure/modules/keyvault/copySecrets.bicep
@@ -1,5 +1,5 @@
 // Source
-param srcKeyVaultKeys array 
+param srcKeyVaultKeys array
 param srcKeyVaultName string
 param srcKeyVaultRGNName string = resourceGroup().name
 param srcKeyVaultSubId string = subscription().subscriptionId
@@ -14,23 +14,27 @@ param destKeyVaultSubId string = subscription().subscriptionId
 param secretPrefix string
 param removeSecretPrefix bool = true
 
-var environmentKeys = [for key in srcKeyVaultKeys: {
+var environmentKeys = [
+  for key in srcKeyVaultKeys: {
     isEnvironmentKey: startsWith(key, secretPrefix)
     value: removeSecretPrefix ? replace(key, secretPrefix, '') : key
     fullName: key
-}]
+  }
+]
 
 resource srcKeyVaultResource 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
-	name: srcKeyVaultName
-    scope: resourceGroup(srcKeyVaultSubId, srcKeyVaultRGNName)
+  name: srcKeyVaultName
+  scope: resourceGroup(srcKeyVaultSubId, srcKeyVaultRGNName)
 }
 
-module secrets 'upsertSecret.bicep' = [for key in environmentKeys: if (key.isEnvironmentKey) {
-	name: key.value
+module secrets 'upsertSecret.bicep' = [
+  for key in environmentKeys: if (key.isEnvironmentKey) {
+    name: '${take(key.value, 58)}-${take(uniqueString(key.value), 6)}'
     scope: resourceGroup(destKeyVaultSubId, destKeyVaultRGName)
     params: {
-        destKeyVaultName: destKeyVaultName
-        secretName: key.value
-        secretValue: srcKeyVaultResource.getSecret(key.fullName)
+      destKeyVaultName: destKeyVaultName
+      secretName: key.value
+      secretValue: srcKeyVaultResource.getSecret(key.fullName)
     }
-}]
+  }
+]


### PR DESCRIPTION
Deployment names can not be longer than 64 characters. Trimming the secret name  + adding a unique hash to avoid potential conflicts.