### PR TITLE
fix(webapi): Return 422 when existing transmission IDs are used in dialog update

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/UpdateDialogCommand.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/UpdateDialogCommand.cs
@@ -183,9 +183,7 @@ internal sealed class UpdateDialogCommandHandler : IRequestHandler<UpdateDialogC
         var existingIds = await _db.GetExistingIds(newDialogActivities, cancellationToken);
         if (existingIds.Count != 0)
         {
-            _domainContext.AddError(
-                nameof(UpdateDialogDto.Activities),
-                $"Entity '{nameof(DialogActivity)}' with the following key(s) already exists: ({string.Join(", ", existingIds)}).");
+            _domainContext.AddError(DomainFailure.EntityExists<DialogActivity>(existingIds));
             return;
         }
 
@@ -257,6 +255,7 @@ internal sealed class UpdateDialogCommandHandler : IRequestHandler<UpdateDialogC
         if (existingIds.Count != 0)
         {
             _domainContext.AddError(DomainFailure.EntityExists<DialogTransmission>(existingIds));
+            return;
         }
 
         dialog.Transmissions.AddRange(newDialogTransmissions);

--- a/src/Digdir.Tool.Dialogporten.GenerateFakeData/DialogGenerator.cs
+++ b/src/Digdir.Tool.Dialogporten.GenerateFakeData/DialogGenerator.cs
@@ -7,6 +7,7 @@ using Digdir.Domain.Dialogporten.Domain.Attachments;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Actions;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Activities;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Transmissions;
 using Digdir.Domain.Dialogporten.Domain.Http;
 using Medo;
 
@@ -226,6 +227,22 @@ public static class DialogGenerator
 
     public static CreateDialogDialogActivityDto GenerateFakeDialogActivity(DialogActivityType.Values? type = null)
         => GenerateFakeDialogActivities(1, type)[0];
+
+    public static List<CreateDialogDialogTransmissionDto> GenerateFakeDialogTransmissions(int? count = null,
+        DialogTransmissionType.Values? type = null)
+    {
+        return new Faker<CreateDialogDialogTransmissionDto>()
+            .RuleFor(o => o.Id, _ => Uuid7.NewUuid7().ToGuid(true))
+            .RuleFor(o => o.CreatedAt, f => f.Date.Past())
+            .RuleFor(o => o.Type, f => type ?? f.PickRandom<DialogTransmissionType.Values>())
+            .RuleFor(o => o.Sender, _ => new() { ActorType = ActorType.Values.ServiceOwner })
+            .RuleFor(o => o.Content, _ => new()
+            {
+                Title = new() { Value = GenerateFakeLocalizations(1) },
+                Summary = new() { Value = GenerateFakeLocalizations(3) }
+            })
+            .Generate(count ?? new Randomizer().Number(1, 4));
+    }
 
     public static List<CreateDialogDialogActivityDto> GenerateFakeDialogActivities(int? count = null, DialogActivityType.Values? type = null)
     {

--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/ServiceOwner/Dialogs/Commands/UpdateDialogTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/ServiceOwner/Dialogs/Commands/UpdateDialogTests.cs
@@ -7,7 +7,6 @@ using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Activities;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Transmissions;
 using Digdir.Tool.Dialogporten.GenerateFakeData;
 using FluentAssertions;
-using Microsoft.IdentityModel.Tokens;
 
 namespace Digdir.Domain.Dialogporten.Application.Integration.Tests.Features.V1.ServiceOwner.Dialogs.Commands;
 
@@ -72,6 +71,7 @@ public class UpdateDialogTests(DialogApplication application) : ApplicationColle
         // Assert
         updateResponse.TryPickT5(out var domainError, out _).Should().BeTrue();
         domainError.Should().NotBeNull();
+        domainError.Errors.Should().Contain(e => e.ErrorMessage.Contains("already exists"));
     }
 
     [Fact]
@@ -108,6 +108,7 @@ public class UpdateDialogTests(DialogApplication application) : ApplicationColle
         // Assert
         updateResponse.TryPickT5(out var domainError, out _).Should().BeTrue();
         domainError.Should().NotBeNull();
+        domainError.Errors.Should().Contain(e => e.ErrorMessage.Contains("already exists"));
     }
 
     private async Task<(CreateDialogCommand, CreateDialogResult)> GenerateDialogWithActivity()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Regression(?), or missed bug from when transmissions where introduced.
* Added missing return when finding existing IDs
* Adjusted the log message for existing activities to use the same extension method as transmissions
* Added tests for both existing activities and existing transmissions 

## Related Issue(s)

- #1088 

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
