### PR TITLE
fix(graphql): Make OrderBy nullable

### DIFF
--- a/docs/schema/V1/package.json
+++ b/docs/schema/V1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digdir/dialogporten-schema",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "GraphQl schema and OpenAPI spec for Dialogporten",
   "author": "DigDir",
   "repository": {

--- a/docs/schema/V1/schema.verified.graphql
+++ b/docs/schema/V1/schema.verified.graphql
@@ -172,7 +172,7 @@ type SearchDialogsPayload {
   items: [SearchDialog!]
   hasNextPage: Boolean!
   continuationToken: String
-  orderBy: String!
+  orderBy: String
   errors: [SearchDialogError!]!
 }
 

--- a/src/Digdir.Domain.Dialogporten.GraphQL/EndUser/SearchDialogs/ObjectTypes.cs
+++ b/src/Digdir.Domain.Dialogporten.GraphQL/EndUser/SearchDialogs/ObjectTypes.cs
@@ -21,9 +21,9 @@ public sealed class SearchDialogValidationError : ISearchDialogError
 public sealed class SearchDialogsPayload
 {
     public List<SearchDialog>? Items { get; set; }
-    public bool HasNextPage { get; }
-    public string? ContinuationToken { get; }
-    public string? OrderBy { get; }
+    public bool HasNextPage { get; set; }
+    public string? ContinuationToken { get; set; }
+    public string? OrderBy { get; set; }
     public List<ISearchDialogError> Errors { get; set; } = [];
 }
 

--- a/src/Digdir.Domain.Dialogporten.GraphQL/EndUser/SearchDialogs/ObjectTypes.cs
+++ b/src/Digdir.Domain.Dialogporten.GraphQL/EndUser/SearchDialogs/ObjectTypes.cs
@@ -23,7 +23,7 @@ public sealed class SearchDialogsPayload
     public List<SearchDialog>? Items { get; set; }
     public bool HasNextPage { get; }
     public string? ContinuationToken { get; }
-    public string OrderBy { get; } = null!;
+    public string? OrderBy { get; }
     public List<ISearchDialogError> Errors { get; set; } = [];
 }
 


### PR DESCRIPTION
## Description
If a GQL search hits a ValidationError, and the query contains OrderBy, the query fails with internal server error
(Attempting to return `null` on non-nullable value)


## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)