### PR TITLE
chore(azure): fix property conflict for redis

### DIFF
--- a/.azure/infrastructure/main.bicep
+++ b/.azure/infrastructure/main.bicep
@@ -155,6 +155,7 @@ module redis '../modules/redis/main.bicep' = {
     sku: redisSku
     version: redisVersion
     subnetId: vnet.outputs.redisSubnetId
+    vnetId: vnet.outputs.virtualNetworkId
   }
 }
 

--- a/.azure/modules/privateDnsZoneGroup/main.bicep
+++ b/.azure/modules/privateDnsZoneGroup/main.bicep
@@ -1,10 +1,6 @@
-param dnsZoneName string
+param dnsZoneId string
 param privateEndpointName string
 param namePrefix string
-
-resource privateDNSZone 'Microsoft.Network/privateDnsZones@2020-06-01' existing = {
-  name: dnsZoneName
-}
 
 resource privateEndpoint 'Microsoft.Network/privateEndpoints@2023-04-01' existing = {
   name: privateEndpointName
@@ -18,7 +14,7 @@ resource pe_dns_zone_group 'Microsoft.Network/privateEndpoints/privateDnsZoneGro
       {
         name: '${namePrefix}-pe-dzg'
         properties: {
-          privateDnsZoneId: privateDNSZone.id
+          privateDnsZoneId: dnsZoneId
         }
       }
     ]

--- a/.azure/modules/redis/main.bicep
+++ b/.azure/modules/redis/main.bicep
@@ -1,6 +1,7 @@
 param namePrefix string
 param location string
 param subnetId string
+param vnetId string
 @minLength(1)
 param environmentKeyVaultName string
 @minLength(1)
@@ -30,8 +31,7 @@ resource redis 'Microsoft.Cache/Redis@2023-08-01' = {
       'maxmemory-policy': 'allkeys-lru'
     }
     redisVersion: version
-    // todo: disable public access once we know the private link is working
-    publicNetworkAccess: 'Enabled'
+    publicNetworkAccess: 'Disabled'
   }
 }
 
@@ -56,12 +56,24 @@ resource redisPrivateEndpoint 'Microsoft.Network/privateEndpoints@2022-01-01' = 
   }
 }
 
+module privateDnsZone '../privateDnsZone/main.bicep' = {
+  name: '${namePrefix}-redis-pdz'
+  params: {
+    namePrefix: namePrefix
+    defaultDomain: 'privatelink.redis.cache.windows.net'
+    vnetId: vnetId
+  }
+}
+
 module privateDnsZoneGroup '../privateDnsZoneGroup/main.bicep' = {
   name: '${namePrefix}-redis-privateDnsZoneGroup'
+  dependsOn: [
+    privateDnsZone
+  ]
   params: {
     // the private DNS Zone is created automatically by Azure, so we just want to reference it
     // https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-private-link#how-do-i-connect-to-my-cache-with-private-endpoint
-    dnsZoneName: 'privatelink.redis.cache.windows.net'
+    dnsZoneId: privateDnsZone.outputs.id
     privateEndpointName: redisPrivateEndpoint.name
     namePrefix: namePrefix
   }

--- a/.azure/modules/redis/main.bicep
+++ b/.azure/modules/redis/main.bicep
@@ -71,8 +71,6 @@ module privateDnsZoneGroup '../privateDnsZoneGroup/main.bicep' = {
     privateDnsZone
   ]
   params: {
-    // the private DNS Zone is created automatically by Azure, so we just want to reference it
-    // https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-private-link#how-do-i-connect-to-my-cache-with-private-endpoint
     dnsZoneId: privateDnsZone.outputs.id
     privateEndpointName: redisPrivateEndpoint.name
     namePrefix: namePrefix
@@ -86,7 +84,6 @@ module redisConnectionString '../keyvault/upsertSecret.bicep' = {
   params: {
     destKeyVaultName: environmentKeyVaultName
     secretName: 'dialogportenRedisConnectionString'
-    // disable public access? Use vnet here maybe?
     secretValue: '${redis.properties.hostName}:${redis.properties.sslPort},password=${redis.properties.accessKeys.primaryKey},ssl=True,abortConnect=False'
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

The default property seems to be publicNetworkAccess: 'Disabled', not possible to both configure private link and disable public network access at the same time it seems. Encountered this issue: https://github.com/Azure/azure-cli/issues/20997

Also, seems like we need to actually create the private DNS Zone manually, although the documentation states otherwise. Other sources say that if we use Bicep for this, we need to create it manually :)

Ran the Bicep manually from local machine, seems to update just fine. 

## Related Issue(s)

- #{issue number}

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
