### PR TITLE
chore: Add default media type for plain text content types

### DIFF
--- a/docs/schema/V1/swagger.verified.json
+++ b/docs/schema/V1/swagger.verified.json
@@ -230,7 +230,7 @@
                         "LanguageCode": "en"
                       }
                     ],
-                    "MediaType": null
+                    "MediaType": "text/plain"
                   },
                   {
                     "Type": 3,
@@ -240,7 +240,7 @@
                         "LanguageCode": "en"
                       }
                     ],
-                    "MediaType": null
+                    "MediaType": "text/plain"
                   }
                 ],
                 "SearchTags": [

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Create/CreateDialogCommandValidator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Create/CreateDialogCommandValidator.cs
@@ -123,12 +123,11 @@ internal sealed class CreateDialogContentDtoValidator : AbstractValidator<Create
             .Must((dto, value) =>
             {
                 var type = DialogContentType.GetValue(dto.Type);
-                return value is null ? type.AllowedMediaTypes.Length == 0 : type.AllowedMediaTypes.Contains(value);
+                return value is not null && type.AllowedMediaTypes.Contains(value);
             })
             .WithMessage(x =>
                 $"{{PropertyName}} '{x.MediaType ?? "null"}' is not allowed for content type {DialogContentType.GetValue(x.Type).Name}. " +
-                $"Valid media types are: {(DialogContentType.GetValue(x.Type).AllowedMediaTypes.Length == 0 ? "None" :
-                    $"{string.Join(", ", DialogContentType.GetValue(x.Type).AllowedMediaTypes!)}")}");
+                $"Allowed media types are {string.Join(", ", DialogContentType.GetValue(x.Type).AllowedMediaTypes.Select(x => $"'{x}'"))}");
         RuleForEach(x => x.Value)
             .ContainsValidHtml()
             .When(x => x.MediaType is not null && (x.MediaType == MediaTypes.Html));

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Create/CreateDialogDto.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Create/CreateDialogDto.cs
@@ -1,4 +1,5 @@
 ﻿using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Localizations;
+using Digdir.Domain.Dialogporten.Domain;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Actions;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Activities;
@@ -35,7 +36,7 @@ public sealed class CreateDialogContentDto
 {
     public DialogContentType.Values Type { get; set; }
     public List<LocalizationDto> Value { get; set; } = [];
-    public string? MediaType { get; set; }
+    public string? MediaType { get; set; } = MediaTypes.PlainText;
 }
 
 public sealed class CreateDialogSearchTagDto

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/UpdateDialogCommandValidator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/UpdateDialogCommandValidator.cs
@@ -118,12 +118,11 @@ internal sealed class UpdateDialogContentDtoValidator : AbstractValidator<Update
             .Must((dto, value) =>
             {
                 var type = DialogContentType.GetValue(dto.Type);
-                return value is null ? type.AllowedMediaTypes.Length == 0 : type.AllowedMediaTypes.Contains(value);
+                return value is not null && type.AllowedMediaTypes.Contains(value);
             })
             .WithMessage(x =>
                 $"{{PropertyName}} '{x.MediaType ?? "null"}' is not allowed for content type {DialogContentType.GetValue(x.Type).Name}. " +
-                $"Valid media types are: {(DialogContentType.GetValue(x.Type).AllowedMediaTypes.Length == 0 ? "None" :
-                    $"{string.Join(", ", DialogContentType.GetValue(x.Type).AllowedMediaTypes!)}")}");
+                $"Allowed media types are {string.Join(", ", DialogContentType.GetValue(x.Type).AllowedMediaTypes.Select(x => $"'{x}'"))}");
         RuleForEach(x => x.Value)
             .ContainsValidHtml()
             .When(x => x.MediaType is not null && (x.MediaType == MediaTypes.Html));

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/UpdateDialogDto.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/UpdateDialogDto.cs
@@ -1,4 +1,5 @@
 ﻿using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Localizations;
+using Digdir.Domain.Dialogporten.Domain;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Actions;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Activities;
@@ -33,7 +34,7 @@ public sealed class UpdateDialogContentDto
 {
     public DialogContentType.Values Type { get; set; }
     public List<LocalizationDto> Value { get; set; } = [];
-    public string? MediaType { get; set; }
+    public string? MediaType { get; set; } = MediaTypes.PlainText;
 }
 
 public sealed class UpdateDialogSearchTagDto

--- a/src/Digdir.Domain.Dialogporten.Domain/Dialogs/Entities/Content/DialogContentType.cs
+++ b/src/Digdir.Domain.Dialogporten.Domain/Dialogs/Entities/Content/DialogContentType.cs
@@ -29,21 +29,21 @@ public class DialogContentType : AbstractLookupEntity<DialogContentType, DialogC
             Required = true,
             MaxLength = Constants.DefaultMaxStringLength,
             OutputInList = true,
-            AllowedMediaTypes = []
+            AllowedMediaTypes = [MediaTypes.PlainText]
         },
         Values.SenderName => new(id)
         {
             Required = false,
             MaxLength = Constants.DefaultMaxStringLength,
             OutputInList = true,
-            AllowedMediaTypes = []
+            AllowedMediaTypes = [MediaTypes.PlainText]
         },
         Values.Summary => new(id)
         {
             Required = true,
             MaxLength = Constants.DefaultMaxStringLength,
             OutputInList = true,
-            AllowedMediaTypes = []
+            AllowedMediaTypes = [MediaTypes.PlainText]
         },
         Values.AdditionalInfo => new(id)
         {
@@ -57,7 +57,7 @@ public class DialogContentType : AbstractLookupEntity<DialogContentType, DialogC
             Required = false,
             MaxLength = 20,
             OutputInList = true,
-            AllowedMediaTypes = []
+            AllowedMediaTypes = [MediaTypes.PlainText]
         },
         Values.MainContentReference => new(id)
         {

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Migrations/20240703094112_AddDefaultMediaTypeForPlainTextContent.Designer.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Migrations/20240703094112_AddDefaultMediaTypeForPlainTextContent.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Digdir.Domain.Dialogporten.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Digdir.Domain.Dialogporten.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(DialogDbContext))]
-    partial class DialogDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240703094112_AddDefaultMediaTypeForPlainTextContent")]
+    partial class AddDefaultMediaTypeForPlainTextContent
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Migrations/20240703094112_AddDefaultMediaTypeForPlainTextContent.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Migrations/20240703094112_AddDefaultMediaTypeForPlainTextContent.cs
@@ -1,0 +1,74 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Digdir.Domain.Dialogporten.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDefaultMediaTypeForPlainTextContent : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.UpdateData(
+                table: "DialogContentType",
+                keyColumn: "Id",
+                keyValue: 1,
+                column: "AllowedMediaTypes",
+                value: new[] { "text/plain" });
+
+            migrationBuilder.UpdateData(
+                table: "DialogContentType",
+                keyColumn: "Id",
+                keyValue: 2,
+                column: "AllowedMediaTypes",
+                value: new[] { "text/plain" });
+
+            migrationBuilder.UpdateData(
+                table: "DialogContentType",
+                keyColumn: "Id",
+                keyValue: 3,
+                column: "AllowedMediaTypes",
+                value: new[] { "text/plain" });
+
+            migrationBuilder.UpdateData(
+                table: "DialogContentType",
+                keyColumn: "Id",
+                keyValue: 5,
+                column: "AllowedMediaTypes",
+                value: new[] { "text/plain" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.UpdateData(
+                table: "DialogContentType",
+                keyColumn: "Id",
+                keyValue: 1,
+                column: "AllowedMediaTypes",
+                value: new string[0]);
+
+            migrationBuilder.UpdateData(
+                table: "DialogContentType",
+                keyColumn: "Id",
+                keyValue: 2,
+                column: "AllowedMediaTypes",
+                value: new string[0]);
+
+            migrationBuilder.UpdateData(
+                table: "DialogContentType",
+                keyColumn: "Id",
+                keyValue: 3,
+                column: "AllowedMediaTypes",
+                value: new string[0]);
+
+            migrationBuilder.UpdateData(
+                table: "DialogContentType",
+                keyColumn: "Id",
+                keyValue: 5,
+                column: "AllowedMediaTypes",
+                value: new string[0]);
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

To be more explicit with media typing, we add 'text/plain' to the content types `Title`, `SenderName`, `Summary`, and `ExtendedStatus`.
This also simplifies error messaging in the create and update validators


## Related Issue(s)

- #889 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
