### PR TITLE
chore: Include error details in local user secret connection string

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ If you need do debug the WebApi/GraphQl projects in an IDE, you can alternativel
 First create a dotnet user secret for the DB connection string.
 
 ```powershell
-dotnet user-secrets set -p .\src\Digdir.Domain.Dialogporten.WebApi\ "Infrastructure:DialogDbConnectionString" "Server=localhost;Port=5432;Database=Dialogporten;User ID=postgres;Password=supersecret;"
+dotnet user-secrets set -p .\src\Digdir.Domain.Dialogporten.WebApi\ "Infrastructure:DialogDbConnectionString" "Server=localhost;Port=5432;Database=Dialogporten;User ID=postgres;Password=supersecret;Include Error Detail=True;"
 ```
 
 Then run `podman compose` without the WebAPI/GraphQl projects.


### PR DESCRIPTION
This gives proper error details when postgresql explodes locally. 

Change your local version manually, if needed
`~/.microsoft/usersecrets/750256a4-f332-4783-8802-8a7d9566f9ca/secrets.json` 
Add `Include Error Detail=True;` to `Infrastructure:DialogDbConnectionString`