### PR TITLE
ci: add env as part of concurrency

### DIFF
--- a/.github/workflows/dispatch-apps.yml
+++ b/.github/workflows/dispatch-apps.yml
@@ -23,7 +23,7 @@ on:
         type: boolean
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ inputs.environment }}
 
 jobs:
   generate-git-short-sha:

--- a/.github/workflows/dispatch-infrastructure.yml
+++ b/.github/workflows/dispatch-infrastructure.yml
@@ -18,7 +18,7 @@ on:
         type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ inputs.environment }}
 
 jobs:
   generate-git-short-sha:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adding environment as a part of the concurrency group in order to be able to deploy to several environments at the same time when dispatching infra or apps manually

<!--- Describe your changes in detail -->

## Related Issue(s)

- #{issue number}

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
