### PR TITLE
chore: Fix migration for DialogElements renaming to Attachments

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Migrations/20240620170240_ChangeDialogElementToDialogAttachment.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Migrations/20240620170240_ChangeDialogElementToDialogAttachment.cs
@@ -42,6 +42,10 @@ namespace Digdir.Domain.Dialogporten.Infrastructure.Persistence.Migrations
                 name: "IX_DialogActivity_DialogElementId",
                 table: "DialogActivity");
 
+            migrationBuilder.DropIndex(
+                name: "IX_LocalizationSet_ElementId",
+                table: "LocalizationSet");
+
             migrationBuilder.DropColumn(
                 name: "DialogElementId",
                 table: "DialogApiAction");
@@ -50,15 +54,21 @@ namespace Digdir.Domain.Dialogporten.Infrastructure.Persistence.Migrations
                 name: "DialogElementId",
                 table: "DialogActivity");
 
-            migrationBuilder.RenameColumn(
+            migrationBuilder.DropColumn(
                 name: "ElementId",
-                table: "LocalizationSet",
-                newName: "AttachmentId");
+                table: "LocalizationSet");
 
-            migrationBuilder.RenameIndex(
-                name: "IX_LocalizationSet_ElementId",
+            migrationBuilder.AddColumn<Guid>(
+                name: "AttachmentId",
                 table: "LocalizationSet",
-                newName: "IX_LocalizationSet_AttachmentId");
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LocalizationSet_AttachmentId",
+                table: "LocalizationSet",
+                column: "AttachmentId",
+                unique: true);
 
             migrationBuilder.CreateTable(
                 name: "DialogAttachment",


### PR DESCRIPTION
Did not properly check that the migration worked *with data in the database* 🤦🏼 
Instead of 
```csharp
            migrationBuilder.RenameColumn(
                name: "ElementId",
                table: "LocalizationSet",
                newName: "AttachmentId");

            migrationBuilder.RenameIndex(
                name: "IX_LocalizationSet_ElementId",
                table: "LocalizationSet",
                newName: "IX_LocalizationSet_AttachmentId");
```

we need to drop the column, or else we get an FK error on the old ElementIds against the new attachment table.

```csharp
            migrationBuilder.DropIndex(
                name: "IX_LocalizationSet_ElementId",
                table: "LocalizationSet");

            migrationBuilder.DropColumn(
                name: "ElementId",
                table: "LocalizationSet");

            migrationBuilder.AddColumn<Guid>(
                name: "AttachmentId",
                table: "LocalizationSet",
                type: "uuid",
                nullable: true);

            migrationBuilder.CreateIndex(
                name: "IX_LocalizationSet_AttachmentId",
                table: "LocalizationSet",
                column: "AttachmentId",
                unique: true);
```