### PR TITLE
chore: add load balancer for web api in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,17 @@ include:
   - docker-compose-no-webapi.yml
 
 services:
+  dialogporten-webapi-loadbalancer:
+    image: nginx:latest
+    ports:
+      - "7214:80"
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf
+    depends_on:
+      - dialogporten-webapi
+    restart: always
   dialogporten-webapi:
+    scale: 2
     build:
       context: .
       dockerfile: src/Digdir.Domain.Dialogporten.WebApi/Dockerfile
@@ -19,7 +29,5 @@ services:
       - Serilog__MinimumLevel__Default=Debug
       - ASPNETCORE_URLS=http://+:8080
       - ASPNETCORE_ENVIRONMENT=Development
-    ports:
-      - "7214:8080"
     volumes:
       - ./.aspnet/https:/https

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ include:
   - docker-compose-no-webapi.yml
 
 services:
-  dialogporten-webapi-loadbalancer:
+  dialogporten-webapi-ingress:
     image: nginx:latest
     ports:
       - "7214:80"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ include:
 
 services:
   dialogporten-webapi-ingress:
-    image: nginx:latest
+    image: nginx:1.25.4
     ports:
       - "7214:80"
     volumes:

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,4 +1,4 @@
-# this nginx config is for the load balancer: dialogporten-webapi-loadbalancer in docker-compose.yml
+# this nginx config is for the load balancer: dialogporten-webapi-ingress in docker-compose.yml
 events {}
 
 http {

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,21 @@
+# this nginx config is for the load balancer: dialogporten-webapi-loadbalancer in docker-compose.yml
+events {}
+
+http {
+    upstream webapi {
+        least_conn;
+        server dialogporten-webapi:8080;
+    }
+
+    server {
+        listen 80;
+
+        location / {
+            proxy_pass http://webapi;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }
+}


### PR DESCRIPTION
In order to replicate the setup in Container Apps, we add a load balancer so we can have more than one replica of the web api. 