### PR TITLE
ci: add production workflow

### DIFF
--- a/.github/workflows/ci-cd-prod.yml
+++ b/.github/workflows/ci-cd-prod.yml
@@ -19,6 +19,7 @@ jobs:
     name: Get current version
     uses: ./.github/workflows/action-get-current-version.yml
 
+  # todo: should not need to re-build and re-publish the image here. Use existing image instead
   publish:
     name: Build and publish docker images
     uses: ./.github/workflows/action-publish.yml

--- a/.github/workflows/ci-cd-prod.yml
+++ b/.github/workflows/ci-cd-prod.yml
@@ -19,7 +19,7 @@ jobs:
     name: Get current version
     uses: ./.github/workflows/action-get-current-version.yml
 
-  # todo: should not need to re-build and re-publish the image here. Use existing image instead
+  # todo: should not need to re-build and re-publish the image here. Use existing image instead https://github.com/digdir/dialogporten/issues/1023
   publish:
     name: Build and publish docker images
     uses: ./.github/workflows/action-publish.yml
@@ -130,19 +130,19 @@ jobs:
       function-project-path: "./src/Digdir.Tool.Dialogporten.SlackNotifier"
       environment: prod
 
-  run-e2e-tests:
-    name: "Run K6 functional end-to-end tests"
-    # we want the end-to-end tests to be dependent on deployment of infrastructure and apps, but if infrastructure is skipped, we still want to run the tests
-    if: ${{ always() && !failure() && !cancelled() && (github.event_name == 'workflow_dispatch' || needs.check-for-changes.outputs.hasBackendChanges == 'true') }}
-    needs: [deploy-apps-prod, check-for-changes]
-    uses: ./.github/workflows/action-run-k6-tests.yml
-    secrets:
-      TOKEN_GENERATOR_USERNAME: ${{ secrets.TOKEN_GENERATOR_USERNAME }}
-      TOKEN_GENERATOR_PASSWORD: ${{ secrets.TOKEN_GENERATOR_PASSWORD }}
-    with:
-      environment: prod
-      apiVersion: v1
-      testSuitePath: tests/k6/suites/all-single-pass.js
-    permissions:
-      checks: write
-      pull-requests: write
+  # run-e2e-tests:
+  #   name: "Run K6 functional end-to-end tests"
+  #   # we want the end-to-end tests to be dependent on deployment of infrastructure and apps, but if infrastructure is skipped, we still want to run the tests
+  #   if: ${{ always() && !failure() && !cancelled() && (github.event_name == 'workflow_dispatch' || needs.check-for-changes.outputs.hasBackendChanges == 'true') }}
+  #   needs: [deploy-apps-prod, check-for-changes]
+  #   uses: ./.github/workflows/action-run-k6-tests.yml
+  #   secrets:
+  #     TOKEN_GENERATOR_USERNAME: ${{ secrets.TOKEN_GENERATOR_USERNAME }}
+  #     TOKEN_GENERATOR_PASSWORD: ${{ secrets.TOKEN_GENERATOR_PASSWORD }}
+  #   with:
+  #     environment: prod
+  #     apiVersion: v1
+  #     testSuitePath: tests/k6/suites/all-single-pass.js
+  #   permissions:
+  #     checks: write
+  #     pull-requests: write

--- a/.github/workflows/ci-cd-prod.yml
+++ b/.github/workflows/ci-cd-prod.yml
@@ -1,0 +1,147 @@
+﻿name: CI/CD Production
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*.*.*"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+
+jobs:
+  # Get changed files between previous tag and current tag: https://github.com/marketplace/actions/changed-files
+  check-for-changes:
+    name: Check for changes
+    uses: ./.github/workflows/action-check-for-changes.yml
+
+  get-current-version:
+    name: Get current version
+    uses: ./.github/workflows/action-get-current-version.yml
+
+  publish:
+    name: Build and publish docker images
+    uses: ./.github/workflows/action-publish.yml
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.check-for-changes.outputs.hasBackendChanges == 'true' }}
+    needs: [get-current-version, check-for-changes]
+    secrets:
+      GCR_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+    with:
+      dockerImageBaseName: ghcr.io/digdir/dialogporten-
+      version: ${{ needs.get-current-version.outputs.version }}
+  
+  dry-run-deploy-infra-prod:
+    name: Dry run deploy infra to prod
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.check-for-changes.outputs.hasAzureChanges == 'true' }}
+    needs: [get-current-version, check-for-changes]
+    uses: ./.github/workflows/action-deploy-infra.yml
+    secrets:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      AZURE_SOURCE_KEY_VAULT_NAME: ${{ secrets.AZURE_SOURCE_KEY_VAULT_NAME }}
+      AZURE_SOURCE_KEY_VAULT_SUBSCRIPTION_ID: ${{ secrets.AZURE_SOURCE_KEY_VAULT_SUBSCRIPTION_ID }}
+      AZURE_SOURCE_KEY_VAULT_RESOURCE_GROUP: ${{ secrets.AZURE_SOURCE_KEY_VAULT_RESOURCE_GROUP }}
+      AZURE_SOURCE_KEY_VAULT_SSH_JUMPER_SSH_PUBLIC_KEY: ${{ secrets.AZURE_SOURCE_KEY_VAULT_SSH_JUMPER_SSH_PUBLIC_KEY }}
+    with:
+      environment: prod
+      region: norwayeast
+      version: ${{ needs.get-current-version.outputs.version }}
+      dryRun: true
+
+  deploy-infra-prod:
+    name: Deploy infra to prod
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.check-for-changes.outputs.hasAzureChanges == 'true' }}
+    needs: [get-current-version, check-for-changes, dry-run-deploy-infra-prod]
+    uses: ./.github/workflows/action-deploy-infra.yml
+    secrets:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      AZURE_SOURCE_KEY_VAULT_NAME: ${{ secrets.AZURE_SOURCE_KEY_VAULT_NAME }}
+      AZURE_SOURCE_KEY_VAULT_SUBSCRIPTION_ID: ${{ secrets.AZURE_SOURCE_KEY_VAULT_SUBSCRIPTION_ID }}
+      AZURE_SOURCE_KEY_VAULT_RESOURCE_GROUP: ${{ secrets.AZURE_SOURCE_KEY_VAULT_RESOURCE_GROUP }}
+      AZURE_SOURCE_KEY_VAULT_SSH_JUMPER_SSH_PUBLIC_KEY: ${{ secrets.AZURE_SOURCE_KEY_VAULT_SSH_JUMPER_SSH_PUBLIC_KEY }}
+    with:
+      environment: prod
+      region: norwayeast
+      version: ${{ needs.get-current-version.outputs.version }}
+
+  dry-run-deploy-apps-prod:
+    name: Dry run deploy apps to prod
+    needs:
+      [get-current-version, check-for-changes, deploy-infra-prod, publish]
+    # we want deployment of apps to be dependent on deployment of infrastructure, but if infrastructure is skipped, we still want to dry-run deploy the apps
+    if: ${{ always() && !failure() && !cancelled() && (github.event_name == 'workflow_dispatch' || needs.check-for-changes.outputs.hasBackendChanges == 'true') }}
+    uses: ./.github/workflows/action-deploy-apps.yml
+    secrets:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      # todo: consider resolving these in another way since they are created in the infra-step
+      AZURE_RESOURCE_GROUP_NAME: ${{ secrets.AZURE_RESOURCE_GROUP_NAME }}
+      AZURE_ENVIRONMENT_KEY_VAULT_NAME: ${{ secrets.AZURE_ENVIRONMENT_KEY_VAULT_NAME }}
+      AZURE_CONTAINER_APP_ENVIRONMENT_NAME: ${{ secrets.AZURE_CONTAINER_APP_ENVIRONMENT_NAME }}
+      AZURE_APP_INSIGHTS_CONNECTION_STRING: ${{ secrets.AZURE_APP_INSIGHTS_CONNECTION_STRING }}
+      AZURE_APP_CONFIGURATION_NAME: ${{ secrets.AZURE_APP_CONFIGURATION_NAME }}
+    with:
+      environment: prod
+      region: norwayeast
+      version: ${{ needs.get-current-version.outputs.version }}
+      dryRun: true
+      runMigration: ${{ github.event_name == 'workflow_dispatch' || needs.check-for-changes.outputs.hasMigrationChanges == 'true' }}
+  
+  deploy-apps-prod:
+    name: Deploy apps to prod
+    needs:
+      [get-current-version, check-for-changes, dry-run-deploy-apps-prod, publish]
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.check-for-changes.outputs.hasBackendChanges == 'true' }}
+    uses: ./.github/workflows/action-deploy-apps.yml
+    secrets:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      # todo: consider resolving these in another way since they are created in the infra-step
+      AZURE_RESOURCE_GROUP_NAME: ${{ secrets.AZURE_RESOURCE_GROUP_NAME }}
+      AZURE_ENVIRONMENT_KEY_VAULT_NAME: ${{ secrets.AZURE_ENVIRONMENT_KEY_VAULT_NAME }}
+      AZURE_CONTAINER_APP_ENVIRONMENT_NAME: ${{ secrets.AZURE_CONTAINER_APP_ENVIRONMENT_NAME }}
+      AZURE_APP_INSIGHTS_CONNECTION_STRING: ${{ secrets.AZURE_APP_INSIGHTS_CONNECTION_STRING }}
+      AZURE_APP_CONFIGURATION_NAME: ${{ secrets.AZURE_APP_CONFIGURATION_NAME }}
+    with:
+      environment: prod
+      region: norwayeast
+      version: ${{ needs.get-current-version.outputs.version }}
+      runMigration: ${{ github.event_name == 'workflow_dispatch' || needs.check-for-changes.outputs.hasMigrationChanges == 'true' }}
+
+  deploy-slack-notifier-prod:
+    name: Deploy slack notifier (prod)
+    needs: [check-for-changes]
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.check-for-changes.outputs.hasSlackNotifierChanges == 'true' }}
+    uses: ./.github/workflows/action-deploy-function.yml
+    secrets:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      # todo: resolve this automatically, or use tags
+      AZURE_FUNCTION_APP_NAME: ${{ secrets.AZURE_SLACK_NOTIFIER_FUNCTION_APP_NAME }}
+    with:
+      function-app-name: "slack-notifier"
+      function-project-path: "./src/Digdir.Tool.Dialogporten.SlackNotifier"
+      environment: prod
+
+  run-e2e-tests:
+    name: "Run K6 functional end-to-end tests"
+    # we want the end-to-end tests to be dependent on deployment of infrastructure and apps, but if infrastructure is skipped, we still want to run the tests
+    if: ${{ always() && !failure() && !cancelled() && (github.event_name == 'workflow_dispatch' || needs.check-for-changes.outputs.hasBackendChanges == 'true') }}
+    needs: [deploy-apps-prod, check-for-changes]
+    uses: ./.github/workflows/action-run-k6-tests.yml
+    secrets:
+      TOKEN_GENERATOR_USERNAME: ${{ secrets.TOKEN_GENERATOR_USERNAME }}
+      TOKEN_GENERATOR_PASSWORD: ${{ secrets.TOKEN_GENERATOR_PASSWORD }}
+    with:
+      environment: prod
+      apiVersion: v1
+      testSuitePath: tests/k6/suites/all-single-pass.js
+    permissions:
+      checks: write
+      pull-requests: write


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Will run a dry-run of the deployment to both infra and apps on a new release. Will have to be reviewed manually before deployment happens. 

We now have a full workflow for deployment to production. Some time in the not so very near future, I think it would be wise to split up the dry-run part and the deployment itself. As right now it would require a review from any of us to even start the dry-run, which should happen automatically on every release. 
<!--- Describe your changes in detail -->

## Related Issue(s)

- #845 

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
