### PR TITLE
fix: Using existing transmission/activity IDs should return HTTP 422

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Create/CreateDialogCommand.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Create/CreateDialogCommand.cs
@@ -7,6 +7,7 @@ using Digdir.Domain.Dialogporten.Domain.Common;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Activities;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Attachments;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Transmissions;
 using FluentValidation.Results;
 using MediatR;
 using OneOf;
@@ -119,6 +120,12 @@ internal sealed class CreateDialogCommandHandler : IRequestHandler<CreateDialogC
         if (existingAttachmentIds.Count != 0)
         {
             _domainContext.AddError(DomainFailure.EntityExists<DialogAttachment>(existingAttachmentIds));
+        }
+
+        var existingTransmissionIds = await _db.GetExistingIds(dialog.Transmissions, cancellationToken);
+        if (existingTransmissionIds.Count != 0)
+        {
+            _domainContext.AddError(DomainFailure.EntityExists<DialogTransmission>(existingTransmissionIds));
         }
 
         await _db.Dialogs.AddAsync(dialog, cancellationToken);

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/UpdateDialogCommand.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/UpdateDialogCommand.cs
@@ -113,9 +113,10 @@ internal sealed class UpdateDialogCommandHandler : IRequestHandler<UpdateDialogC
         await AppendActivity(dialog, request.Dto, cancellationToken);
         VerifyActivityRelations(dialog);
 
-        AppendTransmission(dialog, request.Dto);
-        VerifyActivityTransmissionRelations(dialog);
+        await AppendTransmission(dialog, request.Dto, cancellationToken);
         VerifyTransmissionRelations(dialog);
+
+        VerifyActivityTransmissionRelations(dialog);
 
         dialog.SearchTags
             .Merge(request.Dto.SearchTags,
@@ -277,19 +278,16 @@ internal sealed class UpdateDialogCommandHandler : IRequestHandler<UpdateDialogC
         }
     }
 
-    private void AppendTransmission(DialogEntity dialog, UpdateDialogDto dto)
+    private async Task AppendTransmission(DialogEntity dialog, UpdateDialogDto dto, CancellationToken cancellationToken)
     {
         var newDialogTransmissions = _mapper.Map<List<DialogTransmission>>(dto.Transmissions);
 
-        var existingIds = dialog.Transmissions.Select(x => x.Id).ToList();
-
-        existingIds = existingIds.Intersect(newDialogTransmissions.Select(x => x.Id)).ToList();
+        var existingIds = await _db.GetExistingIds(newDialogTransmissions, cancellationToken);
         if (existingIds.Count != 0)
         {
             _domainContext.AddError(
                 nameof(UpdateDialogDto.Transmissions),
                 $"Entity '{nameof(DialogTransmission)}' with the following key(s) already exists: ({string.Join(", ", existingIds)}).");
-            return;
         }
 
         dialog.Transmissions.AddRange(newDialogTransmissions);
@@ -300,7 +298,11 @@ internal sealed class UpdateDialogCommandHandler : IRequestHandler<UpdateDialogC
 
     private void VerifyTransmissionRelations(DialogEntity dialog)
     {
-        var relatedTransmissionIds = dialog.Transmissions.Where(x => x.RelatedTransmissionId is not null).Select(x => x.RelatedTransmissionId).ToList();
+        var relatedTransmissionIds = dialog.Transmissions
+            .Where(x => x.RelatedTransmissionId is not null)
+            .Select(x => x.RelatedTransmissionId)
+            .ToList();
+
         if (relatedTransmissionIds.Count == 0)
         {
             return;


### PR DESCRIPTION
Introduced a bug when implementing Transmissions, changed the existing activities check to only check on the dialog. 
Reverted to check the entire table.

Also added the same check that was missing for Transmission IDs

## Related Issue(s)

- #959 
