### PR TITLE
chore: Temporarily disable ingress rules for GraphQL

### DIFF
--- a/.azure/modules/containerApp/main.bicep
+++ b/.azure/modules/containerApp/main.bicep
@@ -49,11 +49,11 @@ var probes = [
 var ipSecurityRestrictions = empty(apimIp)
   ? []
   : [
-      {
-        name: 'apim'
-        action: 'Allow'
-        ipAddressRange: apimIp!
-      }
+    //   {
+    //     name: 'apim'
+    //     action: 'Allow'
+    //     ipAddressRange: apimIp!
+    //   }
     ]
 
 var ingress = {


### PR DESCRIPTION
While debugging APIM, allow direct access to service container