### PR TITLE
chore: Fix validation error message for EndUserId on search

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/Search/SearchDialogQueryValidator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/Search/SearchDialogQueryValidator.cs
@@ -26,11 +26,13 @@ internal sealed class SearchDialogQueryValidator : AbstractValidator<SearchDialo
                     : LocalizationValidatorContants.InvalidCultureCodeErrorMessage) +
                 LocalizationValidatorContants.NormalizationErrorMessage);
 
-        RuleFor(x => x)
-            .Must(x => PartyIdentifier.TryParse(x.EndUserId, out var id) && id is NorwegianPersonIdentifier or SystemUserIdentifier)
-            .WithMessage($"'{nameof(SearchDialogQuery.EndUserId)}' must be a valid end user identifier. It should match the format '{NorwegianPersonIdentifier.Prefix}{{norwegian f-nr/d-nr}}' or '{SystemUserIdentifier.Prefix}{{uuid}}'.")
-            .Must(x => !x.ServiceResource.IsNullOrEmpty() || !x.Party.IsNullOrEmpty())
-            .WithMessage($"Either '{nameof(SearchDialogQuery.ServiceResource)}' or '{nameof(SearchDialogQuery.Party)}' must be specified if '{nameof(SearchDialogQuery.EndUserId)}' is provided.")
+        RuleFor(x => x.EndUserId)
+            .Must(x => PartyIdentifier.TryParse(x, out var id) && id is NorwegianPersonIdentifier or SystemUserIdentifier)
+            .WithMessage($"{{PropertyName}} must be a valid end user identifier. It must match the format " +
+                         $"'{NorwegianPersonIdentifier.PrefixWithSeparator}{{norwegian f-nr/d-nr}}' or '{SystemUserIdentifier.PrefixWithSeparator}{{uuid}}'.")
+            .Must((x, _) => !x.ServiceResource.IsNullOrEmpty() || !x.Party.IsNullOrEmpty())
+            .WithMessage($"Either '{nameof(SearchDialogQuery.ServiceResource)}' or '{nameof(SearchDialogQuery.Party)}' " +
+                         $"must be specified if '{nameof(SearchDialogQuery.EndUserId)}' is provided.")
             .When(x => x.EndUserId is not null);
 
         RuleForEach(x => x.Party)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
* Adds missing property name to problem details
* Adds missing separator in urn


```json
    "errors": {
        "": [
            "'EndUserId' must be a valid end user identifier. It should match the format 'urn:altinn:person:identifier-no{norwegian f-nr/d-nr}' or 'urn:altinn:systemuser{uuid}'."
        ],
```

```json
    "errors": {
        "EndUserId": [
            "End User Id must be a valid end user identifier. It must match the format 'urn:altinn:person:identifier-no:{norwegian f-nr/d-nr}' or 'urn:altinn:systemuser:{uuid}'."
        ],
```
