### PR TITLE
chore: Disbale token issuer cache when auth is disabled

### DIFF
--- a/src/Digdir.Domain.Dialogporten.WebApi/Common/Authentication/TokenIssuerCache.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Common/Authentication/TokenIssuerCache.cs
@@ -9,6 +9,12 @@ public interface ITokenIssuerCache
     public Task<string?> GetIssuerForScheme(string schemeName);
 }
 
+// ReSharper disable once ClassNeverInstantiated.Global
+public sealed class DevelopmentTokenIssuerCache : ITokenIssuerCache
+{
+    public Task<string?> GetIssuerForScheme(string schemeName) => Task.FromResult<string?>(null);
+}
+
 public sealed class TokenIssuerCache : ITokenIssuerCache, IDisposable
 {
     private readonly Dictionary<string, string> _issuerMappings = new();

--- a/src/Digdir.Domain.Dialogporten.WebApi/Program.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Program.cs
@@ -137,6 +137,8 @@ static void BuildAndRun(string[] args)
             .ReplaceSingleton<IUser, LocalDevelopmentUser>(predicate: localDevelopmentSettings.UseLocalDevelopmentUser)
             .ReplaceSingleton<IAuthorizationHandler, AllowAnonymousHandler>(
                 predicate: localDevelopmentSettings.DisableAuth)
+            .ReplaceSingleton<ITokenIssuerCache, DevelopmentTokenIssuerCache>(
+                predicate: localDevelopmentSettings.DisableAuth)
             .AddHostedService<
                 OutboxScheduler>(predicate: !localDevelopmentSettings.DisableShortCircuitOutboxDispatcher);
     }


### PR DESCRIPTION
Noticed this when attempting to debug on the airplane going back home.

It is not possible to query the api when offline, with auth disabled 
TokenIssuerCache calls times out, results in HTTP500

This disables the TokenIssuerCache when DisableAuth is set


Manually tested on plane ✈️ 