### PR TITLE
chore: Add local appsettings support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 ##
 ## Get latest from https://github.com/github/gitignore/blob/master/VisualStudio.gitignore
 
+# Local User-specific application configuration
+appsettings.local.json
+
 # User-specific files
 *.rsuser
 *.suo

--- a/README.md
+++ b/README.md
@@ -138,6 +138,51 @@ We are able to toggle some external resources in local development. This is done
 ```
 Toggling these flags will enable/disable the external resources. The `DisableAuth` flag, for example, will disable authentication in the WebAPI project. This is useful when debugging the WebAPI project in an IDE. These settings will only be respected in the `Development` environment.
 
+### Using `appsettings.local.json`
+
+During local development, it is natural to tweak configurations. Some of these configurations are _meant_ to be shared through git, such as the endpoint for a new integration that may be used during local development. Other configurations are only meant for a specific debug session or a developer's personal preferences, which _should not be shared_ through git, such as lowering the log level below warning.
+
+The configuration in the `appsettings.local.json` file takes precedence over **all** other configurations and is only loaded in the **Development environment**. Additionally, it is ignored by git through the `.gitignore` file.
+
+If developers need to add configuration that should be shared, they should use `appsettings.Development.json`. If the configuration is not meant to be shared, they can create an `appsettings.local.json` file to override the desired settings.
+
+Here is an example of enabling debug logging only locally:
+```json5
+// appsettings.local.json
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug"
+    }
+  },
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Debug"
+    }
+  }
+}
+```
+
+#### Adding `appsettings.local.json` to new projects
+Add the following to the `Program.cs` file to load the `appsettings.local.json` file:
+```csharp
+
+Example usage:
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+// or var builder = CoconaApp.CreateBuilder(args);
+// or var builder = Host.CreateApplicationBuilder(args);
+// or some other builder implementing IHostApplicationBuilder
+
+// Left out for brevity
+builder.Configuration
+    // Add local configuration as the last configuration source to override other configurations
+    //.AddSomeOtherConfiguration()
+    .AddLocalConfiguration(builder.Environment);
+
+// Left out for brevity
+```
+
 ## Deployment
 
 This repository contains code for both infrastructure and applications. Configurations for infrastructure are located in `.azure/infrastructure`. Application configuration is in `.azure/applications`. 

--- a/src/Digdir.Domain.Dialogporten.Application/Common/Extensions/ConfigurationExtensions.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Common/Extensions/ConfigurationExtensions.cs
@@ -7,6 +7,13 @@ public static class ConfigurationExtensions
 {
     private const string AppsettingsLocalJson = "appsettings.local.json";
 
+
+    /// <summary>
+    /// Adds the local configuration file (appsettings.local.json) to the configuration builder if the environment is Development.
+    /// </summary>
+    /// <param name="builder">The configuration builder to add the local configuration file to.</param>
+    /// <param name="environment">The host environment to check if it is in development.</param>
+    /// <returns>The configuration builder with the local configuration file added if in development.</returns>
     public static IConfigurationBuilder AddLocalConfiguration(this IConfigurationBuilder builder, IHostEnvironment environment)
         => !environment.IsDevelopment() ? builder : builder.AddJsonFile(AppsettingsLocalJson, optional: true, reloadOnChange: true);
 }

--- a/src/Digdir.Domain.Dialogporten.Application/Common/Extensions/ConfigurationExtensions.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Common/Extensions/ConfigurationExtensions.cs
@@ -1,0 +1,12 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+
+namespace Digdir.Domain.Dialogporten.Application.Common.Extensions;
+
+public static class ConfigurationExtensions
+{
+    private const string AppsettingsLocalJson = "appsettings.local.json";
+
+    public static IConfigurationBuilder AddLocalConfiguration(this IConfigurationBuilder builder, IHostEnvironment environment)
+        => !environment.IsDevelopment() ? builder : builder.AddJsonFile(AppsettingsLocalJson, optional: true, reloadOnChange: true);
+}

--- a/src/Digdir.Domain.Dialogporten.GraphQL/Program.cs
+++ b/src/Digdir.Domain.Dialogporten.GraphQL/Program.cs
@@ -53,7 +53,9 @@ static void BuildAndRun(string[] args)
             services.GetRequiredService<TelemetryConfiguration>(),
             TelemetryConverter.Traces));
 
-    builder.Configuration.AddAzureConfiguration(builder.Environment.EnvironmentName);
+    builder.Configuration
+        .AddAzureConfiguration(builder.Environment.EnvironmentName)
+        .AddLocalConfiguration(builder.Environment);
 
     builder.Services
         .AddOptions<GraphQlSettings>()

--- a/src/Digdir.Domain.Dialogporten.Janitor/Program.cs
+++ b/src/Digdir.Domain.Dialogporten.Janitor/Program.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using Cocona;
 using Digdir.Domain.Dialogporten.Application;
+using Digdir.Domain.Dialogporten.Application.Common.Extensions;
 using Digdir.Domain.Dialogporten.Application.Externals.Presentation;
 using Digdir.Domain.Dialogporten.Infrastructure;
 using Digdir.Domain.Dialogporten.Janitor;
@@ -43,7 +44,9 @@ static void BuildAndRun(string[] args)
     // a command is the scope of the application.   
     builder.Host.UseDefaultServiceProvider(options => options.ValidateScopes = false);
 
-    builder.Configuration.AddUserSecrets<Program>();
+    builder.Configuration
+        .AddUserSecrets<Program>()
+        .AddLocalConfiguration(builder.Environment);
     builder.Host.UseSerilog((context, services, configuration) => configuration
         .ReadFrom.Configuration(context.Configuration)
         .ReadFrom.Services(services)

--- a/src/Digdir.Domain.Dialogporten.Service/Program.cs
+++ b/src/Digdir.Domain.Dialogporten.Service/Program.cs
@@ -3,6 +3,7 @@ using Digdir.Domain.Dialogporten.Application;
 using Digdir.Domain.Dialogporten.Infrastructure;
 using MassTransit;
 using System.Reflection;
+using Digdir.Domain.Dialogporten.Application.Common.Extensions;
 using Microsoft.ApplicationInsights.Extensibility;
 using Serilog;
 using Digdir.Domain.Dialogporten.Application.Externals.Presentation;
@@ -54,6 +55,8 @@ static void BuildAndRun(string[] args)
         .WriteTo.ApplicationInsights(
             services.GetRequiredService<TelemetryConfiguration>(),
             TelemetryConverter.Traces));
+
+    builder.Configuration.AddLocalConfiguration(builder.Environment);
 
     builder.Services
         .AddApplicationInsightsTelemetry()

--- a/src/Digdir.Domain.Dialogporten.WebApi/Program.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Program.cs
@@ -61,7 +61,9 @@ static void BuildAndRun(string[] args)
             services.GetRequiredService<TelemetryConfiguration>(),
             TelemetryConverter.Traces));
 
-    builder.Configuration.AddAzureConfiguration(builder.Environment.EnvironmentName);
+    builder.Configuration
+        .AddAzureConfiguration(builder.Environment.EnvironmentName)
+        .AddLocalConfiguration(builder.Environment);
 
     builder.Services
         .AddOptions<WebApiSettings>()


### PR DESCRIPTION
## Description

Det blir naturlig nok litt flikking av config under lokal utvikling. Noe av denne konfigurasjonen er _ment_ for å deles gjennom git. Eksempelvis endepunktet til en ny integrasjon i test. Annen konfigurasjon er kun ment uneder en spesifikk debugg sesjon eller som den spesifikke utviklers preferanser, som _ikke burde deles_ gjennom git. Eksempelvis det å åpne opp for lavere logg nivå enn warning. 

I denne PRen legger jeg på rammer for å kunne introdusere en appsettings.local.json fil. Konfigurasjonen her har prioritet over *all* annen config og den lastes kun inn i Development environment. I tillegg blir den ignorert av git gjennom .gitignore fila. 

Dersom uviklere nå skal legge på konfigurasjon som er greit å dele så brukes appsettings.Development.json. Dersom det er konfigurasjon som ikke er ment for deling kan det opprettes en appsettings.local.json fil som overrider den konfigurasjonen man er interessert i. 

Følgende er et eksempel på å skru på debug logging kun lokalt:
```jsonc
// appsettings.local.json
{
  "Logging": {
    "LogLevel": {
      "Default": "Debug"
    }
  },
  "Serilog": {
    "MinimumLevel": {
      "Default": "Debug"
    }
  }
}

```