### PR TITLE
fix: Using existing Transmission or Activity IDs should no longer result in internal server error on updates

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/UpdateDialogCommand.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/UpdateDialogCommand.cs
@@ -216,6 +216,7 @@ internal sealed class UpdateDialogCommandHandler : IRequestHandler<UpdateDialogC
             _domainContext.AddError(
                 nameof(UpdateDialogDto.Activities),
                 $"Entity '{nameof(DialogActivity)}' with the following key(s) already exists: ({string.Join(", ", existingIds)}).");
+            return;
         }
 
         dialog.Activities.AddRange(newDialogActivities);
@@ -288,6 +289,7 @@ internal sealed class UpdateDialogCommandHandler : IRequestHandler<UpdateDialogC
             _domainContext.AddError(
                 nameof(UpdateDialogDto.Transmissions),
                 $"Entity '{nameof(DialogTransmission)}' with the following key(s) already exists: ({string.Join(", ", existingIds)}).");
+            return;
         }
 
         dialog.Transmissions.AddRange(newDialogTransmissions);


### PR DESCRIPTION
#981 