### PR TITLE
chore: Updated k6 to use new dialog status

### DIFF
--- a/tests/k6/common/dialog.js
+++ b/tests/k6/common/dialog.js
@@ -48,7 +48,7 @@ export function setSenderName(dialog, senderName, language = "nb") {
 }
 
 export function setStatus(dialog, status) {
-    const validStatuses = ["unspecified", "inprogress", "waiting", "signing", "cancelled", "completed"];
+    const validStatuses = ["unspecified", "inprogress", "new", "draft", "sent", "requiresAttention", "append"];
 
     if (!validStatuses.includes(status)) {
         throw new Error("Invalid status provided.");

--- a/tests/k6/tests/enduser/dialogSearch.js
+++ b/tests/k6/tests/enduser/dialogSearch.js
@@ -57,7 +57,7 @@ export default function () {
         setTitle(dialogs[++d], titleToSearchFor);
         setAdditionalInfo(dialogs[++d], additionalInfoToSearchFor);
         setSearchTags(dialogs[++d], searchTagsToSearchFor);
-        setStatus(dialogs[++d], "signing");
+        setStatus(dialogs[++d], "draft");
         setExtendedStatus(dialogs[++d], extendedStatusToSearchFor);
 
         setSenderName(dialogs[++d], senderNameToSearchFor);

--- a/tests/k6/tests/serviceowner/dialogSearch.js
+++ b/tests/k6/tests/serviceowner/dialogSearch.js
@@ -54,7 +54,7 @@ export default function () {
         setTitle(dialogs[++d], titleToSearchFor);
         setAdditionalInfo(dialogs[++d], additionalInfoToSearchFor);
         setSearchTags(dialogs[++d], searchTagsToSearchFor);
-        setStatus(dialogs[++d], "signing");
+        setStatus(dialogs[++d], "draft");
         setExtendedStatus(dialogs[++d], extendedStatusToSearchFor);
 
         setSenderName(dialogs[++d], senderNameToSearchFor);


### PR DESCRIPTION
## Description

Fixed k6 tests to work with new dialog status

## Related Issue(s)

[#1084](https://github.com/digdir/dialogporten/issues/1084)

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
