### PR TITLE
feat: Add support for legacy enterprise users

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Application/Common/IUserNameRegistry.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Common/IUserNameRegistry.cs
@@ -2,13 +2,14 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Digdir.Domain.Dialogporten.Application.Common.Extensions;
 using Digdir.Domain.Dialogporten.Application.Externals;
+using Digdir.Domain.Dialogporten.Application.Externals.Authentication;
 using Digdir.Domain.Dialogporten.Application.Externals.Presentation;
 
 namespace Digdir.Domain.Dialogporten.Application.Common;
 
 public interface IUserNameRegistry
 {
-    bool TryGetCurrentUserPid([NotNullWhen(true)] out string? userPid);
+    bool TryGetCurrentUserExternalId([NotNullWhen(true)] out string? userExternalId);
     Task<UserInformation?> GetUserInformation(CancellationToken cancellationToken);
 }
 
@@ -18,24 +19,49 @@ public class UserNameRegistry : IUserNameRegistry
 {
     private readonly IUser _user;
     private readonly INameRegistry _nameRegistry;
+    private readonly IOrganizationRegistry _organizationRegistry;
 
-    public UserNameRegistry(IUser user, INameRegistry nameRegistry)
+    public UserNameRegistry(IUser user, INameRegistry nameRegistry, IOrganizationRegistry organizationRegistry)
     {
         _user = user ?? throw new ArgumentNullException(nameof(user));
         _nameRegistry = nameRegistry ?? throw new ArgumentNullException(nameof(nameRegistry));
+        _organizationRegistry = organizationRegistry ?? throw new ArgumentNullException(nameof(organizationRegistry));
     }
 
-    public bool TryGetCurrentUserPid([NotNullWhen(true)] out string? userPid) => _user.TryGetPid(out userPid);
+    public bool TryGetCurrentUserExternalId([NotNullWhen(true)] out string? userExternalId)
+    {
+        if (_user.TryGetPid(out userExternalId)) return true;
+        if (_user.TryGetLegacySystemUserId(out userExternalId)) return true;
+        if (_user.TryGetOrgNumber(out userExternalId)) return true;
+        return false;
+    }
 
     public async Task<UserInformation?> GetUserInformation(CancellationToken cancellationToken)
     {
-        if (!TryGetCurrentUserPid(out var userPid))
+        if (!TryGetCurrentUserExternalId(out var userExernalId))
         {
             return null;
         }
 
-        var userName = await _nameRegistry.GetName(userPid, cancellationToken);
-        return new(userPid, userName);
+        string? userName;
+        switch (_user.GetPrincipal().GetUserType())
+        {
+            case UserType.Person:
+                userName = await _nameRegistry.GetName(userExernalId, cancellationToken);
+                break;
+            case UserType.LegacySystemUser:
+                _user.TryGetLegacySystemUserName(out userName);
+                break;
+            case UserType.Enterprise:
+                userName = await _organizationRegistry.GetOrgShortName(userExernalId, cancellationToken);
+                break;
+            case UserType.Unknown:
+            case UserType.SystemUser: // Implement when we know how this will be handled
+            default:
+                throw new UnreachableException("Unknown user type");
+        }
+
+        return new(userExernalId, userName);
     }
 }
 
@@ -50,11 +76,11 @@ internal sealed class LocalDevelopmentUserNameRegistryDecorator : IUserNameRegis
         _userNameRegistry = userNameRegistry ?? throw new ArgumentNullException(nameof(userNameRegistry));
     }
 
-    public bool TryGetCurrentUserPid([NotNullWhen(true)] out string? userPid) =>
-        _userNameRegistry.TryGetCurrentUserPid(out userPid);
+    public bool TryGetCurrentUserExternalId([NotNullWhen(true)] out string? userExternalId) =>
+        _userNameRegistry.TryGetCurrentUserExternalId(out userExternalId);
 
     public Task<UserInformation?> GetUserInformation(CancellationToken cancellationToken)
-        => _userNameRegistry.TryGetCurrentUserPid(out var userPid)
+        => _userNameRegistry.TryGetCurrentUserExternalId(out var userPid)
             ? Task.FromResult<UserInformation?>(new UserInformation(userPid!, LocalDevelopmentUserPid))
             : throw new UnreachableException();
 }

--- a/src/Digdir.Domain.Dialogporten.Application/Externals/Authentication/UserType.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Externals/Authentication/UserType.cs
@@ -1,0 +1,10 @@
+namespace Digdir.Domain.Dialogporten.Application.Externals.Authentication;
+
+public enum UserType
+{
+    Unknown = 0,
+    Person = 1,
+    LegacySystemUser = 2,
+    SystemUser = 3,
+    Enterprise = 4
+}

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/DialogSeenLogs/Queries/Get/GetDialogSeenLogQuery.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/DialogSeenLogs/Queries/Get/GetDialogSeenLogQuery.cs
@@ -44,9 +44,9 @@ internal sealed class GetDialogSeenLogQueryHandler : IRequestHandler<GetDialogSe
     public async Task<GetDialogSeenLogResult> Handle(GetDialogSeenLogQuery request,
         CancellationToken cancellationToken)
     {
-        if (!_userNameRegistry.TryGetCurrentUserPid(out var userPid))
+        if (!_userNameRegistry.TryGetCurrentUserExternalId(out var userPid))
         {
-            return new Forbidden("No valid user pid found.");
+            return new Forbidden("No valid user was authenticated");
         }
 
         var dialog = await _dbContext.Dialogs

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/DialogSeenLogs/Queries/Search/SearchDialogSeenLogQuery.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/DialogSeenLogs/Queries/Search/SearchDialogSeenLogQuery.cs
@@ -42,9 +42,9 @@ internal sealed class SearchDialogSeenLogQueryHandler : IRequestHandler<SearchDi
 
     public async Task<SearchDialogSeenLogResult> Handle(SearchDialogSeenLogQuery request, CancellationToken cancellationToken)
     {
-        if (!_userNameRegistry.TryGetCurrentUserPid(out var userPid))
+        if (!_userNameRegistry.TryGetCurrentUserExternalId(out var userPid))
         {
-            return new Forbidden("No valid user pid found.");
+            return new Forbidden("No valid user was authenticated");
         }
 
         var dialog = await _db.Dialogs

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/Get/GetDialogQuery.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/Get/GetDialogQuery.cs
@@ -57,7 +57,7 @@ internal sealed class GetDialogQueryHandler : IRequestHandler<GetDialogQuery, Ge
 
         if (userInformation is null)
         {
-            return new Forbidden("No valid user pid found.");
+            return new Forbidden("No valid user was authenticated");
         }
 
         var (userPid, userName) = userInformation;

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/Search/SearchDialogQuery.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/Search/SearchDialogQuery.cs
@@ -136,9 +136,9 @@ internal sealed class SearchDialogQueryHandler : IRequestHandler<SearchDialogQue
 
     public async Task<SearchDialogResult> Handle(SearchDialogQuery request, CancellationToken cancellationToken)
     {
-        if (!_userNameRegistry.TryGetCurrentUserPid(out var userPid))
+        if (!_userNameRegistry.TryGetCurrentUserExternalId(out var userPid))
         {
-            return new Forbidden("No valid user pid found.");
+            return new Forbidden("No valid user was authenticated");
         }
 
         var searchExpression = Expressions.LocalizedSearchExpression(request.Search, request.SearchCultureCode);


### PR DESCRIPTION
This add support for [Altinn 2 legacy enterprise users](https://altinn.github.io/docs/api/rest/kom-i-gang/virksomhet/#autentisering-med-virksomhetsbruker-og-maskinporten) ("virksomhetsbrukere")

## Description

This generalizes `IUserNameRegistry` in order to support legacy Altinn 2 enterprise users, and adds additional extension methods in `ClaimsPrincipalExtensions`. This should lay some of the ground work required to support the new system users.

This means we no longer require a `pid` claim to be present in EU-endpoints requiring authorization; a `urn:altinn:userId` + `urn:altinn:username` or valid org. number in `consumer` will be deemed sufficient, and will cause a authorization request to be made. Altinn Authorization already utilizes `urn:altinn:userid` when enriching the request with roles if a resource party is supplied, so this makes it possible to use enterprise users (which don't have a `pid` claim) to use Dialogporten.

Allowing just a `consumer` claim will open for XACML policies with rules identifying specific organization numbers. This is not used in Altinn-contexts today, but it makes little sense to actively not support it as it might be more relevant in services external to Altinn.

# Related Issue(s)

N/A

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
