### PR TITLE
chore: Add existing ID checks for transmission attachments

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Create/CreateDialogCommand.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Create/CreateDialogCommand.cs
@@ -128,8 +128,8 @@ internal sealed class CreateDialogCommandHandler : IRequestHandler<CreateDialogC
             _domainContext.AddError(DomainFailure.EntityExists<DialogTransmission>(existingTransmissionIds));
         }
 
-        var transmissionAttachements = dialog.Transmissions.SelectMany(x => x.Attachments);
-        var existingTransmissionAttachmentIds = await _db.GetExistingIds(transmissionAttachements, cancellationToken);
+        var transmissionAttachments = dialog.Transmissions.SelectMany(x => x.Attachments);
+        var existingTransmissionAttachmentIds = await _db.GetExistingIds(transmissionAttachments, cancellationToken);
         if (existingTransmissionAttachmentIds.Count != 0)
         {
             _domainContext.AddError(DomainFailure.EntityExists<TransmissionAttachment>(existingTransmissionAttachmentIds));

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Create/CreateDialogCommand.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Create/CreateDialogCommand.cs
@@ -128,6 +128,13 @@ internal sealed class CreateDialogCommandHandler : IRequestHandler<CreateDialogC
             _domainContext.AddError(DomainFailure.EntityExists<DialogTransmission>(existingTransmissionIds));
         }
 
+        var transmissionAttachements = dialog.Transmissions.SelectMany(x => x.Attachments);
+        var existingTransmissionAttachmentIds = await _db.GetExistingIds(transmissionAttachements, cancellationToken);
+        if (existingTransmissionAttachmentIds.Count != 0)
+        {
+            _domainContext.AddError(DomainFailure.EntityExists<TransmissionAttachment>(existingTransmissionAttachmentIds));
+        }
+
         await _db.Dialogs.AddAsync(dialog, cancellationToken);
 
         var saveResult = await _unitOfWork.SaveChangesAsync(cancellationToken);

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/UpdateDialogCommand.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/UpdateDialogCommand.cs
@@ -292,6 +292,16 @@ internal sealed class UpdateDialogCommandHandler : IRequestHandler<UpdateDialogC
             return;
         }
 
+        var transmissionAttachments = newDialogTransmissions.SelectMany(x => x.Attachments);
+        var existingTransmissionAttachmentIds = await _db.GetExistingIds(transmissionAttachments, cancellationToken);
+        if (existingTransmissionAttachmentIds.Count != 0)
+        {
+            _domainContext.AddError(
+                nameof(UpdateDialogDialogTransmissionDto.Attachments),
+                $"Entity '{nameof(TransmissionAttachment)}' with the following key(s) already exists: ({string.Join(", ", existingTransmissionAttachmentIds)}).");
+            return;
+        }
+
         dialog.Transmissions.AddRange(newDialogTransmissions);
 
         // Tell ef explicitly to add transmissions as new to the database.


### PR DESCRIPTION
Not adding as "fix", there is already a note on a previous fix that is related in the release notes

Related issue: #981 