### PR TITLE
feat(webapi): Require legacy scope for HTML support

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Application/Common/Authorization/Constants.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Common/Authorization/Constants.cs
@@ -8,4 +8,5 @@ public static class Constants
     public static readonly Uri UnauthorizedUri = new("urn:dialogporten:unauthorized");
     public const string CorrespondenceScope = "digdir:dialogporten.correspondence";
     public const string ServiceOwnerAdminScope = "digdir:dialogporten.serviceprovider.admin";
+    public const string LegacyHtmlScope = "digdir:dialogporten.serviceprovider.legacyhtml";
 }

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/Common/Content/ContentValueDtoValidator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/Common/Content/ContentValueDtoValidator.cs
@@ -1,4 +1,7 @@
+using Digdir.Domain.Dialogporten.Application.Common.Authorization;
+using Digdir.Domain.Dialogporten.Application.Common.Extensions;
 using Digdir.Domain.Dialogporten.Application.Common.Extensions.FluentValidation;
+using Digdir.Domain.Dialogporten.Application.Externals.Presentation;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Localizations;
 using Digdir.Domain.Dialogporten.Domain;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Contents;
@@ -14,6 +17,8 @@ internal interface IIgnoreOnAssemblyScan;
 
 internal sealed class ContentValueDtoValidator : AbstractValidator<ContentValueDto>, IIgnoreOnAssemblyScan
 {
+    private const string LegacyHtmlMediaType = "text/html";
+
     public ContentValueDtoValidator(DialogTransmissionContentType contentType)
     {
         RuleFor(x => x.MediaType)
@@ -21,12 +26,10 @@ internal sealed class ContentValueDtoValidator : AbstractValidator<ContentValueD
             .Must(value => value is not null && contentType.AllowedMediaTypes.Contains(value))
             .WithMessage($"{{PropertyName}} '{{PropertyValue}}' is not allowed for content type {contentType.Name}. " +
                          $"Allowed media types are {string.Join(", ", contentType.AllowedMediaTypes.Select(x => $"'{x}'"))}");
-        RuleForEach(x => x.Value)
-            .ContainsValidHtml()
-            .When(x => x.MediaType is not null and MediaTypes.Html);
+
         RuleForEach(x => x.Value)
             .ContainsValidMarkdown()
-            .When(x => x.MediaType is not null and MediaTypes.Markdown);
+            .When(x => x.MediaType is MediaTypes.Markdown);
         RuleForEach(x => x.Value)
             .Must(x => Uri.TryCreate(x.Value, UriKind.Absolute, out var uri) && uri.Scheme == Uri.UriSchemeHttps)
             .When(x => x.MediaType is not null && x.MediaType.StartsWith(MediaTypes.EmbeddablePrefix, StringComparison.InvariantCultureIgnoreCase))
@@ -36,19 +39,20 @@ internal sealed class ContentValueDtoValidator : AbstractValidator<ContentValueD
             .SetValidator(_ => new LocalizationDtosValidator(contentType.MaxLength));
     }
 
-    public ContentValueDtoValidator(DialogContentType contentType)
+    public ContentValueDtoValidator(DialogContentType contentType, IUser? user = null)
     {
+        var allowedMediaTypes = GetAllowedMediaTypes(contentType, user);
         RuleFor(x => x.MediaType)
             .NotEmpty()
-            .Must(value => value is not null && contentType.AllowedMediaTypes.Contains(value))
+            .Must(value => value is not null && allowedMediaTypes.Contains(value))
             .WithMessage($"{{PropertyName}} '{{PropertyValue}}' is not allowed for content type {contentType.Name}. " +
-                         $"Allowed media types are {string.Join(", ", contentType.AllowedMediaTypes.Select(x => $"'{x}'"))}");
+                         $"Allowed media types are {string.Join(", ", allowedMediaTypes.Select(x => $"'{x}'"))}");
         RuleForEach(x => x.Value)
             .ContainsValidHtml()
-            .When(x => x.MediaType is not null and MediaTypes.Html);
+            .When(x => x.MediaType.Equals(LegacyHtmlMediaType, StringComparison.OrdinalIgnoreCase));
         RuleForEach(x => x.Value)
             .ContainsValidMarkdown()
-            .When(x => x.MediaType is not null and MediaTypes.Markdown);
+            .When(x => x.MediaType is MediaTypes.Markdown);
         RuleForEach(x => x.Value)
             .Must(x => Uri.TryCreate(x.Value, UriKind.Absolute, out var uri) && uri.Scheme == Uri.UriSchemeHttps)
             .When(x => x.MediaType is not null && x.MediaType.StartsWith(MediaTypes.EmbeddablePrefix, StringComparison.InvariantCultureIgnoreCase))
@@ -56,5 +60,19 @@ internal sealed class ContentValueDtoValidator : AbstractValidator<ContentValueD
         RuleFor(x => x.Value)
             .NotEmpty()
             .SetValidator(_ => new LocalizationDtosValidator(contentType.MaxLength));
+    }
+
+    private static string[] GetAllowedMediaTypes(DialogContentType contentType, IUser? user)
+    {
+        if (user == null)
+        {
+            return contentType.AllowedMediaTypes;
+        }
+
+        var allowHtmlSupport = user.GetPrincipal().HasScope(Constants.LegacyHtmlScope);
+
+        return allowHtmlSupport
+            ? contentType.AllowedMediaTypes.Append(LegacyHtmlMediaType).ToArray()
+            : contentType.AllowedMediaTypes;
     }
 }

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Create/CreateDialogCommandValidator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Create/CreateDialogCommandValidator.cs
@@ -1,7 +1,7 @@
 ﻿using System.Reflection;
 using Digdir.Domain.Dialogporten.Application.Common.Extensions.Enumerables;
 using Digdir.Domain.Dialogporten.Application.Common.Extensions.FluentValidation;
-using Digdir.Domain.Dialogporten.Application.Features.V1.Common;
+using Digdir.Domain.Dialogporten.Application.Externals.Presentation;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Content;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Localizations;
 using Digdir.Domain.Dialogporten.Domain.Actors;
@@ -168,7 +168,7 @@ internal sealed class CreateDialogContentDtoValidator : AbstractValidator<Create
         })
         .ToDictionary(x => x.Property.Name, StringComparer.InvariantCultureIgnoreCase);
 
-    public CreateDialogContentDtoValidator()
+    public CreateDialogContentDtoValidator(IUser? user)
     {
         foreach (var (propertyName, propMetadata) in SourcePropertyMetaDataByName)
         {
@@ -179,12 +179,12 @@ internal sealed class CreateDialogContentDtoValidator : AbstractValidator<Create
                         .NotNull()
                         .WithMessage($"{propertyName} must not be empty.")
                         .SetValidator(new ContentValueDtoValidator(
-                            DialogContentType.Parse(propertyName))!);
+                            DialogContentType.Parse(propertyName), user)!);
                     break;
                 case NullabilityState.Nullable:
                     RuleFor(x => propMetadata.Property.GetValue(x) as ContentValueDto)
                         .SetValidator(new ContentValueDtoValidator(
-                            DialogContentType.Parse(propertyName))!)
+                            DialogContentType.Parse(propertyName), user)!)
                         .When(x => propMetadata.Property.GetValue(x) is not null);
                     break;
                 case NullabilityState.Unknown:

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/UpdateDialogCommandValidator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/UpdateDialogCommandValidator.cs
@@ -1,6 +1,7 @@
 ﻿using System.Reflection;
 using Digdir.Domain.Dialogporten.Application.Common.Extensions.Enumerables;
 using Digdir.Domain.Dialogporten.Application.Common.Extensions.FluentValidation;
+using Digdir.Domain.Dialogporten.Application.Externals.Presentation;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Content;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Localizations;
@@ -222,7 +223,7 @@ internal sealed class UpdateDialogContentDtoValidator : AbstractValidator<Update
             })
             .ToDictionary(x => x.Property.Name, StringComparer.InvariantCultureIgnoreCase);
 
-    public UpdateDialogContentDtoValidator()
+    public UpdateDialogContentDtoValidator(IUser? user)
     {
         foreach (var (propertyName, propMetadata) in SourcePropertyMetaDataByName)
         {
@@ -233,12 +234,12 @@ internal sealed class UpdateDialogContentDtoValidator : AbstractValidator<Update
                         .NotNull()
                         .WithMessage($"{propertyName} must not be empty.")
                         .SetValidator(
-                            new ContentValueDtoValidator(DialogContentType.Parse(propertyName))!);
+                            new ContentValueDtoValidator(DialogContentType.Parse(propertyName), user)!);
                     break;
                 case NullabilityState.Nullable:
                     RuleFor(x => propMetadata.Property.GetValue(x) as ContentValueDto)
                         .SetValidator(
-                            new ContentValueDtoValidator(DialogContentType.Parse(propertyName))!)
+                            new ContentValueDtoValidator(DialogContentType.Parse(propertyName), user)!)
                         .When(x => propMetadata.Property.GetValue(x) is not null);
                     break;
                 case NullabilityState.Unknown:

--- a/src/Digdir.Domain.Dialogporten.Domain/Dialogs/Entities/Contents/DialogContentType.cs
+++ b/src/Digdir.Domain.Dialogporten.Domain/Dialogs/Entities/Contents/DialogContentType.cs
@@ -51,7 +51,7 @@ public class DialogContentType : AbstractLookupEntity<DialogContentType, DialogC
             Required = false,
             MaxLength = 1023,
             OutputInList = false,
-            AllowedMediaTypes = [MediaTypes.Html, MediaTypes.PlainText, MediaTypes.Markdown]
+            AllowedMediaTypes = [MediaTypes.PlainText, MediaTypes.Markdown]
         },
         Values.ExtendedStatus => new(id)
         {

--- a/src/Digdir.Domain.Dialogporten.Domain/MediaTypes.cs
+++ b/src/Digdir.Domain.Dialogporten.Domain/MediaTypes.cs
@@ -7,5 +7,4 @@ public static class MediaTypes
 
     public const string Markdown = "text/markdown";
     public const string PlainText = "text/plain";
-    public const string Html = "text/html";
 }

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Migrations/20240903130302_RemoveHtmlSupportFromDialogContent.Designer.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Migrations/20240903130302_RemoveHtmlSupportFromDialogContent.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Digdir.Domain.Dialogporten.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Digdir.Domain.Dialogporten.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(DialogDbContext))]
-    partial class DialogDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240903130302_RemoveHtmlSupportFromDialogContent")]
+    partial class RemoveHtmlSupportFromDialogContent
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Migrations/20240903130302_RemoveHtmlSupportFromDialogContent.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Migrations/20240903130302_RemoveHtmlSupportFromDialogContent.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Digdir.Domain.Dialogporten.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class RemoveHtmlSupportFromDialogContent : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.UpdateData(
+                table: "DialogContentType",
+                keyColumn: "Id",
+                keyValue: 4,
+                column: "AllowedMediaTypes",
+                value: new[] { "text/plain", "text/markdown" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.UpdateData(
+                table: "DialogContentType",
+                keyColumn: "Id",
+                keyValue: 4,
+                column: "AllowedMediaTypes",
+                value: new[] { "text/html", "text/plain", "text/markdown" });
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This "hides" HTML support from the API, only allowed with legacy scope.
Scope is to be used when importing old stuff from Altinn2/3 to Dialogporten

## Related Issue(s)

- #894 

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
