### PR TITLE
fix: ensure jobs are run with correct arguments and parameters

### DIFF
--- a/.azure/applications/sync-subject-resource-mappings-job/main.bicep
+++ b/.azure/applications/sync-subject-resource-mappings-job/main.bicep
@@ -26,6 +26,11 @@ param environmentKeyVaultName string
 @minLength(9)
 param jobSchedule string
 
+@description('The connection string for Application Insights')
+@minLength(3)
+@secure()
+param appInsightConnectionString string
+
 var namePrefix = 'dp-be-${environment}'
 var baseImageUrl = 'ghcr.io/digdir/dialogporten-'
 var tags = {
@@ -45,6 +50,14 @@ var containerAppEnvVars = [
   {
     name: 'Infrastructure__DialogDbConnectionString'
     secretRef: 'dbconnectionstring'
+  }
+  {
+    name: 'ASPNETCORE_ENVIRONMENT'
+    value: environment
+  }
+  {
+    name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
+    value: appInsightConnectionString
   }
 ]
 

--- a/.azure/applications/sync-subject-resource-mappings-job/main.bicep
+++ b/.azure/applications/sync-subject-resource-mappings-job/main.bicep
@@ -70,7 +70,7 @@ module migrationJob '../../modules/containerAppJob/main.bicep' = {
     secrets: secrets
     tags: tags
     cronExpression: jobSchedule
-    command: 'sync-subject-resource-mappings'
+    args: 'sync-subject-resource-mappings'
   }
 }
 

--- a/.azure/applications/sync-subject-resource-mappings-job/prod.bicepparam
+++ b/.azure/applications/sync-subject-resource-mappings-job/prod.bicepparam
@@ -8,3 +8,4 @@ param jobSchedule = '*/5 * * * *' // Runs every 5 minutes
 //secrets
 param containerAppEnvironmentName = readEnvironmentVariable('AZURE_CONTAINER_APP_ENVIRONMENT_NAME')
 param environmentKeyVaultName = readEnvironmentVariable('AZURE_ENVIRONMENT_KEY_VAULT_NAME')
+param appInsightConnectionString = readEnvironmentVariable('AZURE_APP_INSIGHTS_CONNECTION_STRING')

--- a/.azure/applications/sync-subject-resource-mappings-job/staging.bicepparam
+++ b/.azure/applications/sync-subject-resource-mappings-job/staging.bicepparam
@@ -8,3 +8,4 @@ param jobSchedule = '*/5 * * * *' // Runs every 5 minutes
 //secrets
 param containerAppEnvironmentName = readEnvironmentVariable('AZURE_CONTAINER_APP_ENVIRONMENT_NAME')
 param environmentKeyVaultName = readEnvironmentVariable('AZURE_ENVIRONMENT_KEY_VAULT_NAME')
+param appInsightConnectionString = readEnvironmentVariable('AZURE_APP_INSIGHTS_CONNECTION_STRING')

--- a/.azure/applications/sync-subject-resource-mappings-job/test.bicepparam
+++ b/.azure/applications/sync-subject-resource-mappings-job/test.bicepparam
@@ -8,3 +8,4 @@ param jobSchedule = '*/5 * * * *' // Runs every 5 minutes
 //secrets
 param containerAppEnvironmentName = readEnvironmentVariable('AZURE_CONTAINER_APP_ENVIRONMENT_NAME')
 param environmentKeyVaultName = readEnvironmentVariable('AZURE_ENVIRONMENT_KEY_VAULT_NAME')
+param appInsightConnectionString = readEnvironmentVariable('AZURE_APP_INSIGHTS_CONNECTION_STRING')

--- a/.azure/modules/containerAppJob/main.bicep
+++ b/.azure/modules/containerAppJob/main.bicep
@@ -22,8 +22,8 @@ param tags object
 @description('The cron expression for the job schedule (optional)')
 param cronExpression string = ''
 
-@description('The command for the job (optional)')
-param command string = ''
+@description('The container args for the job (optional)')
+param args string = ''
 
 var isScheduled = !empty(cronExpression)
 
@@ -64,7 +64,7 @@ resource job 'Microsoft.App/jobs@2024-03-01' = {
           env: environmentVariables
           image: image
           name: name
-          command: empty(command) ? null : [command]
+          args: empty(args) ? null : [args]
         }
       ]
     }

--- a/.github/workflows/action-deploy-apps.yml
+++ b/.github/workflows/action-deploy-apps.yml
@@ -256,6 +256,7 @@ jobs:
           # secrets
           AZURE_CONTAINER_APP_ENVIRONMENT_NAME: ${{ secrets.AZURE_CONTAINER_APP_ENVIRONMENT_NAME }}
           AZURE_ENVIRONMENT_KEY_VAULT_NAME: ${{ secrets.AZURE_ENVIRONMENT_KEY_VAULT_NAME }}
+          AZURE_APP_INSIGHTS_CONNECTION_STRING: ${{ secrets.AZURE_APP_INSIGHTS_CONNECTION_STRING }}
         with:
           scope: resourcegroup
           template: ./.azure/applications/${{ matrix.name }}/main.bicep


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Apparently, the `command` property in Bicep for Azure Container Apps overrides the `ENTRYPOINT` property in the `Dockerfile` 🤷  Changing to using arguments instead. Tested with manual update of the container app job. 

https://azureossd.github.io/2024/01/17/Container-Apps-Using-the-command-override-option/

Other things:
- Added application insights connection string
- Added `ASPNETCORE_ENVIRONMENT` in order to use correct appconfig-file

## Related Issue(s)

- #{issue number}

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
