### PR TITLE
fix: remove maskinporten aux from config

### DIFF
--- a/src/Digdir.Domain.Dialogporten.GraphQL/appsettings.Development.json
+++ b/src/Digdir.Domain.Dialogporten.GraphQL/appsettings.Development.json
@@ -49,10 +49,6 @@
           "WellKnown": "https://test.maskinporten.no/.well-known/oauth-authorization-server/"
         },
         {
-          "Name": "MaskinportenAuxiliary",
-          "WellKnown": "https://ver2.maskinporten.no/.well-known/oauth-authorization-server/"
-        },
-        {
           "Name": "Altinn",
           "WellKnown": "https://platform.tt02.altinn.no/authentication/api/v1/openid/.well-known/openid-configuration"
         },

--- a/src/Digdir.Domain.Dialogporten.GraphQL/appsettings.staging.json
+++ b/src/Digdir.Domain.Dialogporten.GraphQL/appsettings.staging.json
@@ -56,10 +56,6 @@
           "WellKnown": "https://test.maskinporten.no/.well-known/oauth-authorization-server/"
         },
         {
-          "Name": "MaskinportenAuxiliary",
-          "WellKnown": "https://ver2.maskinporten.no/.well-known/oauth-authorization-server/"
-        },
-        {
           "Name": "Altinn",
           "WellKnown": "https://platform.tt02.altinn.no/authentication/api/v1/openid/.well-known/openid-configuration"
         },

--- a/src/Digdir.Domain.Dialogporten.GraphQL/appsettings.test.json
+++ b/src/Digdir.Domain.Dialogporten.GraphQL/appsettings.test.json
@@ -56,10 +56,6 @@
           "WellKnown": "https://test.maskinporten.no/.well-known/oauth-authorization-server/"
         },
         {
-          "Name": "MaskinportenAuxiliary",
-          "WellKnown": "https://ver2.maskinporten.no/.well-known/oauth-authorization-server/"
-        },
-        {
           "Name": "Altinn",
           "WellKnown": "https://platform.tt02.altinn.no/authentication/api/v1/openid/.well-known/openid-configuration"
         },

--- a/src/Digdir.Domain.Dialogporten.WebApi/appsettings.Development.json
+++ b/src/Digdir.Domain.Dialogporten.WebApi/appsettings.Development.json
@@ -62,10 +62,6 @@
           "WellKnown": "https://test.maskinporten.no/.well-known/oauth-authorization-server/"
         },
         {
-          "Name": "MaskinportenAuxiliary",
-          "WellKnown": "https://ver2.maskinporten.no/.well-known/oauth-authorization-server/"
-        },
-        {
           "Name": "Altinn",
           "WellKnown": "https://platform.tt02.altinn.no/authentication/api/v1/openid/.well-known/openid-configuration"
         },

--- a/src/Digdir.Domain.Dialogporten.WebApi/appsettings.staging.json
+++ b/src/Digdir.Domain.Dialogporten.WebApi/appsettings.staging.json
@@ -59,10 +59,6 @@
           "WellKnown": "https://test.maskinporten.no/.well-known/oauth-authorization-server/"
         },
         {
-          "Name": "MaskinportenAuxiliary",
-          "WellKnown": "https://ver2.maskinporten.no/.well-known/oauth-authorization-server/"
-        },
-        {
           "Name": "Altinn",
           "WellKnown": "https://platform.tt02.altinn.no/authentication/api/v1/openid/.well-known/openid-configuration"
         },

--- a/src/Digdir.Domain.Dialogporten.WebApi/appsettings.test.json
+++ b/src/Digdir.Domain.Dialogporten.WebApi/appsettings.test.json
@@ -59,10 +59,6 @@
           "WellKnown": "https://test.maskinporten.no/.well-known/oauth-authorization-server/"
         },
         {
-          "Name": "MaskinportenAuxiliary",
-          "WellKnown": "https://ver2.maskinporten.no/.well-known/oauth-authorization-server/"
-        },
-        {
           "Name": "Altinn",
           "WellKnown": "https://platform.tt02.altinn.no/authentication/api/v1/openid/.well-known/openid-configuration"
         },


### PR DESCRIPTION
## Description

Removed references to https://[ver2.maskinporten.no/.well-known/oauth-authorization-server/](https://ver2.maskinporten.no/.well-known/oauth-authorization-server/), as it seems to cause issues.

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
