### PR TITLE
chore(ssh-jumper): add AD group with administrator login

### DIFF
--- a/.azure/infrastructure/main.bicep
+++ b/.azure/infrastructure/main.bicep
@@ -36,6 +36,9 @@ param sourceKeyVaultName string
 @minLength(3)
 param sourceKeyVaultSshJumperSshPublicKey string
 
+@description('The object ID of the group to assign the VM Admin Login role')
+param vmAdminGroupObjectId string
+
 import { Sku as KeyVaultSku } from '../modules/keyvault/create.bicep'
 param keyVaultSku KeyVaultSku
 
@@ -165,6 +168,7 @@ module sshJumper '../modules/ssh-jumper/main.bicep' = {
     subnetId: vnet.outputs.defaultSubnetId
     tags: tags
     sshPublicKey: secrets.sourceKeyVaultSshJumperSshPublicKey
+    vmAdminGroupObjectId: vmAdminGroupObjectId
   }
 }
 

--- a/.azure/infrastructure/main.bicep
+++ b/.azure/infrastructure/main.bicep
@@ -36,9 +36,6 @@ param sourceKeyVaultName string
 @minLength(3)
 param sourceKeyVaultSshJumperSshPublicKey string
 
-@description('The object ID of the group to assign the SSH Jumper Admin Login role')
-param sshJumperAdminGroupObjectId string
-
 @description('The object ID of the group to assign the Admin Login role for SSH Jumper')
 param sshJumperAdminLoginGroupObjectId string
 

--- a/.azure/infrastructure/main.bicep
+++ b/.azure/infrastructure/main.bicep
@@ -36,8 +36,11 @@ param sourceKeyVaultName string
 @minLength(3)
 param sourceKeyVaultSshJumperSshPublicKey string
 
-@description('The object ID of the group to assign the VM Admin Login role')
-param vmAdminGroupObjectId string
+@description('The object ID of the group to assign the SSH Jumper Admin Login role')
+param sshJumperAdminGroupObjectId string
+
+@description('The object ID of the group to assign the Admin Login role for SSH Jumper')
+param sshJumperAdminLoginGroupObjectId string
 
 import { Sku as KeyVaultSku } from '../modules/keyvault/create.bicep'
 param keyVaultSku KeyVaultSku
@@ -168,7 +171,7 @@ module sshJumper '../modules/ssh-jumper/main.bicep' = {
     subnetId: vnet.outputs.defaultSubnetId
     tags: tags
     sshPublicKey: secrets.sourceKeyVaultSshJumperSshPublicKey
-    vmAdminGroupObjectId: vmAdminGroupObjectId
+    adminLoginGroupObjectId: sshJumperAdminLoginGroupObjectId
   }
 }
 

--- a/.azure/infrastructure/prod.bicepparam
+++ b/.azure/infrastructure/prod.bicepparam
@@ -46,4 +46,4 @@ param serviceBusSku = {
   capacity: 1
 }
 
-param vmAdminGroupObjectId = 'c12e51e3-5cbd-4229-8a31-5394c423fb5f'
+param sshJumperAdminLoginGroupObjectId = 'c12e51e3-5cbd-4229-8a31-5394c423fb5f'

--- a/.azure/infrastructure/prod.bicepparam
+++ b/.azure/infrastructure/prod.bicepparam
@@ -46,4 +46,5 @@ param serviceBusSku = {
   capacity: 1
 }
 
-param sshJumperAdminLoginGroupObjectId = 'c12e51e3-5cbd-4229-8a31-5394c423fb5f'
+// Altinn Product Dialogporten: Developers Prod
+param sshJumperAdminLoginGroupObjectId = 'a94de4bf-0a83-4d30-baba-0c6a7365571c'

--- a/.azure/infrastructure/prod.bicepparam
+++ b/.azure/infrastructure/prod.bicepparam
@@ -45,3 +45,5 @@ param serviceBusSku = {
   tier: 'Premium'
   capacity: 1
 }
+
+param vmAdminGroupObjectId = 'c12e51e3-5cbd-4229-8a31-5394c423fb5f'

--- a/.azure/infrastructure/soak.bicepparam
+++ b/.azure/infrastructure/soak.bicepparam
@@ -46,4 +46,5 @@ param serviceBusSku = {
   capacity: 1
 }
 
+// Altinn Product Dialogporten: Developers Dev
 param sshJumperAdminLoginGroupObjectId = 'c12e51e3-5cbd-4229-8a31-5394c423fb5f'

--- a/.azure/infrastructure/soak.bicepparam
+++ b/.azure/infrastructure/soak.bicepparam
@@ -46,4 +46,4 @@ param serviceBusSku = {
   capacity: 1
 }
 
-param vmAdminGroupObjectId = 'c12e51e3-5cbd-4229-8a31-5394c423fb5f'
+param sshJumperAdminLoginGroupObjectId = 'c12e51e3-5cbd-4229-8a31-5394c423fb5f'

--- a/.azure/infrastructure/soak.bicepparam
+++ b/.azure/infrastructure/soak.bicepparam
@@ -45,3 +45,5 @@ param serviceBusSku = {
   tier: 'Premium'
   capacity: 1
 }
+
+param vmAdminGroupObjectId = 'c12e51e3-5cbd-4229-8a31-5394c423fb5f'

--- a/.azure/infrastructure/staging.bicepparam
+++ b/.azure/infrastructure/staging.bicepparam
@@ -46,4 +46,4 @@ param serviceBusSku = {
   capacity: 1
 }
 
-param vmAdminGroupObjectId = 'c12e51e3-5cbd-4229-8a31-5394c423fb5f'
+param sshJumperAdminLoginGroupObjectId = 'c12e51e3-5cbd-4229-8a31-5394c423fb5f'

--- a/.azure/infrastructure/staging.bicepparam
+++ b/.azure/infrastructure/staging.bicepparam
@@ -45,5 +45,5 @@ param serviceBusSku = {
   tier: 'Premium'
   capacity: 1
 }
-
-param sshJumperAdminLoginGroupObjectId = 'c12e51e3-5cbd-4229-8a31-5394c423fb5f'
+// Altinn Product Dialogporten: Developers Prod
+param sshJumperAdminLoginGroupObjectId = 'a94de4bf-0a83-4d30-baba-0c6a7365571c'

--- a/.azure/infrastructure/staging.bicepparam
+++ b/.azure/infrastructure/staging.bicepparam
@@ -45,3 +45,5 @@ param serviceBusSku = {
   tier: 'Premium'
   capacity: 1
 }
+
+param vmAdminGroupObjectId = 'c12e51e3-5cbd-4229-8a31-5394c423fb5f'

--- a/.azure/infrastructure/test.bicepparam
+++ b/.azure/infrastructure/test.bicepparam
@@ -46,4 +46,5 @@ param serviceBusSku = {
   capacity: 1
 }
 
+// Altinn Product Dialogporten: Developers Dev
 param sshJumperAdminLoginGroupObjectId = 'c12e51e3-5cbd-4229-8a31-5394c423fb5f'

--- a/.azure/infrastructure/test.bicepparam
+++ b/.azure/infrastructure/test.bicepparam
@@ -46,4 +46,4 @@ param serviceBusSku = {
   capacity: 1
 }
 
-param vmAdminGroupObjectId = 'c12e51e3-5cbd-4229-8a31-5394c423fb5f'
+param sshJumperAdminLoginGroupObjectId = 'c12e51e3-5cbd-4229-8a31-5394c423fb5f'

--- a/.azure/infrastructure/test.bicepparam
+++ b/.azure/infrastructure/test.bicepparam
@@ -45,3 +45,5 @@ param serviceBusSku = {
   tier: 'Premium'
   capacity: 1
 }
+
+param vmAdminGroupObjectId = 'c12e51e3-5cbd-4229-8a31-5394c423fb5f'

--- a/.azure/modules/ssh-jumper/main.bicep
+++ b/.azure/modules/ssh-jumper/main.bicep
@@ -14,6 +14,9 @@ param tags object
 @secure()
 param sshPublicKey string
 
+@description('The object ID of the group to assign the VM Admin Login role')
+param vmAdminGroupObjectId string
+
 var name = '${namePrefix}-ssh-jumper'
 
 resource publicIp 'Microsoft.Network/publicIPAddresses@2023-11-01' = {
@@ -79,6 +82,7 @@ module virtualMachine '../../modules/virtualMachine/main.bicep' = {
     sshPublicKey: sshPublicKey
     location: location
     tags: tags
+    adminLoginADGroupObjectId: vmAdminGroupObjectId
     hardwareProfile: {
       vmSize: 'Standard_B1s'
     }

--- a/.azure/modules/ssh-jumper/main.bicep
+++ b/.azure/modules/ssh-jumper/main.bicep
@@ -14,8 +14,8 @@ param tags object
 @secure()
 param sshPublicKey string
 
-@description('The object ID of the group to assign the VM Admin Login role')
-param vmAdminGroupObjectId string
+@description('The object ID of the group to assign the Admin Login role for SSH Jumper')
+param adminLoginGroupObjectId string
 
 var name = '${namePrefix}-ssh-jumper'
 
@@ -82,7 +82,7 @@ module virtualMachine '../../modules/virtualMachine/main.bicep' = {
     sshPublicKey: sshPublicKey
     location: location
     tags: tags
-    adminLoginADGroupObjectId: vmAdminGroupObjectId
+    adminLoginGroupObjectId: adminLoginGroupObjectId
     hardwareProfile: {
       vmSize: 'Standard_B1s'
     }

--- a/.azure/modules/virtualMachine/main.bicep
+++ b/.azure/modules/virtualMachine/main.bicep
@@ -69,7 +69,7 @@ type StorageProfile = {
 param storageProfile StorageProfile
 
 @description('Specifies the AD group object ID for the virtual machine administrator login')
-param adminLoginADGroupObjectId string
+param adminLoginGroupObjectId string
 
 @description('Specifies the SSH public key for the virtual machine')
 @secure()
@@ -140,11 +140,11 @@ resource vmAdminLoginRoleDefinition 'Microsoft.Authorization/roleDefinitions@202
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(virtualMachine.id, adminLoginADGroupObjectId, vmAdminLoginRoleDefinition.id)
+  name: guid(virtualMachine.id, adminLoginGroupObjectId, vmAdminLoginRoleDefinition.id)
   scope: virtualMachine
   properties: {
     roleDefinitionId: vmAdminLoginRoleDefinition.id
-    principalId: adminLoginADGroupObjectId
+    principalId: adminLoginGroupObjectId
     principalType: 'Group'
   }
 }

--- a/.azure/modules/virtualMachine/main.bicep
+++ b/.azure/modules/virtualMachine/main.bicep
@@ -68,6 +68,9 @@ type StorageProfile = {
 @description('Specifies the storage profile for the virtual machine')
 param storageProfile StorageProfile
 
+@description('Specifies the AD group object ID for the virtual machine administrator login')
+param adminLoginADGroupObjectId string
+
 @description('Specifies the SSH public key for the virtual machine')
 @secure()
 param sshPublicKey string
@@ -127,5 +130,21 @@ resource aadLoginExtension 'Microsoft.Compute/virtualMachines/extensions@2024-07
     type: 'AADSSHLoginForLinux'
     typeHandlerVersion: '1.0'
     autoUpgradeMinorVersion: true
+  }
+}
+
+@description('This is the built-in Virtual Machine Administrator Login role. See https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#compute')
+resource vmAdminLoginRoleDefinition 'Microsoft.Authorization/roleDefinitions@2022-04-01' existing = {
+  scope: subscription()
+  name: '1c0163c0-47e6-4577-8991-ea5c82e286e4'
+}
+
+resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(virtualMachine.id, adminLoginADGroupObjectId, vmAdminLoginRoleDefinition.id)
+  scope: virtualMachine
+  properties: {
+    roleDefinitionId: vmAdminLoginRoleDefinition.id
+    principalId: adminLoginADGroupObjectId
+    principalType: 'Group'
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

There are two main AD-groups. One for test and one for prod (staging and prod). We add the role administrator login for these groups so developers can get in to the vnet

<!--- Describe your changes in detail -->

## Related Issue(s)

- #{issue number}

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced access control for SSH Jumper administration with new parameters for group management.
  - Introduced Azure Active Directory group-based administrator logins for virtual machines, improving security and access management.

- **Bug Fixes**
  - No specific bug fixes were mentioned in this release.

- **Documentation**
  - Updated parameter configurations for SSH Jumper and virtual machine modules to reflect new access control features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->