### PR TITLE
ci: run k6 tests regardless if previous jobs skipped

### DIFF
--- a/.github/workflows/ci-cd-main.yml
+++ b/.github/workflows/ci-cd-main.yml
@@ -123,7 +123,9 @@ jobs:
 
   run-e2e-tests:
     name: "Run K6 functional end-to-end tests"
-    needs: [deploy-apps-test]
+    # we want the end-to-end tests to be dependent on deployment of infrastructure and apps, but if infrastructure is skipped, we still want to run the tests
+    if: ${{ always() && !failure() && !cancelled() && needs.check-for-changes.outputs.hasBackendChanges == 'true' }}
+    needs: [deploy-apps-test, check-for-changes]
     uses: ./.github/workflows/action-run-k6-tests.yml
     secrets:
       TOKEN_GENERATOR_USERNAME: ${{ secrets.TOKEN_GENERATOR_USERNAME }}

--- a/.github/workflows/ci-cd-staging.yml
+++ b/.github/workflows/ci-cd-staging.yml
@@ -70,7 +70,9 @@ jobs:
 
   run-e2e-tests:
     name: "Run K6 functional end-to-end tests"
-    needs: [deploy-apps-staging]
+    # we want the end-to-end tests to be dependent on deployment of infrastructure and apps, but if infrastructure is skipped, we still want to run the tests
+    if: ${{ always() && !failure() && !cancelled() && needs.check-for-changes.outputs.hasBackendChanges == 'true' }}
+    needs: [deploy-apps-staging, check-for-changes]
     uses: ./.github/workflows/action-run-k6-tests.yml
     secrets:
       TOKEN_GENERATOR_USERNAME: ${{ secrets.TOKEN_GENERATOR_USERNAME }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

- To ensure the tests are run regardless of if the previous jobs have been skipped, we add the same logic as for deploying apps. 
- Ensure tests are run only if backend code has been changes

## Related Issue(s)


## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
