### PR TITLE
chore: Set HTTP verb default to GET in migration

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Migrations/20240610130651_AddPromptAndHttpMethodToGuiAction.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Migrations/20240610130651_AddPromptAndHttpMethodToGuiAction.cs
@@ -22,7 +22,7 @@ namespace Digdir.Domain.Dialogporten.Infrastructure.Persistence.Migrations
                 table: "DialogGuiAction",
                 type: "integer",
                 nullable: false,
-                defaultValue: 0);
+                defaultValue: 1);
 
             migrationBuilder.CreateIndex(
                 name: "IX_LocalizationSet_DialogGuiActionPrompt_GuiActionId",


### PR DESCRIPTION
The migration fails when attempting to set HTTP verb defaults on the new GUI action property.
Default was set to 0, which violates ID restriction on the HTTP verb table. Default should be GET, same as in the create dialog command.