### PR TITLE
fix: Fix iss claim in dialog token

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Application/Common/IDialogTokenGenerator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Common/IDialogTokenGenerator.cs
@@ -58,7 +58,7 @@ internal class DialogTokenGenerator : IDialogTokenGenerator
             { DialogTokenClaimTypes.ServiceResource, dialog.ServiceResource },
             { DialogTokenClaimTypes.DialogId, dialog.Id },
             { DialogTokenClaimTypes.Actions, GetAuthorizedActions(authorizationResult) },
-            { DialogTokenClaimTypes.Issuer, _applicationSettings.Dialogporten.BaseUri + issuerVersion },
+            { DialogTokenClaimTypes.Issuer, _applicationSettings.Dialogporten.BaseUri.AbsoluteUri.TrimEnd('/') + issuerVersion },
             { DialogTokenClaimTypes.IssuedAt, now },
             { DialogTokenClaimTypes.NotBefore, now },
             { DialogTokenClaimTypes.Expires, now + (long)_tokenLifetime.TotalSeconds }

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/Get/GetDialogQuery.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/Get/GetDialogQuery.cs
@@ -134,7 +134,7 @@ internal sealed class GetDialogQueryHandler : IRequestHandler<GetDialogQuery, Ge
         dialogDto.DialogToken = _dialogTokenGenerator.GetDialogToken(
             dialog,
             authorizationResult,
-            "api/v1"
+            "/api/v1"
         );
 
         DecorateWithAuthorization(dialogDto, authorizationResult);


### PR DESCRIPTION
## Description

This fixes the `iss` claim getting either two slashes or no slashes after the base uri part, due some `Uri` ToString() behaviour I do not fully understand. 

Before this fix, tokens made on test (any other environment than localdev) missed a slash resulting in `iss` claim being `https://altinn-dev-api.azure-api.net/dialogportenapi/v1`. This was due to the call to `GetDialogToken` missing a leading slash. However, this resulted in double slashes when running locally, ie `https://localhost:7247//api/v1`. Both configurations are defined with `BaseUri` values without trailing slashes.

The fix consists of adding a leading slash to the `GetDialogToken` call, and trimming any trailing slash from the `BaseUri` when concatenating in `DialogGenerator`

## Related Issue(s)

- N/A

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added
