### PR TITLE
chore: Add additional e2e tests

### DIFF
--- a/tests/k6/common/token.js
+++ b/tests/k6/common/token.js
@@ -58,7 +58,7 @@ function fetchToken(url, tokenOptions, type) {
 export function getServiceOwnerTokenFromGenerator(tokenOptions = null) {
   let fullTokenOptions = extend({}, defaultTokenOptions, tokenOptions);
   const url = `http://altinn-testtools-token-generator.azurewebsites.net/api/GetEnterpriseToken?env=tt02&scopes=${encodeURIComponent(fullTokenOptions.scopes)}&org=${fullTokenOptions.orgName}&orgNo=${fullTokenOptions.orgNo}&ttl=${tokenTtl}`;
-  return fetchToken(url, fullTokenOptions, `service owner (orgno:${fullTokenOptions.orgNo})`);
+  return fetchToken(url, fullTokenOptions, `service owner (orgno:${fullTokenOptions.orgNo} orgName:${fullTokenOptions.orgName})`);
 }
 
 export function getEnduserTokenFromGenerator(tokenOptions = null) {

--- a/tests/k6/tests/serviceowner/authorization.js
+++ b/tests/k6/tests/serviceowner/authorization.js
@@ -1,4 +1,4 @@
-import { describe, expect, expectStatusFor, getSO, postSO, putSO, patchSO, deleteSO } from '../../common/testimports.js'
+import { describe, expect, expectStatusFor, getSO, postSO, putSO, patchSO, deleteSO, purgeSO } from '../../common/testimports.js'
 import { default as dialogToInsert } from './testdata/01-create-dialog.js';
 
 export default function () {
@@ -116,7 +116,7 @@ export default function () {
 
     // Finally, cleanup by deleting the dialog
     describe('Allow deleting dialog as valid serviceowner', () => {
-        let r = deleteSO('dialogs/' + dialogId);
+        let r = purgeSO('dialogs/' + dialogId);
         expect(r.status, 'response status').to.equal(204);
     });
 

--- a/tests/k6/tests/serviceowner/concurrency.js
+++ b/tests/k6/tests/serviceowner/concurrency.js
@@ -1,4 +1,4 @@
-import { describe, expect, expectStatusFor, postSO, postSOAsync, deleteSO } from '../../common/testimports.js'
+import { describe, expect, expectStatusFor, postSO, postSOAsync, purgeSO } from '../../common/testimports.js'
 import { default as dialogToInsert } from './testdata/01-create-dialog.js';
 
 export default function () {
@@ -26,7 +26,7 @@ export default function () {
         const results = await Promise.all(promises);
 
         // Cleanup here, as we're in another thread
-        deleteSO('dialogs/' + dialogId);
+        purgeSO('dialogs/' + dialogId);
 
         results.forEach((r) => {
             expect(r.status, 'status code for concurrently added child entity').to.equal(201);

--- a/tests/k6/tests/serviceowner/dialogCreatePatchDelete.js
+++ b/tests/k6/tests/serviceowner/dialogCreatePatchDelete.js
@@ -1,4 +1,4 @@
-import { describe, expect, expectStatusFor, getSO, postSO, deleteSO, patchSO, uuidv4 } from '../../common/testimports.js'
+import { describe, expect, expectStatusFor, getSO, postSO, purgeSO, patchSO, uuidv4 } from '../../common/testimports.js'
 import { default as dialogToInsert } from './testdata/01-create-dialog.js';
 
 export default function () {
@@ -69,8 +69,8 @@ export default function () {
         expect(r.json(), 'dialog').to.have.nested.property("apiActions[0].endpoints[1].url").to.equal(newApiActionEndpointUrl);
     });
 
-    describe('Perform dialog delete', () => {
-        let r = deleteSO('dialogs/' + dialogId);
+    describe('Perform dialog purge', () => {
+        let r = purgeSO('dialogs/' + dialogId);
         expectStatusFor(r).to.equal(204);
     });
 }

--- a/tests/k6/tests/serviceowner/testdata/01-create-dialog.js
+++ b/tests/k6/tests/serviceowner/testdata/01-create-dialog.js
@@ -20,7 +20,8 @@ export default function () {
             { "type": "Title", "value": [ { "cultureCode": "nb_NO", "value": "Skjema for rapportering av et eller annet" } ] },
             { "type": "SenderName", "value": [ { "cultureCode": "nb_NO", "value": "Avsendernavn" } ] },
             { "type": "Summary", "value": [ { "cultureCode": "nb_NO", "value": "Et sammendrag her. Maks 200 tegn, ingen HTML-støtte. Påkrevd. Vises i liste." } ] },
-            { "type": "AdditionalInfo", "value": [ { "cultureCode": "nb_NO", "value": "Utvidet forklaring (enkel HTML-støtte, inntil 1023 tegn). Ikke påkrevd. Vises kun i detaljvisning." } ] }
+            { "type": "AdditionalInfo", "value": [ { "cultureCode": "nb_NO", "value": "Utvidet forklaring (enkel HTML-støtte, inntil 1023 tegn). Ikke påkrevd. Vises kun i detaljvisning." } ] },
+            { "type": "ExtendedStatus", "value": [ { "cultureCode": "nb_NO", "value": "Utvidet Status" } ] },
         ],
         "guiActions": [
             {


### PR DESCRIPTION
## Description

This adds e2e for "org"-filtering and add ExtendedStatus to the test data. This also fixes some clean up issues, making sure a test run purges all data it inserts.

## Related Issue(s)

N/A

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
