### PR TITLE
fix: Accept app references with urn:altinn:resource prefix

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Create/CreateDialogCommandValidator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Create/CreateDialogCommandValidator.cs
@@ -26,9 +26,8 @@ internal sealed class CreateDialogCommandValidator : AbstractValidator<CreateDia
             .IsValidUri()
             .MaximumLength(Constants.DefaultMaxUriLength)
             .Must(x =>
-                (x?.StartsWith(Constants.ServiceResourcePrefixGeneric, StringComparison.InvariantCulture) ?? false)
-                || (x?.StartsWith(Constants.ServiceResourcePrefixApp, StringComparison.InvariantCulture) ?? false))
-                .WithMessage($"'{{PropertyName}}' must start with '{Constants.ServiceResourcePrefixGeneric}' or '{Constants.ServiceResourcePrefixApp}'.");
+                x?.StartsWith(Constants.ServiceResourcePrefix, StringComparison.InvariantCulture) ?? false)
+                .WithMessage($"'{{PropertyName}}' must start with '{Constants.ServiceResourcePrefix}'.");
 
         RuleFor(x => x.Party)
             .IsValidPartyIdentifier()

--- a/src/Digdir.Domain.Dialogporten.Domain/Common/Constants.cs
+++ b/src/Digdir.Domain.Dialogporten.Domain/Common/Constants.cs
@@ -6,6 +6,5 @@ public static class Constants
     public const int DefaultMaxStringLength = 255;
     public const int DefaultMaxUriLength = 1023;
 
-    public const string ServiceResourcePrefixGeneric = "urn:altinn:resource:";
-    public const string ServiceResourcePrefixApp = "urn:altinn:app:";
+    public const string ServiceResourcePrefix = "urn:altinn:resource:";
 }

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/Authorization/AuthorizedPartiesHelper.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/Authorization/AuthorizedPartiesHelper.cs
@@ -8,8 +8,6 @@ internal static class AuthorizedPartiesHelper
     private const string PartyTypeOrganization = "Organization";
     private const string PartyTypePerson = "Person";
     private const string AttributeIdResource = "urn:altinn:resource";
-    private const string AttributeIdApp = "urn:altinn:app";
-    private const string AppIdPrefix = "app_";
     private const string MainAdministratorRoleCode = "HADM";
     private const string AccessManagerRoleCode = "ADMAI";
     private static readonly string[] KeyRoleCodes = ["DAGL", "LEDE", "INNH", "DTPR", "DTSO", "BEST"];
@@ -57,8 +55,5 @@ internal static class AuthorizedPartiesHelper
     }
 
     private static List<string> GetPrefixedResources(List<string> dtoAuthorizedResources) =>
-        dtoAuthorizedResources.Select(resource => resource.StartsWith(AppIdPrefix, StringComparison.Ordinal)
-                ? AttributeIdApp + ":" + resource
-                : AttributeIdResource + ":" + resource)
-            .ToList();
+        dtoAuthorizedResources.Select(resource => $"{AttributeIdResource}:{resource}").ToList();
 }

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/ResourceRegistry/ResourceRegistryClient.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/ResourceRegistry/ResourceRegistryClient.cs
@@ -44,9 +44,7 @@ internal sealed class ResourceRegistryClient : IResourceRegistry
             .ToDictionary(
                 x => x.Key,
                 x => x.Select(
-                    x => x.ResourceType == ResourceTypeAltinnApp
-                        ? $"{Constants.ServiceResourcePrefixApp}{x.Identifier}"
-                        : $"{Constants.ServiceResourcePrefixGeneric}{x.Identifier}")
+                    x => $"{Constants.ServiceResourcePrefix}{x.Identifier}")
                     .ToArray()
             );
 


### PR DESCRIPTION
## Description

This fixes the handling of service resource values referring to Altinn apps so that they too use the same prefix as generic resources. The decision request helper now only checks for the reserved resource name prefix (`app_`) in order to determine how the XACML request should be constructed.

## Related Issue(s)

- #681

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
