### PR TITLE
chore(test): Add architecture test for Medu.Uuidv7 usage

### DIFF
--- a/Digdir.Domain.Dialogporten.sln
+++ b/Digdir.Domain.Dialogporten.sln
@@ -61,6 +61,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Digdir.Domain.Dialogporten.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Digdir.Domain.Dialogporten.Janitor", "src\Digdir.Domain.Dialogporten.Janitor\Digdir.Domain.Dialogporten.Janitor.csproj", "{0900E3CF-F9D8-4B29-957F-484B3B028D6D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Digdir.Domain.Dialogporten.Architecture.Tests", "tests\Digdir.Domain.Dialogporten.Architecture.Tests\Digdir.Domain.Dialogporten.Architecture.Tests.csproj", "{E389C7C8-9610-40AC-86DC-769B1B7DC78E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -147,6 +149,10 @@ Global
 		{0900E3CF-F9D8-4B29-957F-484B3B028D6D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0900E3CF-F9D8-4B29-957F-484B3B028D6D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0900E3CF-F9D8-4B29-957F-484B3B028D6D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E389C7C8-9610-40AC-86DC-769B1B7DC78E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E389C7C8-9610-40AC-86DC-769B1B7DC78E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E389C7C8-9610-40AC-86DC-769B1B7DC78E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E389C7C8-9610-40AC-86DC-769B1B7DC78E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -175,6 +181,7 @@ Global
 		{1EF1AE42-17F1-4761-ACFE-DF8E8A9B9429} = {CADB8189-4AA1-4732-844A-C41DBF3EC8B7}
 		{AF35FFCA-1206-4C08-A003-DA4A1344CCD5} = {CADB8189-4AA1-4732-844A-C41DBF3EC8B7}
 		{0900E3CF-F9D8-4B29-957F-484B3B028D6D} = {320B47A0-5EB8-4B6E-8C84-90633A1849CA}
+		{E389C7C8-9610-40AC-86DC-769B1B7DC78E} = {CADB8189-4AA1-4732-844A-C41DBF3EC8B7}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B2FE67FF-7622-4AFB-AD8E-961B6A39D888}

--- a/tests/Digdir.Domain.Dialogporten.Architecture.Tests/DialogportenAssemblies.cs
+++ b/tests/Digdir.Domain.Dialogporten.Architecture.Tests/DialogportenAssemblies.cs
@@ -8,31 +8,34 @@ using Digdir.Domain.Dialogporten.Janitor;
 using Digdir.Domain.Dialogporten.Service.Consumers.OutboxMessages;
 using Digdir.Domain.Dialogporten.WebApi.Endpoints.V1;
 using Digdir.Library.Entity.Abstractions;
+using Digdir.Library.Entity.EntityFrameworkCore;
 
 namespace Digdir.Domain.Dialogporten.Architecture.Tests;
 
 public static class DialogportenAssemblies
 {
-    private static readonly Assembly ApplicationAssembly = typeof(GetDialogDto).Assembly;
-    private static readonly Assembly CdcAssembly = typeof(ICdcSink<>).Assembly;
-    private static readonly Assembly DomainAssembly = typeof(DialogEntity).Assembly;
-    private static readonly Assembly GraphQlAssembly = typeof(ApplicationInsightEventListener).Assembly;
-    private static readonly Assembly InfrastructureAssembly = typeof(IUnitOfWork).Assembly;
-    private static readonly Assembly JanitorAssembly = typeof(ConsoleUser).Assembly;
-    private static readonly Assembly ServiceAssembly = typeof(OutboxMessageConsumer).Assembly;
-    private static readonly Assembly WebApiAssembly = typeof(MetadataGroup).Assembly;
-    private static readonly Assembly EntityAbstractionsAssembly = typeof(IEntity).Assembly;
+    private static readonly Assembly Application = typeof(GetDialogDto).Assembly;
+    private static readonly Assembly Cdc = typeof(ICdcSink<>).Assembly;
+    private static readonly Assembly Domain = typeof(DialogEntity).Assembly;
+    private static readonly Assembly GraphQl = typeof(ApplicationInsightEventListener).Assembly;
+    private static readonly Assembly Infrastructure = typeof(IUnitOfWork).Assembly;
+    private static readonly Assembly Janitor = typeof(ConsoleUser).Assembly;
+    private static readonly Assembly Service = typeof(OutboxMessageConsumer).Assembly;
+    private static readonly Assembly WebApi = typeof(MetadataGroup).Assembly;
+    private static readonly Assembly EntityAbstractions = typeof(IEntity).Assembly;
+    private static readonly Assembly EntityFrameworkCore = typeof(EntityLibraryEfCoreExtensions).Assembly;
 
     internal static readonly List<Assembly> All =
     [
-        ApplicationAssembly,
-        CdcAssembly,
-        DomainAssembly,
-        GraphQlAssembly,
-        InfrastructureAssembly,
-        JanitorAssembly,
-        ServiceAssembly,
-        WebApiAssembly,
-        EntityAbstractionsAssembly
+        Application,
+        Cdc,
+        Domain,
+        GraphQl,
+        Infrastructure,
+        Janitor,
+        Service,
+        WebApi,
+        EntityAbstractions,
+        EntityFrameworkCore
     ];
 }

--- a/tests/Digdir.Domain.Dialogporten.Architecture.Tests/DialogportenAssemblies.cs
+++ b/tests/Digdir.Domain.Dialogporten.Architecture.Tests/DialogportenAssemblies.cs
@@ -1,0 +1,38 @@
+using System.Reflection;
+using Digdir.Domain.Dialogporten.Application.Externals;
+using Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.Dialogs.Queries.Get;
+using Digdir.Domain.Dialogporten.ChangeDataCapture;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities;
+using Digdir.Domain.Dialogporten.GraphQL;
+using Digdir.Domain.Dialogporten.Janitor;
+using Digdir.Domain.Dialogporten.Service.Consumers.OutboxMessages;
+using Digdir.Domain.Dialogporten.WebApi.Endpoints.V1;
+using Digdir.Library.Entity.Abstractions;
+
+namespace Digdir.Domain.Dialogporten.Architecture.Tests;
+
+public static class DialogportenAssemblies
+{
+    private static readonly Assembly ApplicationAssembly = typeof(GetDialogDto).Assembly;
+    private static readonly Assembly CdcAssembly = typeof(ICdcSink<>).Assembly;
+    private static readonly Assembly DomainAssembly = typeof(DialogEntity).Assembly;
+    private static readonly Assembly GraphQlAssembly = typeof(ApplicationInsightEventListener).Assembly;
+    private static readonly Assembly InfrastructureAssembly = typeof(IUnitOfWork).Assembly;
+    private static readonly Assembly JanitorAssembly = typeof(ConsoleUser).Assembly;
+    private static readonly Assembly ServiceAssembly = typeof(OutboxMessageConsumer).Assembly;
+    private static readonly Assembly WebApiAssembly = typeof(MetadataGroup).Assembly;
+    private static readonly Assembly EntityAbstractionsAssembly = typeof(IEntity).Assembly;
+
+    internal static readonly List<Assembly> All =
+    [
+        ApplicationAssembly,
+        CdcAssembly,
+        DomainAssembly,
+        GraphQlAssembly,
+        InfrastructureAssembly,
+        JanitorAssembly,
+        ServiceAssembly,
+        WebApiAssembly,
+        EntityAbstractionsAssembly
+    ];
+}

--- a/tests/Digdir.Domain.Dialogporten.Architecture.Tests/Digdir.Domain.Dialogporten.Architecture.Tests.csproj
+++ b/tests/Digdir.Domain.Dialogporten.Architecture.Tests/Digdir.Domain.Dialogporten.Architecture.Tests.csproj
@@ -1,0 +1,39 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector" Version="6.0.0"/>
+        <PackageReference Include="Medo.Uuid7" Version="2.0.0" />
+        <PackageReference Include="Microsoft.Build" Version="17.11.4" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
+        <PackageReference Include="NetArchTest.Rules" Version="1.3.2" />
+        <PackageReference Include="xunit" Version="2.5.3"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit"/>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\Digdir.Domain.Dialogporten.Application\Digdir.Domain.Dialogporten.Application.csproj" />
+      <ProjectReference Include="..\..\src\Digdir.Domain.Dialogporten.ChangeDataCapture\Digdir.Domain.Dialogporten.ChangeDataCapture.csproj" />
+      <ProjectReference Include="..\..\src\Digdir.Domain.Dialogporten.Domain\Digdir.Domain.Dialogporten.Domain.csproj" />
+      <ProjectReference Include="..\..\src\Digdir.Domain.Dialogporten.GraphQL\Digdir.Domain.Dialogporten.GraphQL.csproj" />
+      <ProjectReference Include="..\..\src\Digdir.Domain.Dialogporten.Infrastructure\Digdir.Domain.Dialogporten.Infrastructure.csproj" />
+      <ProjectReference Include="..\..\src\Digdir.Domain.Dialogporten.Janitor\Digdir.Domain.Dialogporten.Janitor.csproj" />
+      <ProjectReference Include="..\..\src\Digdir.Domain.Dialogporten.Service\Digdir.Domain.Dialogporten.Service.csproj" />
+      <ProjectReference Include="..\..\src\Digdir.Domain.Dialogporten.WebApi\Digdir.Domain.Dialogporten.WebApi.csproj" />
+      <ProjectReference Include="..\..\src\Digdir.Library.Entity.Abstractions\Digdir.Library.Entity.Abstractions.csproj" />
+      <ProjectReference Include="..\..\src\Digdir.Library.Entity.EntityFrameworkCore\Digdir.Library.Entity.EntityFrameworkCore.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/tests/Digdir.Domain.Dialogporten.Architecture.Tests/Medo/MedoUsageTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Architecture.Tests/Medo/MedoUsageTests.cs
@@ -1,0 +1,28 @@
+using NetArchTest.Rules;
+using Medo;
+using IdentifiableExtensions = Digdir.Library.Entity.Abstractions.Features.Identifiable.IdentifiableExtensions;
+
+namespace Digdir.Domain.Dialogporten.Architecture.Tests.Medo;
+
+public class MedoUsageTests
+{
+    [Fact]
+    public void Medo_Namespace_Should_Only_Be_Used_In_IdentifiableExtensions()
+    {
+        var identifiableExtensionsNamespace = typeof(IdentifiableExtensions).Namespace;
+        var medoNamespace = typeof(Uuid7).Namespace;
+
+        var result = Types
+            .InAssemblies(DialogportenAssemblies.All)
+            .That()
+            .DoNotResideInNamespace(identifiableExtensionsNamespace)
+            .ShouldNot()
+            .HaveDependencyOn(medoNamespace)
+            .GetResult();
+
+        var failingTypes = result.FailingTypes ?? new List<Type>();
+
+        Assert.Empty(failingTypes);
+        Assert.True(result.IsSuccessful);
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
This adds a new architecture test project which uses [NetArchTest](https://github.com/BenMorris/NetArchTest) to check all assemblies for usage of the `Medo` library.
It should only be used in `IdentifiableExtensions`, so that we can control/guarantee that we are using it correctly when it comes to endianness.

## Related Issue(s)

- #1071 

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
