### PR TITLE
ci: ensure migration is run on manual dispatch

### DIFF
--- a/.github/workflows/ci-cd-main.yml
+++ b/.github/workflows/ci-cd-main.yml
@@ -106,7 +106,7 @@ jobs:
       environment: test
       region: norwayeast
       version: ${{ needs.get-current-version.outputs.version }}-${{ needs.generate-git-short-sha.outputs.gitShortSha }}
-      runMigration: ${{ needs.check-for-changes.outputs.hasMigrationChanges == 'true' }}
+      runMigration: ${{ github.event_name == 'workflow_dispatch' || needs.check-for-changes.outputs.hasMigrationChanges == 'true' }}
 
   deploy-slack-notifier-test:
     name: Deploy slack notifier (test)

--- a/.github/workflows/ci-cd-staging.yml
+++ b/.github/workflows/ci-cd-staging.yml
@@ -68,7 +68,7 @@ jobs:
       environment: staging
       region: norwayeast
       version: ${{ needs.get-current-version.outputs.version }}
-      runMigration: ${{ needs.check-for-changes.outputs.hasMigrationChanges == 'true' }}
+      runMigration: ${{ github.event_name == 'workflow_dispatch' || needs.check-for-changes.outputs.hasMigrationChanges == 'true' }}
 
   deploy-slack-notifier-staging:
     name: Deploy slack notifier (staging)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When dispatching the `main` or `staging` workflows manually we want to run through every workflow and job. This ensures that we also include running the migration

<!--- Describe your changes in detail -->

## Related Issue(s)

- #{issue number}

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
