### PR TITLE
chore: Remove log level settings from launchSettings.json

### DIFF
--- a/src/Digdir.Domain.Dialogporten.WebApi/Properties/launchSettings.json
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Properties/launchSettings.json
@@ -26,10 +26,7 @@
       "launchUrl": "swagger",
       "applicationUrl": "https://localhost:7214;http://localhost:5123",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development",
-        "Serilog__WriteTo__0__Name": "Console",
-        "Serilog__WriteTo__0__Args__outputTemplate": "[{Timestamp:HH:mm:ss.fff} {Level:u3}] {Message:lj}{NewLine}{Exception}",
-        "Serilog__MinimumLevel__Default": "Debug"
+        "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
     "IIS Express": {


### PR DESCRIPTION
To re-create the example which is removed in this PR, use this in [`appsettings.local.json`](https://github.com/digdir/dialogporten/?tab=readme-ov-file#using-appsettingslocaljson):

```json
{
  "Serilog": {
    "WriteTo": [
      {
        "Name": "Console",
        "Args": {
          "outputTemplate": "[{Timestamp:HH:mm:ss.fff} {Level:u3}] {Message:lj}{NewLine}{Exception}"
        }
      }
    ],
    "MinimumLevel": {
      "Default": "Debug"
    }
  }
}
```