### PR TITLE
feat(service): use in-memory transport instead of rabbitmq

### DIFF
--- a/.env
+++ b/.env
@@ -4,8 +4,4 @@ POSTGRES_PASSWORD=supersecret
 POSTGRES_DB=Dialogporten
 DB_CONNECTION_STRING=Server=dialogporten-postgres;Port=5432;Database=${POSTGRES_DB};User ID=${POSTGRES_USER};Password=${POSTGRES_PASSWORD};
 
-RABBITMQ_USER=guest
-RABBITMQ_PASSWORD=guest
-RABBITMQ_HOST=dialogporten-rabbitmq
-
 COMPOSE_PROJECT_NAME=digdir

--- a/.github/workflows/action-publish.yml
+++ b/.github/workflows/action-publish.yml
@@ -33,8 +33,6 @@ jobs:
             imageName: cdc
           - dockerfile: ./src/Digdir.Domain.Dialogporten.Infrastructure/MigrationBundle.dockerfile
             imageName: migration-bundle
-          - dockerfile: ./RabbitMq/Dockerfile
-            imageName: rabbitmq
 
     permissions:
       contents: read

--- a/RabbitMq/Dockerfile
+++ b/RabbitMq/Dockerfile
@@ -1,8 +1,0 @@
-FROM rabbitmq:3-management
-
-COPY ./RabbitMq/enabled_plugins /etc/rabbitmq/enabled_plugins
-
-RUN chown -R rabbitmq:rabbitmq /etc/rabbitmq/enabled_plugins
-
-# What ports should be exposed?
-EXPOSE 4369 5671 5672 15671 15672 15692 25672 35672-35682

--- a/RabbitMq/enabled_plugins
+++ b/RabbitMq/enabled_plugins
@@ -1,1 +1,0 @@
-[rabbitmq_management, rabbitmq_prometheus, rabbitmq_shovel, rabbitmq_shovel_management].

--- a/docker-compose-no-webapi.yml
+++ b/docker-compose-no-webapi.yml
@@ -16,20 +16,6 @@ services:
       interval: 2s
       timeout: 20s
       retries: 5
-
-  dialogporten-rabbitmq:
-    build:
-      context: .
-      dockerfile: RabbitMq/Dockerfile
-    restart: always
-    ports:
-      - "5672:5672"
-      - "15672:15672"
-    healthcheck:
-      test: [ "CMD-SHELL", "rabbitmq-diagnostics check_running" ]
-      interval: 5s
-      timeout: 20s
-      retries: 5
   
   dialogporten-redis:
     image: redis:6.0-alpine
@@ -50,14 +36,9 @@ services:
     depends_on:
       dialogporten-postgres:
         condition: service_healthy
-      dialogporten-rabbitmq:
-        condition: service_healthy
     environment:
       - Infrastructure:DialogDbConnectionString=${DB_CONNECTION_STRING}
       - ASPNETCORE_ENVIRONMENT=Development
-      - RabbitMq:Host=${RABBITMQ_HOST}
-      - RabbitMq:Username=${RABBITMQ_USERNAME}
-      - RabbitMq:Password=${RABBITMQ_PASSWORD}
   
   dialogporten-cdc:
     build:
@@ -67,14 +48,9 @@ services:
     depends_on:
       dialogporten-postgres:
         condition: service_healthy
-      dialogporten-rabbitmq:
-        condition: service_healthy
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
       - Infrastructure:DialogDbConnectionString=${DB_CONNECTION_STRING}
       - ReplicationSlotName=outboxmessage_replication_slot
       - PublicationName=outboxmessage_publication
       - TableName=OutboxMessage
-      - RabbitMq:Host=${RABBITMQ_HOST}
-      - RabbitMq:Username=${RABBITMQ_USERNAME}
-      - RabbitMq:Password=${RABBITMQ_PASSWORD}

--- a/enabled_plugins
+++ b/enabled_plugins
@@ -1,1 +1,0 @@
-[rabbitmq_management, rabbitmq_prometheus, rabbitmq_shovel, rabbitmq_shovel_management].

--- a/src/Digdir.Domain.Dialogporten.ChangeDataCapture/appsettings.Development.json
+++ b/src/Digdir.Domain.Dialogporten.ChangeDataCapture/appsettings.Development.json
@@ -1,10 +1,5 @@
 {
   "ReplicationSlotName": "outboxmessage_replication_slot",
   "PublicationName": "outboxmessage_publication",
-  "TableName": "OutboxMessage",
-  "RabbitMq": {
-    "Host": "localhost",
-    "Username": "guest",
-    "Password": "guest"
-  }
+  "TableName": "OutboxMessage"
 }

--- a/src/Digdir.Domain.Dialogporten.Service/Digdir.Domain.Dialogporten.Service.csproj
+++ b/src/Digdir.Domain.Dialogporten.Service/Digdir.Domain.Dialogporten.Service.csproj
@@ -9,16 +9,15 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="MassTransit.RabbitMQ" Version="8.2.0" />
-        <PackageReference Include="RabbitMQ.Client" Version="6.8.1" />
+        <PackageReference Include="MassTransit" Version="8.2.0" />
         <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
-        <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="4.0.0"/>
+        <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="4.0.0" />
         <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\Digdir.Domain.Dialogporten.Application\Digdir.Domain.Dialogporten.Application.csproj"/>
-        <ProjectReference Include="..\Digdir.Domain.Dialogporten.Infrastructure\Digdir.Domain.Dialogporten.Infrastructure.csproj"/>
+        <ProjectReference Include="..\Digdir.Domain.Dialogporten.Application\Digdir.Domain.Dialogporten.Application.csproj" />
+        <ProjectReference Include="..\Digdir.Domain.Dialogporten.Infrastructure\Digdir.Domain.Dialogporten.Infrastructure.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/Digdir.Domain.Dialogporten.Service/Program.cs
+++ b/src/Digdir.Domain.Dialogporten.Service/Program.cs
@@ -9,7 +9,7 @@ using Digdir.Domain.Dialogporten.Application.Externals.Presentation;
 using Digdir.Domain.Dialogporten.Service;
 
 // TODO: Add AppConfiguration and key vault
-// TODO: Configure RabbitMQ connection settings 
+// TODO: Configure Service bus connection settings 
 // TODO: Configure Postgres connection settings
 // TODO: Improve exceptions thrown in this assembly
 
@@ -60,29 +60,20 @@ static void BuildAndRun(string[] args)
         .AddMassTransit(x =>
         {
             x.AddConsumers(thisAssembly);
-            x.UsingRabbitMq((context, cfg) =>
+
+            var useInMemoryTransport = builder.Configuration.GetValue<bool>("MassTransit:UseInMemoryTransport");
+
+            if (useInMemoryTransport)
             {
-                const string rabbitMqSection = "RabbitMq";
-                cfg.Host(builder.Configuration[$"{rabbitMqSection}:Host"], "/", h =>
+                x.UsingInMemory((context, cfg) =>
                 {
-                    h.Username(builder.Configuration[$"{rabbitMqSection}:Username"]);
-                    h.Password(builder.Configuration[$"{rabbitMqSection}:Password"]);
+                    cfg.ConfigureEndpoints(context);
                 });
-                cfg.ReceiveEndpoint(thisAssembly.GetName().Name!, x =>
-                {
-                    x.UseMessageRetry(r => r.Intervals(
-                        TimeSpan.FromSeconds(1),
-                        TimeSpan.FromSeconds(3),
-                        TimeSpan.FromSeconds(10)));
-                    // TODO: Add delayed redelivery - but we need a rabbitmq plugin for this
-                    //x.UseDelayedRedelivery(r => r.Intervals(
-                    //    TimeSpan.FromMinutes(1),
-                    //    TimeSpan.FromMinutes(3),
-                    //    TimeSpan.FromMinutes(10)));
-                    x.SetQuorumQueue();
-                    x.ConfigureConsumers(context);
-                });
-            });
+            }
+            else
+            {
+                // todo: Configure for using Azure Service Bus
+            }
         })
         .AddApplication(builder.Configuration, builder.Environment)
         .AddInfrastructure(builder.Configuration, builder.Environment)

--- a/src/Digdir.Domain.Dialogporten.Service/appsettings.Development.json
+++ b/src/Digdir.Domain.Dialogporten.Service/appsettings.Development.json
@@ -5,10 +5,8 @@
             "Microsoft.AspNetCore": "Warning"
         }
     },
-    "RabbitMq": {
-        "Host": "localhost",
-        "Username": "guest",
-        "Password": "guest"
+    "MassTransit": {
+        "UseInMemoryTransport": true
     },
     "Infrastructure": {
         "Redis": {


### PR DESCRIPTION
Related to #50 

- Remove all traces of RabbitMQ
- Add in-memory transport if specified in settings