### PR TITLE
chore: disable renovate for bicep files

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,13 @@
   "extends": [
     "config:base"
   ],
-  "schedule": ["before 7am on Sunday", "before 7am on Wednesday"],
+  "schedule": [
+    "before 7am on Sunday",
+    "before 7am on Wednesday"
+  ],
   "updateNotScheduled": false,
-  "minimumReleaseAge": "7 days"
+  "minimumReleaseAge": "7 days",
+  "ignorePaths": [
+    ".azure/**/*"
+  ]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Renovate keeps trying to update dependencies in bicep files. Three different things seem to fail dependent on what is upgraded:
- The API version is not available in the region, which is the case for https://github.com/digdir/dialogporten/pull/706
- Types not available which is the case here https://github.com/digdir/dialogporten/actions/runs/9020616557/job/24786200707?pr=703
- Works, but not published in docs which is the case here: https://github.com/digdir/dialogporten/actions/runs/9048868949/job/24862382412?pr=720


## Related Issue(s)

- #{issue number}

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
