### PR TITLE
fix(WebAPI): Allow purging of softly deleted dialogs

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Purge/PurgeDialogCommand.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Purge/PurgeDialogCommand.cs
@@ -43,6 +43,7 @@ internal sealed class PurgeDialogCommandHandler : IRequestHandler<PurgeDialogCom
             .Include(x => x.Attachments)
             .Include(x => x.Activities)
             .Where(x => resourceIds.Contains(x.ServiceResource))
+            .IgnoreQueryFilters()
             .FirstOrDefaultAsync(x => x.Id == request.DialogId, cancellationToken);
 
         if (dialog is null)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Query filter makes it impossible to purge a softly deleted dialog

## Related Issue(s)

- #939 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
