### PR TITLE
fix(graphql): Add missing enum value ExtendedStatus in schema

### DIFF
--- a/docs/schema/V1/package.json
+++ b/docs/schema/V1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digdir/dialogporten-schema",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "GraphQl schema and OpenAPI spec for Dialogporten",
   "author": "DigDir",
   "repository": {

--- a/docs/schema/V1/schema.verified.graphql
+++ b/docs/schema/V1/schema.verified.graphql
@@ -241,6 +241,7 @@ enum ContentType {
   SENDER_NAME
   SUMMARY
   ADDITIONAL_INFO
+  EXTENDED_STATUS
 }
 
 enum DialogStatus {

--- a/src/Digdir.Domain.Dialogporten.Domain/Dialogs/Entities/DialogEntity.cs
+++ b/src/Digdir.Domain.Dialogporten.Domain/Dialogs/Entities/DialogEntity.cs
@@ -42,6 +42,7 @@ public class DialogEntity :
     // === Principal relationships ===
     [AggregateChild]
     public List<DialogContent> Content { get; set; } = [];
+
     [AggregateChild]
     public List<DialogSearchTag> SearchTags { get; set; } = [];
 

--- a/src/Digdir.Domain.Dialogporten.GraphQL/EndUser/Common/ObjectTypes.cs
+++ b/src/Digdir.Domain.Dialogporten.GraphQL/EndUser/Common/ObjectTypes.cs
@@ -11,7 +11,8 @@ public enum ContentType
     Title = 1,
     SenderName = 2,
     Summary = 3,
-    AdditionalInfo = 4
+    AdditionalInfo = 4,
+    ExtendedStatus = 5
 }
 
 public sealed class Content


### PR DESCRIPTION
## Description

ExtendedStatus enum value missing for dialog content

## Related Issue(s)

- #732 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
