### PR TITLE
Some suggestions to Bjørn

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Application/Common/Extensions/Enumerables/AsyncEnumerableExtensions.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Common/Extensions/Enumerables/AsyncEnumerableExtensions.cs
@@ -1,0 +1,15 @@
+namespace Digdir.Domain.Dialogporten.Application.Common.Extensions.Enumerables;
+
+public static class AsyncEnumerableExtensions
+{
+    public static IAsyncEnumerable<T> Empty<T>() => EmptyAsyncEnumerator<T>.Instance;
+
+    private class EmptyAsyncEnumerator<T> : IAsyncEnumerable<T>, IAsyncEnumerator<T>
+    {
+        public static readonly EmptyAsyncEnumerator<T> Instance = new();
+        public T Current => default!;
+        public ValueTask DisposeAsync() => default;
+        public ValueTask<bool> MoveNextAsync() => new(false);
+        public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = new()) => this;
+    }
+}

--- a/src/Digdir.Domain.Dialogporten.Application/Externals/IDialogDbContext.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Externals/IDialogDbContext.cs
@@ -15,8 +15,6 @@ namespace Digdir.Domain.Dialogporten.Application.Externals;
 
 public interface IDialogDbContext
 {
-    DatabaseFacade Database { get; }
-
     DbSet<DialogEntity> Dialogs { get; }
     DbSet<DialogStatus> DialogStatuses { get; }
 

--- a/src/Digdir.Domain.Dialogporten.Application/Externals/IResourceRegistry.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Externals/IResourceRegistry.cs
@@ -4,7 +4,8 @@ public interface IResourceRegistry
 {
     Task<IReadOnlyCollection<ServiceResourceInformation>> GetResourceInformationForOrg(string orgNumber, CancellationToken cancellationToken);
     Task<ServiceResourceInformation?> GetResourceInformation(string serviceResourceId, CancellationToken cancellationToken);
-    IAsyncEnumerable<UpdatedSubjectResource> GetUpdatedSubjectResources(DateTimeOffset since, CancellationToken cancellationToken);
+    IAsyncEnumerable<List<UpdatedSubjectResource>> GetUpdatedSubjectResources(DateTimeOffset since, int batchSize,
+        CancellationToken cancellationToken);
 }
 
 public sealed record ServiceResourceInformation
@@ -21,10 +22,5 @@ public sealed record ServiceResourceInformation
     }
 }
 
-public sealed record UpdatedSubjectResource
-{
-    public Uri Subject { get; set; } = null!;
-    public Uri Resource { get; set; } = null!;
-    public DateTimeOffset UpdatedAt { get; set; }
-    public bool Deleted { get; set; }
-}
+
+public sealed record UpdatedSubjectResource(Uri SubjectUrn, Uri ResourceUrn, DateTimeOffset UpdatedAt, bool Deleted);

--- a/src/Digdir.Domain.Dialogporten.Application/Externals/ISubjectResourceRepository.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Externals/ISubjectResourceRepository.cs
@@ -1,0 +1,30 @@
+using Digdir.Domain.Dialogporten.Domain.SubjectResources;
+using Digdir.Library.Entity.Abstractions.Features.Identifiable;
+
+namespace Digdir.Domain.Dialogporten.Application.Externals;
+
+public interface ISubjectResourceRepository
+{
+    Task<int> Merge(List<MergableSubjectResource> subjectResource, CancellationToken cancellationToken);
+}
+
+public class MergableSubjectResource : SubjectResource
+{
+    public bool IsDeleted { get; set; }
+}
+
+public static class SubjectResourceExtensions
+{
+    public static MergableSubjectResource ToMergableSubjectResource(this UpdatedSubjectResource subjectResource, DateTimeOffset createdAt)
+    {
+        return new MergableSubjectResource
+        {
+            Id = IdentifiableExtensions.CreateVersion7(),
+            Subject = subjectResource.SubjectUrn.ToString()!,
+            Resource = subjectResource.ResourceUrn.ToString()!,
+            CreatedAt = createdAt.ToUniversalTime(),
+            UpdatedAt = subjectResource.UpdatedAt.ToUniversalTime(),
+            IsDeleted = subjectResource.Deleted
+        };
+    }
+}

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ResourceRegistry/Commands/Synchronize/SynchronizeSubjectResourceMappingsCommand.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ResourceRegistry/Commands/Synchronize/SynchronizeSubjectResourceMappingsCommand.cs
@@ -1,13 +1,8 @@
-using System.Data;
 using Digdir.Domain.Dialogporten.Application.Common.ReturnTypes;
 using Digdir.Domain.Dialogporten.Application.Externals;
-using Digdir.Domain.Dialogporten.Domain.SubjectResources;
-using Digdir.Library.Entity.Abstractions.Features.Identifiable;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
-using Npgsql;
-using NpgsqlTypes;
 using OneOf;
 using OneOf.Types;
 
@@ -16,6 +11,7 @@ namespace Digdir.Domain.Dialogporten.Application.Features.V1.ResourceRegistry.Co
 public class SynchronizeSubjectResourceMappingsCommand : IRequest<SynchronizeResourceRegistryResult>
 {
     public DateTimeOffset? Since { get; set; }
+    public int? BatchSize { get; set; }
 }
 
 [GenerateOneOf]
@@ -23,201 +19,58 @@ public partial class SynchronizeResourceRegistryResult : OneOfBase<Success, Vali
 
 internal sealed class SynchronizeResourceRegistryCommandHandler : IRequestHandler<SynchronizeSubjectResourceMappingsCommand, SynchronizeResourceRegistryResult>
 {
-    private const int DatabaseMaxBatchSize = 200;
-    private const string Schema = "public";
-    private const string SubjectResourceLastUpdateTable = nameof(SubjectResourceLastUpdate);
-    private const string LastUpdateColumn = nameof(SubjectResourceLastUpdate.LastUpdate);
-    private const string IdColumn = nameof(SubjectResourceLastUpdate.Id);
-    private const string SubjectResourceTable = nameof(SubjectResource);
-    private const string ResourceColumn = nameof(SubjectResource.Resource);
-    private const string SubjectColumn = nameof(SubjectResource.Subject);
-    private const string CreatedAtColumn = nameof(SubjectResource.CreatedAt);
-    private const string UpdatedAtColumn = nameof(SubjectResource.UpdatedAt);
-
+    private const int DefaultBatchSize = 1000;
     private readonly IDialogDbContext _dialogDbContext;
     private readonly IResourceRegistry _resourceRegistry;
+    private readonly ISubjectResourceRepository _subjectResourceRepository;
     private readonly ILogger<SynchronizeResourceRegistryCommandHandler> _logger;
 
     public SynchronizeResourceRegistryCommandHandler(
         IDialogDbContext dialogDbContext,
         IResourceRegistry resourceRegistry,
+        ISubjectResourceRepository subjectResourceRepository,
         ILogger<SynchronizeResourceRegistryCommandHandler> logger)
     {
         _dialogDbContext = dialogDbContext ?? throw new ArgumentNullException(nameof(dialogDbContext));
         _resourceRegistry = resourceRegistry ?? throw new ArgumentNullException(nameof(resourceRegistry));
+        _subjectResourceRepository = subjectResourceRepository ?? throw new ArgumentNullException(nameof(subjectResourceRepository));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
     public async Task<SynchronizeResourceRegistryResult> Handle(SynchronizeSubjectResourceMappingsCommand request, CancellationToken cancellationToken)
     {
-        await using var conn = new NpgsqlConnection(_dialogDbContext.Database.GetConnectionString());
-        await conn.OpenAsync(cancellationToken);
-
         // 1. Get the last updated timestamp from parameter, or the database, or use a default
-        var lastUpdated = request.Since ?? await GetLastUpdated(conn, cancellationToken);
-        _logger.LogInformation("Last updated: {LastUpdated}", lastUpdated.ToString($"O"));
+        var lastUpdated = request.Since
+            ?? await _dialogDbContext.SubjectResources
+                .Select(x => x.UpdatedAt)
+                .DefaultIfEmpty()
+                .MaxAsync(cancellationToken);
 
-        // Allow for a few seconds of drift between server clocks
-        var newLastUpdated = DateTimeOffset.Now.Subtract(TimeSpan.FromSeconds(3));
+        _logger.LogInformation("Fetching updated subject resources since {LastUpdated:O}.", lastUpdated);
 
-        _logger.LogInformation("Fetching updated subject resources since {LastUpdated}", lastUpdated);
-
-        // 2. Start a transaction to ensure that we can perform all changes atomically
-        await using var tx = await conn.BeginTransactionAsync(IsolationLevel.RepeatableRead, cancellationToken);
-
-        var remoteUpdatedSubjectResources = new List<UpdatedSubjectResource>();
-        var numDeleted = 0;
-        var numUpserted = 0;
-        await foreach (var resource in _resourceRegistry.GetUpdatedSubjectResources(lastUpdated, cancellationToken))
+        var mergeCount = 0;
+        try
         {
-            // Batch results to avoid too many database round trips
-            remoteUpdatedSubjectResources.Add(resource);
-            if (remoteUpdatedSubjectResources.Count < DatabaseMaxBatchSize) continue;
-
-            // 3. Delete the subjectResources that are no longer in the resource registry
-            numDeleted += await HandleDeletedSubjectResources(conn, tx, remoteUpdatedSubjectResources, cancellationToken);
-
-            // 4. Add the ones that are new (or no longer deleted)
-            numUpserted += await HandleNewOrUpdatedSubjectResources(conn, tx, remoteUpdatedSubjectResources, cancellationToken);
-            remoteUpdatedSubjectResources.Clear();
+            await foreach (var resourceBatch in _resourceRegistry.GetUpdatedSubjectResources(lastUpdated, request.BatchSize ?? DefaultBatchSize, cancellationToken))
+            {
+                var created = DateTimeOffset.Now;
+                var mergeableSubjectResources = resourceBatch
+                    .Select(x => x.ToMergableSubjectResource(created))
+                    .ToList();
+                mergeCount += await _subjectResourceRepository.Merge(mergeableSubjectResources, cancellationToken);
+            }
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Failed to sync subject-resources. {UpdatedAmount} subject-resources were synced before the error occurred.", mergeCount);
+            throw;
         }
 
-        // Process any remaining resources that didn't fit into a full batch
-        if (remoteUpdatedSubjectResources.Count > 0)
+        if (mergeCount > 0)
         {
-            numDeleted += await HandleDeletedSubjectResources(conn, tx, remoteUpdatedSubjectResources, cancellationToken);
-            numUpserted += await HandleNewOrUpdatedSubjectResources(conn, tx, remoteUpdatedSubjectResources, cancellationToken);
+            _logger.LogInformation("Successfully synced {UpdatedAmount} subject resources.", mergeCount);
         }
-
-        // 5. Update the last updated timestamp in the database if we have any changes
-        if (numDeleted > 0 || numUpserted > 0)
-        {
-            _logger.LogInformation("Deleted {NumDeleted} and inserted/updated {NumUpserted} subject resources", numDeleted, numUpserted);
-            _logger.LogInformation("Setting last updated timestamp to {NewLastUpdated}", newLastUpdated.ToString($"O"));
-            await SetLastUpdated(conn, tx, newLastUpdated, cancellationToken);
-        }
-
-        // 6. Commit changes to the database
-        await tx.CommitAsync(cancellationToken);
-        _logger.LogInformation("Subject resources synced successfully");
 
         return new Success();
-    }
-
-    private static async Task<DateTimeOffset> GetLastUpdated(NpgsqlConnection conn, CancellationToken cancellationToken)
-    {
-        const string sql = $"""
-                            SELECT "{LastUpdateColumn}" FROM {Schema}."{SubjectResourceLastUpdateTable}" LIMIT 1
-                            """;
-        await using var cmd = new NpgsqlCommand(sql, conn);
-        await cmd.PrepareAsync(cancellationToken);
-        await using var reader = await cmd.ExecuteReaderAsync(cancellationToken);
-
-        return await reader.ReadAsync(cancellationToken)
-            ? await reader.GetFieldValueAsync<DateTimeOffset>(0, cancellationToken: cancellationToken)
-            : DateTimeOffset.MinValue;
-    }
-
-    private static async Task SetLastUpdated(NpgsqlConnection conn, NpgsqlTransaction tx, DateTimeOffset newLastUpdated, CancellationToken cancellationToken)
-    {
-        var knownUuid = new Guid("deadbeef-dead-beef-dead-beefdeadbeef"); // Fixed guid to ensure only one row is updated
-        const string sql = $"""
-                            INSERT INTO {Schema}."{SubjectResourceLastUpdateTable}" ("{IdColumn}", "{LastUpdateColumn}")
-                            VALUES (@id, @lastUpdate)
-                            ON CONFLICT ("{IdColumn}") 
-                            DO UPDATE SET "{LastUpdateColumn}" = EXCLUDED."{LastUpdateColumn}";
-                            """;
-
-        await using var cmd = new NpgsqlCommand(sql, conn, tx);
-
-        cmd.Parameters.Add(new NpgsqlParameter("id", NpgsqlDbType.Uuid) { Value = knownUuid });
-        cmd.Parameters.Add(new NpgsqlParameter("lastUpdate", NpgsqlDbType.TimestampTz) { Value = newLastUpdated.ToUniversalTime() });
-
-        await cmd.PrepareAsync(cancellationToken);
-        await cmd.ExecuteNonQueryAsync(cancellationToken);
-    }
-
-    private static async Task<int> HandleDeletedSubjectResources(NpgsqlConnection conn, NpgsqlTransaction tx, List<UpdatedSubjectResource> remoteUpdatedSubjectResources, CancellationToken cancellationToken)
-    {
-        const string sql = $"""
-                            DELETE FROM {Schema}."{SubjectResourceTable}" WHERE ("{ResourceColumn}", "{SubjectColumn}") IN (
-                                SELECT UNNEST(@resources), UNNEST(@subjects)
-                            )
-                            """;
-
-        var resources = remoteUpdatedSubjectResources
-            .Where(x => x.Deleted)
-            .Select(deletedSubjectResource => deletedSubjectResource.Resource.ToString())
-            .ToArray();
-
-        if (resources.Length == 0)
-        {
-            return 0;
-        }
-
-        var subjects = remoteUpdatedSubjectResources
-            .Where(x => x.Deleted)
-            .Select(deletedSubjectResource => deletedSubjectResource.Subject.ToString())
-            .ToArray();
-
-        await using var cmd = new NpgsqlCommand(sql, conn, tx);
-
-        cmd.Parameters.Add(new NpgsqlParameter("@resources", NpgsqlDbType.Array | NpgsqlDbType.Text) { Value = resources });
-        cmd.Parameters.Add(new NpgsqlParameter("@subjects", NpgsqlDbType.Array | NpgsqlDbType.Text) { Value = subjects });
-
-        return await cmd.ExecuteNonQueryAsync(cancellationToken);
-    }
-
-    private static async Task<int> HandleNewOrUpdatedSubjectResources(NpgsqlConnection conn, NpgsqlTransaction tx, List<UpdatedSubjectResource> remoteUpdatedSubjectResources, CancellationToken cancellationToken)
-    {
-        const string sql =
-            $"""
-             WITH new_data AS (
-                 SELECT 
-                     unnest(@ids) AS {IdColumn},
-                     unnest(@resources) AS {ResourceColumn}, 
-                     unnest(@subjects) AS {SubjectColumn}, 
-                     unnest(@createdAtTimes) AS {CreatedAtColumn}
-             )
-             INSERT INTO {Schema}."{SubjectResourceTable}" ("{IdColumn}", "{ResourceColumn}", "{SubjectColumn}", "{CreatedAtColumn}", "{UpdatedAtColumn}")
-             SELECT {IdColumn}, {ResourceColumn}, {SubjectColumn}, {CreatedAtColumn}, NOW()
-             FROM new_data
-             ON CONFLICT ("{ResourceColumn}", "{SubjectColumn}") 
-             DO UPDATE SET "{CreatedAtColumn}" = EXCLUDED."{CreatedAtColumn}", "{UpdatedAtColumn}" = NOW()
-             """;
-
-        var newOrUpdatedSubjectResources = remoteUpdatedSubjectResources
-            .Where(x => !x.Deleted)
-            .ToList();
-
-        if (remoteUpdatedSubjectResources.Count == 0)
-        {
-            return 0;
-        }
-
-        var ids = newOrUpdatedSubjectResources
-            .Select(_ => new Guid?().CreateVersion7IfDefault())
-            .ToArray();
-
-        var resources = newOrUpdatedSubjectResources
-            .Select(x => x.Resource.ToString())
-            .ToArray();
-
-        var subjects = newOrUpdatedSubjectResources
-            .Select(x => x.Subject.ToString())
-            .ToArray();
-
-        var createdAtTimes = newOrUpdatedSubjectResources
-            .Select(x => x.UpdatedAt.ToUniversalTime())
-            .ToArray();
-
-        await using var cmd = new NpgsqlCommand(sql, conn, tx);
-
-        cmd.Parameters.Add(new NpgsqlParameter("@ids", NpgsqlDbType.Array | NpgsqlDbType.Uuid) { Value = ids });
-        cmd.Parameters.Add(new NpgsqlParameter("@resources", NpgsqlDbType.Array | NpgsqlDbType.Text) { Value = resources });
-        cmd.Parameters.Add(new NpgsqlParameter("@subjects", NpgsqlDbType.Array | NpgsqlDbType.Text) { Value = subjects });
-        cmd.Parameters.Add(new NpgsqlParameter("@createdAtTimes", NpgsqlDbType.Array | NpgsqlDbType.TimestampTz) { Value = createdAtTimes });
-
-        return await cmd.ExecuteNonQueryAsync(cancellationToken);
     }
 }

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ResourceRegistry/Commands/Synchronize/SynchronizeSubjectResourceMappingsCommandValidator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ResourceRegistry/Commands/Synchronize/SynchronizeSubjectResourceMappingsCommandValidator.cs
@@ -1,0 +1,11 @@
+using FluentValidation;
+
+namespace Digdir.Domain.Dialogporten.Application.Features.V1.ResourceRegistry.Commands.Synchronize;
+
+internal sealed class SynchronizeSubjectResourceMappingsCommandValidator : AbstractValidator<SynchronizeSubjectResourceMappingsCommand>
+{
+    public SynchronizeSubjectResourceMappingsCommandValidator()
+    {
+        RuleFor(x => x.BatchSize).InclusiveBetween(1, 1000);
+    }
+}

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/ResourceRegistry/LocalDevelopmentResourceRegistry.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/ResourceRegistry/LocalDevelopmentResourceRegistry.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿using System.Diagnostics.CodeAnalysis;
+using Digdir.Domain.Dialogporten.Application.Common.Extensions.Enumerables;
 using Digdir.Domain.Dialogporten.Application.Externals;
 using Microsoft.EntityFrameworkCore;
 
@@ -37,13 +38,9 @@ internal sealed class LocalDevelopmentResourceRegistry : IResourceRegistry
             new ServiceResourceInformation(serviceResourceId, LocalResourceType, LocalOrgId));
     }
 
-#pragma warning disable CA1822
-    public async IAsyncEnumerable<UpdatedSubjectResource> GetUpdatedSubjectResources(DateTimeOffset _, [EnumeratorCancellation] CancellationToken __)
-#pragma warning restore CA1822
-    {
-        await Task.CompletedTask;
-        yield break;
-    }
+    [SuppressMessage("Performance", "CA1822:Mark members as static")]
+    public IAsyncEnumerable<List<UpdatedSubjectResource>> GetUpdatedSubjectResources(DateTimeOffset _, int __, CancellationToken ___)
+        => AsyncEnumerableExtensions.Empty<List<UpdatedSubjectResource>>();
 
     private sealed class ServiceResourceInformationEqualityComparer : IEqualityComparer<ServiceResourceInformation>
     {

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/InfrastructureExtensions.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/InfrastructureExtensions.cs
@@ -27,6 +27,7 @@ using Digdir.Domain.Dialogporten.Infrastructure.Altinn.NameRegistry;
 using Digdir.Domain.Dialogporten.Infrastructure.Altinn.OrganizationRegistry;
 using Digdir.Domain.Dialogporten.Infrastructure.Altinn.ResourceRegistry;
 using Digdir.Domain.Dialogporten.Infrastructure.Persistence.Configurations.Actors;
+using Digdir.Domain.Dialogporten.Infrastructure.Persistence.Repositories;
 using ZiggyCreatures.Caching.Fusion;
 using ZiggyCreatures.Caching.Fusion.NullObjects;
 
@@ -134,6 +135,7 @@ public static class InfrastructureExtensions
             .AddScoped<IUnitOfWork, UnitOfWork>()
 
             // Transient
+            .AddTransient<ISubjectResourceRepository, SubjectResourceRepository>()
             .AddTransient<OutboxDispatcher>()
             .AddTransient<ConvertDomainEventsToOutboxMessagesInterceptor>()
             .AddTransient<PopulateActorNameInterceptor>()

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Repositories/SubjectResourceRepository.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Repositories/SubjectResourceRepository.cs
@@ -1,0 +1,50 @@
+using Digdir.Domain.Dialogporten.Application.Externals;
+using Digdir.Domain.Dialogporten.Domain.SubjectResources;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+
+namespace Digdir.Domain.Dialogporten.Infrastructure.Persistence.Repositories;
+
+internal class SubjectResourceRepository : ISubjectResourceRepository
+{
+    private readonly DialogDbContext _dbContext;
+
+    public SubjectResourceRepository(DialogDbContext dbContext)
+    {
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+    }
+
+    public async Task<int> Merge(List<MergableSubjectResource> subjectResource, CancellationToken cancellationToken)
+    {
+        const string sql =
+            $"""
+            with source as (
+            	SELECT *
+            	FROM unnest(@ids, @subjects, @resources, @createdAts, @updatedAts, @isDeletes) 
+            	    as s(id, subject, resource, createdAt, updatedAt, isDeleted)
+            )
+            merge into "{nameof(SubjectResource)}" t
+            using source s
+            on t."{nameof(SubjectResource.Subject)}" = s.subject
+            	AND t."{nameof(SubjectResource.Resource)}" = s.resource
+            when matched AND s.isDeleted then 
+            	delete
+            when matched AND NOT s.isDeleted then
+              	update set "{nameof(SubjectResource.UpdatedAt)}" = s.updatedAt
+            when not matched then
+              	insert ("{nameof(SubjectResource.Id)}", "{nameof(SubjectResource.Subject)}", "{nameof(SubjectResource.Resource)}", "{nameof(SubjectResource.CreatedAt)}", "{nameof(SubjectResource.UpdatedAt)}")
+              	values (s.id, s.subject, s.resource, s.createdAt, s.updatedAt);
+            """;
+
+        return subjectResource.Count == 0 ? 0
+            : await _dbContext.Database.ExecuteSqlRawAsync(sql,
+            [
+                new NpgsqlParameter("ids", subjectResource.Select(x => x.Id).ToArray()),
+                new NpgsqlParameter("subjects", subjectResource.Select(x => x.Subject).ToArray()),
+                new NpgsqlParameter("resources", subjectResource.Select(x => x.Resource).ToArray()),
+                new NpgsqlParameter("createdAts", subjectResource.Select(x => x.CreatedAt).ToArray()),
+                new NpgsqlParameter("updatedAts", subjectResource.Select(x => x.UpdatedAt).ToArray()),
+                new NpgsqlParameter("isDeletes", subjectResource.Select(x => x.IsDeleted).ToArray())
+            ], cancellationToken);
+    }
+}

--- a/src/Digdir.Domain.Dialogporten.Janitor/Commands.cs
+++ b/src/Digdir.Domain.Dialogporten.Janitor/Commands.cs
@@ -8,13 +8,20 @@ internal static class Commands
 {
     internal static CoconaApp AddJanitorCommands(this CoconaApp app)
     {
-        app.AddCommand("sync-subject-resource-mappings", (
+        app.AddCommand("sync-subject-resource-mappings", async (
                 [FromService] CoconaAppContext ctx,
                 [FromService] ISender application,
-                [Argument] DateTimeOffset? since)
-            => application.Send(
-                new SynchronizeSubjectResourceMappingsCommand { Since = since },
-                ctx.CancellationToken));
+                [Option('s')] DateTimeOffset? since,
+                [Option('b')] int? batchSize)
+            =>
+            {
+                var result = await application.Send(
+                    new SynchronizeSubjectResourceMappingsCommand { Since = since, BatchSize = batchSize },
+                    ctx.CancellationToken);
+                return result.Match(
+                    success => 0,
+                    validationError => -1);
+            });
 
         // app.AddCommand("test", ([Argument] MahInputs inputs) => Console.WriteLine("Hello, World!"));
 

--- a/src/Digdir.Domain.Dialogporten.Janitor/Properties/launchSettings.json
+++ b/src/Digdir.Domain.Dialogporten.Janitor/Properties/launchSettings.json
@@ -5,7 +5,7 @@
       "environmentVariables": {
         "DOTNET_ENVIRONMENT": "Development"
       },
-      "commandLineArgs": "sync-subject-resource-mappings 2022-01-01T00:00:00Z"
+      "commandLineArgs": "sync-subject-resource-mappings"
     }
   }
 }

--- a/src/Digdir.Library.Entity.Abstractions/Features/Identifiable/IdentifiableExtensions.cs
+++ b/src/Digdir.Library.Entity.Abstractions/Features/Identifiable/IdentifiableExtensions.cs
@@ -19,13 +19,26 @@ public static class IdentifiableExtensions
     /// </summary>
     /// <param name="value"></param>
     /// <returns></returns>
-    public static Guid CreateVersion7IfDefault(this Guid? value)
+    public static Guid CreateVersion7IfDefault(this Guid? value) =>
+        value?.CreateVersion7IfDefault() ?? CreateVersion7();
+
+    /// <summary>
+    /// Creates a new version 7 UUID if the value is <see cref="Guid.Empty"/>.
+    /// </summary>
+    /// <param name="value">The <see cref="Guid"/> to check and potentially update.</param>
+    /// <returns>A new version 7 UUID if the value is <see cref="Guid.Empty"/>, otherwise the original value.</returns>
+    public static Guid CreateVersion7IfDefault(this Guid value) =>
+        value == default ? CreateVersion7() : value;
+
+    /// <summary>
+    /// Creates a new version 7 UUID.
+    /// </summary>
+    /// <returns>A new version 7 UUID in big endian format.</returns>
+    public static Guid CreateVersion7()
     {
         // We want Guids in big endian format. The default behavior of Medo is big endian,
         // however, the implicit conversion from Medo.Uuid7 to Guid is little endian.
         // "matchGuidEndianness" is set to true to ensure big endian.
-        return !value.HasValue || value.Value == default
-            ? Uuid7.NewUuid7().ToGuid(matchGuidEndianness: true)
-            : value.Value;
+        return Uuid7.NewUuid7().ToGuid(matchGuidEndianness: true);
     }
 }


### PR DESCRIPTION
Hvis dette godkjennes, fungerer det slik:
1. Hent sist oppdatert dato fra enten kommando input, eller den største UpdatedAt i SubjectResources tabellen, eller DateTimeOffset.MinValue (i den rekkefølgen).
2. Stream subjekt-ressurs-mappings batchvis fra ressursregisteret
3. Stapp det inn i DB via en merge statement
4. Repiter steg 2 og 3 til ressursregisteret ikke har noen flere mappings

MERK - nå brukes ikke SubjectResourceLastUpdates tabellen ettersom siste oppdateringsdato hentes fra SubjectResources. Jeg tror dette blir korrekt. I tillegg gjør dette at vi ikke trenger å ta hensyn til server clock drift ettersom SubjectResources.UpdatedAt hentes og populeres direkte fra ressurs registeret. Altså vi bruker ikke DP sin tid, vi bruker ressurs registeret sin tid. Eneste er at når vi er "ferdig" med syncen ser jeg at ressurs register apiet fremdeles returnerer data, som sier til meg at de henter data fra OG MED "since". IMO mener jeg dette er feil. Det burde IMO kun vært fra, med et unntakt på likhet innenfor tie-breakeren. Dette er den samme problemstillingen vi har løst på vår paginering. 

Jeg har tatt bort transaksnonshåndteringen fordi vi nå bruker en sql merge statement for hele batchen. Dvs hver batch kan håndteres i hver sin transaksjon. Men her kom jeg på noe. Dersom det såpass mange subjekt-ressurs-mappinger innenfor samme timestamp at det strekker seg over flere batcher og det skjer en exception kan man havne i en litt uggen tilstand. Si for enkelhets skyld at det er 100 stk innenfor samme tidspunkt og vi batcher i sett på 10. Dvs at vi må ha 10x10 successfull batches for å traversere til et nytt tidspunkt. Men dersom vi failer på batch nr 5 vil vi med steg 1 ovenfor hente ut det samme tidspunktet for alle 100 stk og starte fra starten igjen (batch 1). Det er ikke et problem slik apiet er nå (fra **og med** since), men dersom apiet endrer seg til kun fra since blir det et issue. Vi kan løse det med å generere vårt eget token som sendes inn til endepunktet for tie-breakeren, men da må vi vite hvordan ressurs registeret sorterer responsen utover UpdatedAt for å finne korrekt element i vår db for å lage token ut ifra. Denne problemstillingen er ikke løst med SubjectResourceLastUpdates tabellen heller, men det er kanskje ikke et stort problem. 

Jeg mener dette er en forenkling av koden, og at det plasserer ansvarsområdene på rett plass (infra huser sql queries, ikke app). @elsand Bare huk tak i meg om du har noen spørsmål eller vil sparre om løsningen 😁 Håper dette er til hjelp 🙂 

PS - tok utgangspunkt i din gromme upsert metode når jeg lagde mergen! 🙌 