### PR TITLE
chore: Remove space from property names in validation errors

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Application/ApplicationExtensions.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/ApplicationExtensions.cs
@@ -26,6 +26,11 @@ public static class ApplicationExtensions
             .ValidateFluently()
             .ValidateOnStart();
 
+        // Configures FluentValidation to use property names as
+        // display names without an added space.
+        // 'CreatedAt', not 'Created At'.
+        ValidatorOptions.Global.DisplayNameResolver = (_, member, _) => member?.Name;
+
         services
             // Framework
             .AddAutoMapper(thisAssembly)


### PR DESCRIPTION
I think it reads better without the space (?) 🤔
It also matches when we use nameOf()

Old: 
![CleanShot 2024-09-09 at 19 36 17@2x](https://github.com/user-attachments/assets/b19ad4be-49e6-4d7d-ac5c-aec9a2e79249)


New:
![CleanShot 2024-09-09 at 19 35 07@2x](https://github.com/user-attachments/assets/c8b56d36-b218-4a0a-a783-87f6c12a7eac)
