### PR TITLE
chore(ci/cd): Fail pipeline if there's k6-test errors

### DIFF
--- a/.github/workflows/action-run-k6-tests.yml
+++ b/.github/workflows/action-run-k6-tests.yml
@@ -50,5 +50,6 @@ jobs:
       uses: EnricoMi/publish-unit-test-result-action@v2
       if: always()
       with:
+        action_fail: true
         files: |
           junit.xml


### PR DESCRIPTION
## Description

This should case the pipeline to fail if there's errors in the tests, as per https://github.com/EnricoMi/publish-unit-test-result-action

## Related Issue(s)

- #876
