### PR TITLE
chore(azure): set static IP for private link in subnet

### DIFF
--- a/.azure/modules/serviceBus/main.bicep
+++ b/.azure/modules/serviceBus/main.bicep
@@ -75,7 +75,7 @@ module privateDnsZone '../privateDnsZone/main.bicep' = {
       {
         name: 'default'
         ttl: 300
-        ip: privateEndpoint.properties.networkInterfaces[0].properties.ipConfigurations[0].properties.privateIPAddress
+        ip: privateEndpoint.properties.ipConfigurations[0].properties.privateIPAddress
       }
     ]
   }

--- a/.azure/modules/serviceBus/main.bicep
+++ b/.azure/modules/serviceBus/main.bicep
@@ -44,7 +44,7 @@ resource privateEndpoint 'Microsoft.Network/privateEndpoints@2021-05-01' = {
           groupId: 'namespace'
           memberName: 'namespace'
           // must be in the range of the subnet
-          privateIPAddress: '10.0.4.10'
+          privateIPAddress: '10.0.4.4'
         }
       }
     ]

--- a/.azure/modules/serviceBus/main.bicep
+++ b/.azure/modules/serviceBus/main.bicep
@@ -37,6 +37,17 @@ resource privateEndpoint 'Microsoft.Network/privateEndpoints@2021-05-01' = {
     subnet: {
       id: subnetId
     }
+    ipConfigurations: [
+      {
+        name: 'default'
+        properties: {
+          groupId: 'namespace'
+          memberName: 'namespace'
+          // must be in the range of the subnet
+          privateIPAddress: '10.0.4.10'
+        }
+      }
+    ]
     privateLinkServiceConnections: [
       {
         name: '${namePrefix}-plsc'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

When creating a private DNS zone, Azure creates a dynamic IP. However, we need to know this IP upfront in order to set the proper A-record

## Related Issue(s)

- #686 

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
