### PR TITLE
chore(azure): add unique resource names

### DIFF
--- a/.azure/bicepconfig.json
+++ b/.azure/bicepconfig.json
@@ -27,8 +27,6 @@
   },
   "experimentalFeaturesEnabled": {
     "compileTimeImports": true,
-    "userDefinedFunctions": false,
-    "extensibility": true,
-    "ProviderRegistry": true
+    "userDefinedFunctions": true
   }
 }

--- a/.azure/bicepconfig.json
+++ b/.azure/bicepconfig.json
@@ -27,6 +27,8 @@
   },
   "experimentalFeaturesEnabled": {
     "compileTimeImports": true,
-    "userDefinedFunctions": false
+    "userDefinedFunctions": false,
+    "extensibility": true,
+    "ProviderRegistry": true
   }
 }

--- a/.azure/functions/resourceName.bicep
+++ b/.azure/functions/resourceName.bicep
@@ -3,7 +3,7 @@
 func uniqueStringBySubscriptionAndResourceGroup() string => uniqueString('${subscription().id}${resourceGroup().id}')
 
 // This function generates a unique resource name by appending a unique string to the given name, ensuring the total length does not exceed the specified limit.
-// The function ensures that the name is always postfixed with the full length of the unique string, which is 13 characters plus a dash.
+// It also ensures that the name is always postfixed with the full length of the unique string, which is 13 characters plus a dash.
 // Example:
 // uniqueResourceName(name: 'my-resource', limit: 50) => 'my-resource-1234567890123'
 // Example:

--- a/.azure/functions/resourceName.bicep
+++ b/.azure/functions/resourceName.bicep
@@ -1,0 +1,13 @@
+// This function generates a unique string based on the subscription ID and resource group ID
+@export()
+func uniqueStringBySubscriptionAndResourceGroup() string => uniqueString('${subscription().id}${resourceGroup().id}')
+
+// This function generates a unique resource name by appending a unique string to the given name, ensuring the total length does not exceed the specified limit.
+// The function ensures that the name is always postfixed with the full length of the unique string, which is 13 characters plus a dash.
+// Example:
+// uniqueResourceName(name: 'my-resource', limit: 50) => 'my-resource-1234567890123'
+// Example:
+// uniqueResourceName(name: 'my-resource', limit: 20) => 'my-res-1234567890123'
+@export()
+func uniqueResourceName(name string, limit int) string =>
+  '${take(name, limit - 13 - 1)}-${uniqueStringBySubscriptionAndResourceGroup()}'

--- a/.azure/modules/appConfiguration/create.bicep
+++ b/.azure/modules/appConfiguration/create.bicep
@@ -1,3 +1,5 @@
+import { uniqueResourceName } from '../../functions/resourceName.bicep'
+
 param namePrefix string
 param location string
 
@@ -7,8 +9,11 @@ type Sku = {
 }
 param sku Sku
 
+var appConfigNameMaxLength = 63
+var appConfigName = uniqueResourceName('${namePrefix}-appConfiguration', appConfigNameMaxLength)
+
 resource appConfig 'Microsoft.AppConfiguration/configurationStores@2023-03-01' = {
-  name: '${namePrefix}-appConfiguration'
+  name: appConfigName
   location: location
   sku: sku
   properties: {

--- a/.azure/modules/functionApp/slackNotifier.bicep
+++ b/.azure/modules/functionApp/slackNotifier.bicep
@@ -49,7 +49,10 @@ param sku Sku
 // todo: add name of function as param and turn this into a reusable module
 // We use uniqueStringBySubscriptionAndResourceGroup directly here to avoid having too short storage account name.
 // This should be refactored to use one common storage account. Or one storage account for all app functions.
-var storageAccountName = take('${'${namePrefix}-sn'}-${uniqueStringBySubscriptionAndResourceGroup()}', 24)
+var storageAccountName = take(
+  replace('${'${namePrefix}-sn'}-${uniqueStringBySubscriptionAndResourceGroup()}', '-', ''),
+  24
+)
 
 resource storageAccount 'Microsoft.Storage/storageAccounts@2023-04-01' = {
   name: storageAccountName

--- a/.azure/modules/functionApp/slackNotifier.bicep
+++ b/.azure/modules/functionApp/slackNotifier.bicep
@@ -1,3 +1,5 @@
+import { uniqueStringBySubscriptionAndResourceGroup, uniqueResourceName } from '../../functions/resourceName.bicep'
+
 param location string
 param applicationInsightsName string
 param namePrefix string
@@ -5,134 +7,169 @@ param keyVaultName string
 
 @export()
 type Sku = {
-    storageAccountName: 'Standard_LRS' | 'Standard_GRS' | 'Standard_RAGRS' | 'Standard_ZRS' | 'Premium_LRS' | 'Premium_ZRS'
-    applicationServicePlanName: 'F1' | 'D1' | 'B1' | 'B2' | 'B3' | 'S1' | 'S2' | 'S3' | 'P1' | 'P2' | 'P3' | 'P1V2' | 'P2V2' | 'P3V2' | 'I1' | 'I2' | 'I3' | 'Y1' | 'Y2' | 'Y3' | 'Y1v2' | 'Y2v2' | 'Y3v2' | 'Y1v2Isolated' | 'Y2v2Isolated' | 'Y3v2Isolated'
-    applicationServicePlanTier: 'Free' | 'Shared' | 'Basic' | 'Dynamic' | 'Standard' | 'Premium' | 'Isolated'
+  storageAccountName:
+    | 'Standard_LRS'
+    | 'Standard_GRS'
+    | 'Standard_RAGRS'
+    | 'Standard_ZRS'
+    | 'Premium_LRS'
+    | 'Premium_ZRS'
+  applicationServicePlanName:
+    | 'F1'
+    | 'D1'
+    | 'B1'
+    | 'B2'
+    | 'B3'
+    | 'S1'
+    | 'S2'
+    | 'S3'
+    | 'P1'
+    | 'P2'
+    | 'P3'
+    | 'P1V2'
+    | 'P2V2'
+    | 'P3V2'
+    | 'I1'
+    | 'I2'
+    | 'I3'
+    | 'Y1'
+    | 'Y2'
+    | 'Y3'
+    | 'Y1v2'
+    | 'Y2v2'
+    | 'Y3v2'
+    | 'Y1v2Isolated'
+    | 'Y2v2Isolated'
+    | 'Y3v2Isolated'
+  applicationServicePlanTier: 'Free' | 'Shared' | 'Basic' | 'Dynamic' | 'Standard' | 'Premium' | 'Isolated'
 }
 param sku Sku
 
 // Storage account names only supports lower case and numbers
 // todo: add name of function as param and turn this into a reusable module
-var storageAccountName = '${replace(namePrefix, '-', '')}${substring('slacknotifier', 0, 10)}sa'
+// We use uniqueStringBySubscriptionAndResourceGroup directly here to avoid having too short storage account name.
+// This should be refactored to use one common storage account. Or one storage account for all app functions.
+var storageAccountName = take('${'${namePrefix}-sn'}-${uniqueStringBySubscriptionAndResourceGroup()}', 24)
 
 resource storageAccount 'Microsoft.Storage/storageAccounts@2023-04-01' = {
-    name: storageAccountName
-    location: location
-    sku: {
-        name: sku.storageAccountName
-    }
-    kind: 'Storage'
-    properties: {
-        supportsHttpsTrafficOnly: true
-        defaultToOAuthAuthentication: true
-        minimumTlsVersion: 'TLS1_2'
-    }
+  name: storageAccountName
+  location: location
+  sku: {
+    name: sku.storageAccountName
+  }
+  kind: 'Storage'
+  properties: {
+    supportsHttpsTrafficOnly: true
+    defaultToOAuthAuthentication: true
+    minimumTlsVersion: 'TLS1_2'
+  }
 }
 
 resource applicationServicePlan 'Microsoft.Web/serverfarms@2023-12-01' = {
-    name: '${namePrefix}-slacknotifier-asp'
-    location: location
-    sku: {
-        name: sku.applicationServicePlanName
-        tier: sku.applicationServicePlanTier
-    }
-    properties: {}
+  name: '${namePrefix}-slacknotifier-asp'
+  location: location
+  sku: {
+    name: sku.applicationServicePlanName
+    tier: sku.applicationServicePlanTier
+  }
+  properties: {}
 }
 
 resource applicationInsights 'Microsoft.Insights/components@2020-02-02' existing = {
-    name: applicationInsightsName
+  name: applicationInsightsName
 }
 
-var functionAppName = '${namePrefix}-slacknotifier-fa'
+var functionAppNameMaxLength = 40
+var functionAppName = uniqueResourceName('${namePrefix}-slacknotifier-fa', functionAppNameMaxLength)
 resource functionApp 'Microsoft.Web/sites@2023-12-01' = {
-    name: functionAppName
-    location: location
-    kind: 'functionapp'
-    identity: {
-        type: 'SystemAssigned'
+  name: functionAppName
+  location: location
+  kind: 'functionapp'
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    serverFarmId: applicationServicePlan.id
+    publicNetworkAccess: 'Enabled'
+    siteConfig: {
+      // Setting/updating appSettings in separate module in order to not delete already deployed functions, see below
     }
-    properties: {
-        serverFarmId: applicationServicePlan.id
-        publicNetworkAccess: 'Enabled'
-        siteConfig: {
-            // Setting/updating appSettings in separate module in order to not delete already deployed functions, see below
-        }
-        httpsOnly: true
-    }
+    httpsOnly: true
+  }
 }
 
 var appSettings = {
-    AzureWebJobsStorage: 'DefaultEndpointsProtocol=https;AccountName=${storageAccountName};EndpointSuffix=${environment().suffixes.storage};AccountKey=${storageAccount.listKeys().keys[0].value}'
-    WEBSITE_CONTENTAZUREFILECONNECTIONSTRING: 'DefaultEndpointsProtocol=https;AccountName=${storageAccountName};EndpointSuffix=${environment().suffixes.storage};AccountKey=${storageAccount.listKeys().keys[0].value}'
-    WEBSITE_CONTENTSHARE: toLower(functionAppName)
-    FUNCTIONS_EXTENSION_VERSION: '~4'
-    APPINSIGHTS_INSTRUMENTATIONKEY: applicationInsights.properties.InstrumentationKey
-    Slack__WebhookUrl: '@Microsoft.KeyVault(VaultName=${keyVaultName};SecretName=Slack--Webhook--Url)'
-    FUNCTIONS_WORKER_RUNTIME: 'dotnet-isolated'
+  AzureWebJobsStorage: 'DefaultEndpointsProtocol=https;AccountName=${storageAccountName};EndpointSuffix=${environment().suffixes.storage};AccountKey=${storageAccount.listKeys().keys[0].value}'
+  WEBSITE_CONTENTAZUREFILECONNECTIONSTRING: 'DefaultEndpointsProtocol=https;AccountName=${storageAccountName};EndpointSuffix=${environment().suffixes.storage};AccountKey=${storageAccount.listKeys().keys[0].value}'
+  WEBSITE_CONTENTSHARE: toLower(functionAppName)
+  FUNCTIONS_EXTENSION_VERSION: '~4'
+  APPINSIGHTS_INSTRUMENTATIONKEY: applicationInsights.properties.InstrumentationKey
+  Slack__WebhookUrl: '@Microsoft.KeyVault(VaultName=${keyVaultName};SecretName=Slack--Webhook--Url)'
+  FUNCTIONS_WORKER_RUNTIME: 'dotnet-isolated'
 }
 
 module updateAppSettings 'appSettings.bicep' = {
-    name: '${functionAppName}-appsettings'
-    params: {
-        webAppName: functionAppName
-        currentAppSettings: list(resourceId('Microsoft.Web/sites/config', functionAppName, 'appsettings'), '2023-01-01').properties
-        appSettings: appSettings
-    }
+  name: '${functionAppName}-appsettings'
+  params: {
+    webAppName: functionAppName
+    currentAppSettings: list(resourceId('Microsoft.Web/sites/config', functionAppName, 'appsettings'), '2023-01-01').properties
+    appSettings: appSettings
+  }
 }
 
 var defaultFunctionKey = listkeys('${functionApp.id}/host/default', '2023-01-01').functionKeys.default
 var forwardAlertToSlackTriggerUrl = 'https://${functionApp.properties.defaultHostName}/api/forwardalerttoslack?code=${defaultFunctionKey}'
 resource notifyDevTeam 'Microsoft.Insights/actionGroups@2023-01-01' = {
-    name: '${namePrefix}-notify-devteam-ag'
-    location: 'Global'
-    properties: {
-        enabled: true
-        groupShortName: 'DevNotify'
-        azureFunctionReceivers: [
-            {
-                name: functionApp.properties.defaultHostName
-                functionName: 'ForwardAlertToSlack'
-                functionAppResourceId: functionApp.id
-                httpTriggerUrl: forwardAlertToSlackTriggerUrl
-                useCommonAlertSchema: true
-            }
-        ]
-    }
+  name: '${namePrefix}-notify-devteam-ag'
+  location: 'Global'
+  properties: {
+    enabled: true
+    groupShortName: 'DevNotify'
+    azureFunctionReceivers: [
+      {
+        name: functionApp.properties.defaultHostName
+        functionName: 'ForwardAlertToSlack'
+        functionAppResourceId: functionApp.id
+        httpTriggerUrl: forwardAlertToSlackTriggerUrl
+        useCommonAlertSchema: true
+      }
+    ]
+  }
 }
 
 resource exceptionOccuredAlertRule 'Microsoft.Insights/scheduledQueryRules@2023-03-15-preview' = {
-    name: '${namePrefix}-exception-occured-sqr'
-    location: location
-    properties: {
-        enabled: true
-        severity: 1
-        evaluationFrequency: 'PT5M'
-        windowSize: 'PT5M'
-        scopes: [ applicationInsights.id ]
-        autoMitigate: false
-        targetResourceTypes: [
-            'microsoft.insights/components'
-        ]
-        criteria: {
-            allOf: [
-                {
-                    query: 'exceptions | summarize count = count() by environment = tostring(customDimensions.AspNetCoreEnvironment), problemId'
-                    operator: 'GreaterThan'
-                    threshold: 0
-                    timeAggregation: 'Count'
-                    failingPeriods: {
-                        numberOfEvaluationPeriods: 1
-                        minFailingPeriodsToAlert: 1
-                    }
-                }
-            ]
+  name: '${namePrefix}-exception-occured-sqr'
+  location: location
+  properties: {
+    enabled: true
+    severity: 1
+    evaluationFrequency: 'PT5M'
+    windowSize: 'PT5M'
+    scopes: [applicationInsights.id]
+    autoMitigate: false
+    targetResourceTypes: [
+      'microsoft.insights/components'
+    ]
+    criteria: {
+      allOf: [
+        {
+          query: 'exceptions | summarize count = count() by environment = tostring(customDimensions.AspNetCoreEnvironment), problemId'
+          operator: 'GreaterThan'
+          threshold: 0
+          timeAggregation: 'Count'
+          failingPeriods: {
+            numberOfEvaluationPeriods: 1
+            minFailingPeriodsToAlert: 1
+          }
         }
-        actions: {
-            actionGroups: [
-                notifyDevTeam.id
-            ]
-        }
+      ]
     }
+    actions: {
+      actionGroups: [
+        notifyDevTeam.id
+      ]
+    }
+  }
 }
 
 output functionAppPrincipalId string = functionApp.identity.principalId

--- a/.azure/modules/postgreSql/create.bicep
+++ b/.azure/modules/postgreSql/create.bicep
@@ -1,4 +1,4 @@
-import { uniqueResourceName } from '../../functions/resourcePostFix.bicep'
+import { uniqueResourceName } from '../../functions/resourceName.bicep'
 
 param namePrefix string
 param location string

--- a/.azure/modules/postgreSql/create.bicep
+++ b/.azure/modules/postgreSql/create.bicep
@@ -22,8 +22,8 @@ param administratorLoginPassword string
 
 var administratorLogin = 'dialogportenPgAdmin'
 var databaseName = 'dialogporten'
-// postgresql max characters is 63
-var postgresqlName = uniqueResourceName('${namePrefix}-postgres', 63)
+var postgresServerNameMaxLength = 63
+var postgresServerName = uniqueResourceName('${namePrefix}-postgres', postgresServerNameMaxLength)
 
 // Uncomment the following lines to add logical replication.
 // see https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/concepts-logical#pre-requisites-for-logical-replication-and-logical-decoding
@@ -58,7 +58,7 @@ module privateDnsZone '../privateDnsZone/main.bicep' = {
 }
 
 resource postgres 'Microsoft.DBforPostgreSQL/flexibleServers@2022-12-01' = {
-  name: postgresqlName
+  name: postgresServerName
   location: location
   properties: {
     version: '15'

--- a/.azure/modules/postgreSql/create.bicep
+++ b/.azure/modules/postgreSql/create.bicep
@@ -1,3 +1,5 @@
+import { uniqueResourceName } from '../../functions/resourcePostFix.bicep'
+
 param namePrefix string
 param location string
 param environmentKeyVaultName string
@@ -20,6 +22,8 @@ param administratorLoginPassword string
 
 var administratorLogin = 'dialogportenPgAdmin'
 var databaseName = 'dialogporten'
+// postgresql max characters is 63
+var postgresqlName = uniqueResourceName('${namePrefix}-postgres', 63)
 
 // Uncomment the following lines to add logical replication.
 // see https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/concepts-logical#pre-requisites-for-logical-replication-and-logical-decoding
@@ -54,7 +58,7 @@ module privateDnsZone '../privateDnsZone/main.bicep' = {
 }
 
 resource postgres 'Microsoft.DBforPostgreSQL/flexibleServers@2022-12-01' = {
-  name: '${namePrefix}-postgres'
+  name: postgresqlName
   location: location
   properties: {
     version: '15'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Meeting some issues when creating resources in another subscription. Some resource names are global across the azure infrastructure. Another potential issue is DoS if someone uses our prefix to create resources.

- Add two helper functions to help generate unique resource names
- Adds a unique postfix based on resourcegroup id and subscription id on the resources that requires globally unique names. 
- Slack notifier storage account is a bit different as it has max 24 chars and needs lowercase letters and numbers only. Refactored to work fine, but we should look into creating a common storage account

<!--- Describe your changes in detail -->

## Related Issue(s)

- #783 

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
