### PR TITLE
chore: Add EndUser SeenLog hash length tests

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Application/Common/IStringHasher.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Common/IStringHasher.cs
@@ -12,6 +12,7 @@ internal interface IStringHasher
 
 internal class PersistentRandomSaltStringHasher : IStringHasher
 {
+    public const int StringLength = 10;
     private const int SaltSize = 16;
     private readonly Lazy<byte[]> _lazySalt = new(() => RandomNumberGenerator.GetBytes(SaltSize));
 
@@ -29,6 +30,6 @@ internal class PersistentRandomSaltStringHasher : IStringHasher
 
         var hashBytes = SHA256.HashData(buffer);
 
-        return BitConverter.ToString(hashBytes, 0, 5).Replace("-", "").ToLowerInvariant();
+        return BitConverter.ToString(hashBytes, 0, StringLength / 2).Replace("-", "").ToLowerInvariant();
     }
 }

--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Common/DialogApplication.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Common/DialogApplication.cs
@@ -2,9 +2,11 @@
 using System.Text.Json;
 using Digdir.Domain.Dialogporten.Application.Common;
 using Digdir.Domain.Dialogporten.Application.Externals;
+using Digdir.Domain.Dialogporten.Application.Externals.AltinnAuthorization;
 using Digdir.Domain.Dialogporten.Application.Externals.Presentation;
 using Digdir.Domain.Dialogporten.Domain.Outboxes;
 using Digdir.Domain.Dialogporten.Infrastructure;
+using Digdir.Domain.Dialogporten.Infrastructure.Altinn.Authorization;
 using Digdir.Domain.Dialogporten.Infrastructure.Altinn.ResourceRegistry;
 using Digdir.Domain.Dialogporten.Infrastructure.DomainEvents.Outbox;
 using Digdir.Domain.Dialogporten.Infrastructure.Persistence;
@@ -17,6 +19,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using Npgsql;
+using NSec.Cryptography;
 using NSubstitute;
 using Respawn;
 using Respawn.Graph;
@@ -61,6 +64,7 @@ public class DialogApplication : IAsyncLifetime
             .AddScoped<INameRegistry>(_ => CreateNameRegistrySubstitute())
             .AddScoped<IOptions<ApplicationSettings>>(_ => CreateApplicationSettingsSubstitute())
             .AddScoped<IUnitOfWork, UnitOfWork>()
+            .AddScoped<IAltinnAuthorization, LocalDevelopmentAltinnAuthorization>()
             .AddSingleton<ICloudEventBus, IntegrationTestCloudBus>()
             .Decorate<IUserResourceRegistry, LocalDevelopmentUserResourceRegistryDecorator>()
             .Decorate<IUserNameRegistry, LocalDevelopmentUserNameRegistryDecorator>()
@@ -82,9 +86,21 @@ public class DialogApplication : IAsyncLifetime
         return nameRegistrySubstitute;
     }
 
+    private static string Base64UrlEncode(byte[] input) => Convert.ToBase64String(input).Replace("+", "-").Replace("/", "_").TrimEnd('=');
+
     private static IOptions<ApplicationSettings> CreateApplicationSettingsSubstitute()
     {
         var applicationSettingsSubstitute = Substitute.For<IOptions<ApplicationSettings>>();
+
+        using var primaryKeyPair = Key.Create(SignatureAlgorithm.Ed25519,
+            new KeyCreationParameters { ExportPolicy = KeyExportPolicies.AllowPlaintextExport });
+        var primaryPublicKey = primaryKeyPair.Export(KeyBlobFormat.RawPublicKey);
+        var primaryPrivateKey = primaryKeyPair.Export(KeyBlobFormat.RawPrivateKey);
+
+        using var secondaryKeyPair = Key.Create(SignatureAlgorithm.Ed25519,
+            new KeyCreationParameters { ExportPolicy = KeyExportPolicies.AllowPlaintextExport });
+        var secondaryPublicKey = secondaryKeyPair.Export(KeyBlobFormat.RawPublicKey);
+        var secondaryPrivateKey = secondaryKeyPair.Export(KeyBlobFormat.RawPrivateKey);
 
         applicationSettingsSubstitute
             .Value
@@ -97,15 +113,15 @@ public class DialogApplication : IAsyncLifetime
                     {
                         Primary = new Ed25519KeyPair
                         {
-                            Kid = "kid1",
-                            PrivateComponent = "private1",
-                            PublicComponent = "public1"
+                            Kid = "integration-test-primary-signing-key",
+                            PrivateComponent = Base64UrlEncode(primaryPrivateKey),
+                            PublicComponent = Base64UrlEncode(primaryPublicKey)
                         },
                         Secondary = new Ed25519KeyPair
                         {
-                            Kid = "kid2",
-                            PrivateComponent = "private2",
-                            PublicComponent = "public2"
+                            Kid = "integration-test-secondary-signing-key",
+                            PrivateComponent = Base64UrlEncode(secondaryPrivateKey),
+                            PublicComponent = Base64UrlEncode(secondaryPublicKey)
                         }
                     }
                 }

--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/Dialogs/Queries/GetDialogTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/Dialogs/Queries/GetDialogTests.cs
@@ -8,9 +8,7 @@ namespace Digdir.Domain.Dialogporten.Application.Integration.Tests.Features.V1.D
 [Collection(nameof(DialogCqrsCollectionFixture))]
 public class GetDialogTests : ApplicationCollectionFixture
 {
-    public GetDialogTests(DialogApplication application) : base(application)
-    {
-    }
+    public GetDialogTests(DialogApplication application) : base(application) { }
 
     [Fact]
     public async Task Get_ReturnsSimpleDialog_WhenDialogExists()

--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/Dialogs/Queries/SeenLogTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/Dialogs/Queries/SeenLogTests.cs
@@ -1,5 +1,8 @@
 using Digdir.Domain.Dialogporten.Application.Common;
 using Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.Dialogs.Queries.Get;
+using Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.Dialogs.Queries.Search;
+using Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.DialogSeenLogs.Queries.Get;
+using Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.DialogSeenLogs.Queries.Search;
 using Digdir.Domain.Dialogporten.Application.Integration.Tests.Common;
 using Digdir.Tool.Dialogporten.GenerateFakeData;
 using FluentAssertions;
@@ -22,9 +25,90 @@ public class SeenLogTests(DialogApplication application) : ApplicationCollection
         // Assert
         response.TryPickT0(out var result, out _).Should().BeTrue();
         result.Should().NotBeNull();
-        result
+
+        result.SeenSinceLastUpdate
+            .Single()
+            .EndUserIdHash
+            .Should()
+            .HaveLength(PersistentRandomSaltStringHasher.StringLength);
+    }
+
+    [Fact]
+    public async Task Search_Dialog_Should_Not_Return_User_Ids_Unhashed()
+    {
+        // Arrange
+        var createDialogCommand = DialogGenerator.GenerateSimpleFakeDialog();
+        var createCommandResponse = await Application.Send(createDialogCommand);
+
+        // Trigger SeenLog
+        await Application.Send(new GetDialogQuery { DialogId = createCommandResponse.AsT0.Value });
+
+        // Act
+        var response = await Application.Send(new SearchDialogQuery
+        {
+            ServiceResource = [createDialogCommand.ServiceResource]
+        });
+
+        // Assert
+        response.TryPickT0(out var result, out _).Should().BeTrue();
+        result.Should().NotBeNull();
+
+        result.Items
+            .Single()
             .SeenSinceLastUpdate
             .Single()
+            .EndUserIdHash
+            .Should()
+            .HaveLength(PersistentRandomSaltStringHasher.StringLength);
+    }
+
+    [Fact]
+    public async Task Get_SeenLog_Should_Not_Return_User_Ids_Unhashed()
+    {
+        // Arrange
+        var createDialogCommand = DialogGenerator.GenerateSimpleFakeDialog();
+        var createCommandResponse = await Application.Send(createDialogCommand);
+
+        var triggerSeenLogResponse = await Application.Send(new GetDialogQuery { DialogId = createCommandResponse.AsT0.Value });
+        var seenLogId = triggerSeenLogResponse.AsT0.SeenSinceLastUpdate.Single().Id;
+
+        // Act
+        var response = await Application.Send(new GetDialogSeenLogQuery
+        {
+            DialogId = createCommandResponse.AsT0.Value,
+            SeenLogId = seenLogId
+        });
+
+        // Assert
+        response.TryPickT0(out var result, out _).Should().BeTrue();
+        result.Should().NotBeNull();
+
+        result.EndUserIdHash
+            .Should()
+            .HaveLength(PersistentRandomSaltStringHasher.StringLength);
+    }
+
+    [Fact]
+    public async Task Search_SeenLog_Should_Not_Return_User_Ids_Unhashed()
+    {
+        // Arrange
+        var createDialogCommand = DialogGenerator.GenerateSimpleFakeDialog();
+        var createCommandResponse = await Application.Send(createDialogCommand);
+
+        // Trigger SeenLog
+        await Application.Send(new GetDialogQuery { DialogId = createCommandResponse.AsT0.Value });
+
+        // Act
+        var response = await Application.Send(new SearchDialogSeenLogQuery
+        {
+            DialogId = createCommandResponse.AsT0.Value,
+        });
+
+        // Assert
+        response.TryPickT0(out var result, out _).Should().BeTrue();
+        result.Should().NotBeNull();
+
+        result.Single()
             .EndUserIdHash
             .Should()
             .HaveLength(PersistentRandomSaltStringHasher.StringLength);

--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/Dialogs/Queries/SeenLogTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/Dialogs/Queries/SeenLogTests.cs
@@ -1,0 +1,32 @@
+using Digdir.Domain.Dialogporten.Application.Common;
+using Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.Dialogs.Queries.Get;
+using Digdir.Domain.Dialogporten.Application.Integration.Tests.Common;
+using Digdir.Tool.Dialogporten.GenerateFakeData;
+using FluentAssertions;
+
+namespace Digdir.Domain.Dialogporten.Application.Integration.Tests.Features.V1.Dialogs.Queries;
+
+[Collection(nameof(DialogCqrsCollectionFixture))]
+public class SeenLogTests(DialogApplication application) : ApplicationCollectionFixture(application)
+{
+    [Fact]
+    public async Task Get_Dialog_Should_Not_Return_User_Ids_Unhashed()
+    {
+        // Arrange
+        var createDialogCommand = DialogGenerator.GenerateSimpleFakeDialog();
+        var createCommandResponse = await Application.Send(createDialogCommand);
+
+        // Act
+        var response = await Application.Send(new GetDialogQuery { DialogId = createCommandResponse.AsT0.Value });
+
+        // Assert
+        response.TryPickT0(out var result, out _).Should().BeTrue();
+        result.Should().NotBeNull();
+        result
+            .SeenSinceLastUpdate
+            .Single()
+            .EndUserIdHash
+            .Should()
+            .HaveLength(PersistentRandomSaltStringHasher.StringLength);
+    }
+}


### PR DESCRIPTION
Adding tests for hash length on seen log, EndUser queries

## Description

Making sure we don't leak un-hashed user IDs

## Related Issue(s)

- #460 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
