### PR TITLE
fix(auth): Malformed JWTs no longer results in InternalServerError 

### DIFF
--- a/src/Digdir.Domain.Dialogporten.WebApi/Common/Authentication/JwtSchemeSelectorMiddleware.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Common/Authentication/JwtSchemeSelectorMiddleware.cs
@@ -1,4 +1,6 @@
 ﻿using System.IdentityModel.Tokens.Jwt;
+using FastEndpoints;
+using FluentValidation.Results;
 
 namespace Digdir.Domain.Dialogporten.WebApi.Common.Authentication;
 
@@ -33,9 +35,16 @@ public class JwtSchemeSelectorMiddleware
             return _next(context);
         }
 
-        var jwtToken = handler.ReadJwtToken(token);
-        context.Items[Constants.CurrentTokenIssuer] = jwtToken.Issuer;
-        return _next(context);
+        try
+        {
+            var jwtToken = handler.ReadJwtToken(token);
+            context.Items[Constants.CurrentTokenIssuer] = jwtToken.Issuer;
+            return _next(context);
+        }
+        catch (Exception)
+        {
+            return context.Response.SendErrorsAsync([new ValidationFailure("BearerToken", "Malformed token")]);
+        }
     }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Some malformed tokens results in 500 errors in `JwtSchemeSelectorMiddleware`

## Related Issue(s)

- #868 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
