### PR TITLE
fix: Fix BaseUri on localhost trailing slash discrepancy on OAuth metadata

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/WellKnown/OauthAuthorizationServer/Queries/Get/GetOauthAuthorizationServerQuery.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/WellKnown/OauthAuthorizationServer/Queries/Get/GetOauthAuthorizationServerQuery.cs
@@ -17,10 +17,11 @@ internal sealed class GetOauthAuthorizationServerQueryHandler : IRequestHandler<
 
     public async Task<GetOauthAuthorizationServerDto> Handle(GetOauthAuthorizationServerQuery request, CancellationToken cancellationToken)
     {
+        var issuerUrl = _applicationSettings.Dialogporten.BaseUri.AbsoluteUri.TrimEnd('/') + "/api/v1";
         return await Task.FromResult(new GetOauthAuthorizationServerDto
         {
-            Issuer = _applicationSettings.Dialogporten.BaseUri + "api/v1",
-            JwksUri = _applicationSettings.Dialogporten.BaseUri + "api/v1/.well-known/jwks.json"
+            Issuer = issuerUrl,
+            JwksUri = $"{issuerUrl}/.well-known/jwks.json"
         });
     }
 }


### PR DESCRIPTION
## Description

This is the same issue as fixed for the `iss` claim in #1047 (trailing slash behaviour differs when BaseUri is localhost). Root cause not yet determined, but this functions as a workaround. 

## Related Issue(s)

- N/A

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved the construction of the `Issuer` and `JwksUri` properties for better readability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->