### PR TITLE
chore(k6): Exceptions thrown during k6 results in test suite stopping without error

### DIFF
--- a/tests/k6/common/testimports.js
+++ b/tests/k6/common/testimports.js
@@ -3,7 +3,7 @@ export { uuidv4 } from './uuid.js';
 export { describe } from './describe.js';
 export { customConsole  } from './console.js';
 export { getServiceOwnerTokenFromGenerator, getEnduserTokenFromGenerator } from './token.js';
-export { 
+export {
     getEU,
     getSO,
     postSO,

--- a/tests/k6/suites/all-single-pass.js
+++ b/tests/k6/suites/all-single-pass.js
@@ -1,10 +1,19 @@
 import { runAllTests } from "../tests/all-tests.js";
 import { default as summary } from "../common/summary.js";
+import { chai, describe } from '../common/testimports.js'
 
 
 export let options = {};
 
-export default function () { runAllTests(); }
+export default function () {
+    try {
+        runAllTests();
+    } catch (error) {
+        describe('Exception during test suite', () => {
+            chai.assert(true == false, 'See the full stack trace at the top of the log');
+        });
+    }
+}
 
 export function handleSummary(data) {
     return summary(data);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

If a suite throws an exception, the entire run just stops.
The tests that are run up to that point becomes the basis for the result.
If all tests up to the failure point is OK, the entire deployment gets a 100% ✅ 

## Related Issue(s)

- #1038 

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
