### PR TITLE
fix: Allow new activities to reference old activities

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/UpdateDialogCommandValidator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/UpdateDialogCommandValidator.cs
@@ -95,9 +95,6 @@ internal sealed class UpdateDialogDtoValidator : AbstractValidator<UpdateDialogD
         RuleFor(x => x.Activities)
             .UniqueBy(x => x.Id);
         RuleForEach(x => x.Activities)
-            .IsIn(x => x.Activities,
-                dependentKeySelector: activity => activity.RelatedActivityId,
-                principalKeySelector: activity => activity.Id)
             .SetValidator(activityValidator);
     }
 }

--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Common/DialogApplication.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Common/DialogApplication.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.ObjectModel;
+using System.Reflection;
 using System.Text.Json;
+using AutoMapper;
 using Digdir.Domain.Dialogporten.Application.Common;
 using Digdir.Domain.Dialogporten.Application.Externals;
 using Digdir.Domain.Dialogporten.Application.Externals.AltinnAuthorization;
@@ -29,6 +31,7 @@ namespace Digdir.Domain.Dialogporten.Application.Integration.Tests.Common;
 
 public class DialogApplication : IAsyncLifetime
 {
+    private IMapper? _mapper;
     private Respawner _respawner = null!;
     private ServiceProvider _rootProvider = null!;
     private readonly PostgreSqlContainer _dbContainer = new PostgreSqlBuilder()
@@ -37,6 +40,12 @@ public class DialogApplication : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
+        var config = new MapperConfiguration(cfg =>
+        {
+            cfg.AddMaps(Assembly.GetAssembly(typeof(ApplicationSettings)));
+        });
+        _mapper = config.CreateMapper();
+
         AssertionOptions.AssertEquivalencyUsing(options =>
         {
             //options.ExcludingMissingMembers();
@@ -143,6 +152,8 @@ public class DialogApplication : IAsyncLifetime
 
         return organizationRegistrySubstitute;
     }
+
+    public IMapper GetMapper() => _mapper!;
 
     public async Task DisposeAsync()
     {

--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/ServiceOwner/Dialogs/Commands/UpdateDialogTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/ServiceOwner/Dialogs/Commands/UpdateDialogTests.cs
@@ -1,13 +1,55 @@
-﻿using Digdir.Domain.Dialogporten.Application.Integration.Tests.Common;
+﻿using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialogs.Queries.Get;
+using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialogs.Commands.Create;
+using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialogs.Commands.Update;
+using Digdir.Domain.Dialogporten.Application.Integration.Tests.Common;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Activities;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Actors;
+using Digdir.Tool.Dialogporten.GenerateFakeData;
+using FluentAssertions;
 
 namespace Digdir.Domain.Dialogporten.Application.Integration.Tests.Features.V1.ServiceOwner.Dialogs.Commands;
 
 [Collection(nameof(DialogCqrsCollectionFixture))]
-public class UpdateDialogTests : ApplicationCollectionFixture
+public class UpdateDialogTests(DialogApplication application) : ApplicationCollectionFixture(application)
 {
-    public UpdateDialogTests(DialogApplication application) : base(application)
+    [Fact]
+    public async Task New_Activity_Should_Be_Able_To_Refer_To_Old_Activity()
     {
-    }
-    // TODO: Add tests
-}
+        // Arrange
+        var (_, createCommandResponse) = await GenerateDialogWithActivity();
+        var getDialogQuery = new GetDialogQuery { DialogId = createCommandResponse.AsT0.Value };
+        var getDialogDto = await Application.Send(getDialogQuery);
 
+        var mapper = Application.GetMapper();
+        var updateDialogDto = mapper.Map<UpdateDialogDto>(getDialogDto.AsT0);
+
+        // New activity refering to old activity
+        updateDialogDto.Activities.Add(new UpdateDialogDialogActivityDto
+        {
+            Type = DialogActivityType.Values.DialogClosed,
+            RelatedActivityId = getDialogDto.AsT0.Activities.First().Id,
+            PerformedBy = new UpdateDialogDialogActivityActorDto
+            {
+                ActorType = DialogActorType.Values.ServiceOwner
+            }
+        });
+
+        // Act
+        var updateResponse = await Application.Send(new UpdateDialogCommand { Id = createCommandResponse.AsT0.Value, Dto = updateDialogDto });
+
+        // Assert
+        updateResponse.TryPickT0(out var result, out _).Should().BeTrue();
+        result.Should().NotBeNull();
+    }
+
+    private async Task<(CreateDialogCommand, CreateDialogResult)> GenerateDialogWithActivity()
+    {
+        var createDialogCommand = DialogGenerator.GenerateSimpleFakeDialog();
+        var activity = DialogGenerator.GenerateFakeDialogActivity(type: DialogActivityType.Values.Information);
+        activity.PerformedBy.ActorId = DialogGenerator.GenerateRandomParty(forcePerson: true);
+        activity.PerformedBy.ActorName = null;
+        createDialogCommand.Activities.Add(activity);
+        var createCommandResponse = await Application.Send(createDialogCommand);
+        return (createDialogCommand, createCommandResponse);
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

It is currently not possible to create a new DialogActivity that refers to an old DialogActivity via `relatedActivityId`
This check in the validator requires the referred Id to be present in the DTO, which we don't allow. 
```cshap
        RuleForEach(x => x.Activities)
            .IsIn(x => x.Activities,
                dependentKeySelector: activity => activity.RelatedActivityId,
                principalKeySelector: activity => activity.Id)
            .SetValidator(activityValidator);
```

This suggestion is to move this check from the validator to the handler and load all activities to verify the relation ID.

## Related Issue(s)
- #931 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
