### PR TITLE
Revert "chore: Update Maskinporten API client "

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Digdir.Domain.Dialogporten.Infrastructure.csproj
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Digdir.Domain.Dialogporten.Infrastructure.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <ItemGroup>
-        <PackageReference Include="Altinn.ApiClients.Maskinporten" Version="9.2.0" />
+        <PackageReference Include="Altinn.ApiClients.Maskinporten" Version="9.1.0"/>
         <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.8" />
         <PackageReference Include="Altinn.Authorization.ABAC" Version="0.0.8"/>
         <PackageReference Include="Bogus" Version="35.6.0"/>


### PR DESCRIPTION
Reverts digdir/dialogporten#1034

Endpoints are throwing 401 errors with the new client, reverting change for now
