### PR TITLE
fix: Add missing events to dialog subscription

### DIFF
--- a/docs/schema/V1/schema.verified.graphql
+++ b/docs/schema/V1/schema.verified.graphql
@@ -132,8 +132,9 @@ type DialogByIdPayload {
   errors: [DialogByIdError!]!
 }
 
-type DialogUpdatedPayload {
+type DialogEventPayload {
   id: UUID!
+  type: DialogEventType!
 }
 
 type GuiAction {
@@ -211,7 +212,7 @@ type SeenLog {
 }
 
 type Subscriptions @authorize(policy: "enduser") {
-  dialogUpdated(dialogId: UUID!): DialogUpdatedPayload!
+  dialogEvents(dialogId: UUID!): DialogEventPayload!
 }
 
 type Transmission {
@@ -294,6 +295,11 @@ enum ApplyPolicy {
 enum AttachmentUrlConsumer {
   GUI
   API
+}
+
+enum DialogEventType {
+  DIALOG_UPDATED
+  DIALOG_DELETED
 }
 
 enum DialogStatus {

--- a/src/Digdir.Domain.Dialogporten.GraphQL/EndUser/DialogById/ObjectTypes.cs
+++ b/src/Digdir.Domain.Dialogporten.GraphQL/EndUser/DialogById/ObjectTypes.cs
@@ -201,7 +201,14 @@ public enum AttachmentUrlConsumer
     Api = 2
 }
 
-public sealed class DialogUpdatedPayload
+public sealed class DialogEventPayload
 {
     public Guid Id { get; set; }
+    public DialogEventType Type { get; set; }
+}
+
+public enum DialogEventType
+{
+    DialogUpdated = 1,
+    DialogDeleted = 2
 }

--- a/src/Digdir.Domain.Dialogporten.GraphQL/EndUser/DialogById/Subscriptions.cs
+++ b/src/Digdir.Domain.Dialogporten.GraphQL/EndUser/DialogById/Subscriptions.cs
@@ -14,7 +14,7 @@ public sealed class Subscriptions
     public DialogEventPayload DialogEvents(Guid dialogId,
         [EventMessage] DialogEventPayload eventMessage)
     {
-        Console.WriteLine(dialogId);
+        ArgumentNullException.ThrowIfNull(dialogId);
         ArgumentNullException.ThrowIfNull(eventMessage);
         return eventMessage;
     }

--- a/src/Digdir.Domain.Dialogporten.GraphQL/EndUser/DialogById/Subscriptions.cs
+++ b/src/Digdir.Domain.Dialogporten.GraphQL/EndUser/DialogById/Subscriptions.cs
@@ -10,11 +10,12 @@ namespace Digdir.Domain.Dialogporten.GraphQL.EndUser.DialogById;
 public sealed class Subscriptions
 {
     [Subscribe]
-    [Topic($"{Constants.DialogUpdatedTopic}{{{nameof(dialogId)}}}")]
-    public DialogUpdatedPayload DialogUpdated(Guid dialogId,
-        [EventMessage] Guid eventMessage)
+    [Topic($"{Constants.DialogEventsTopic}{{{nameof(dialogId)}}}")]
+    public DialogEventPayload DialogEvents(Guid dialogId,
+        [EventMessage] DialogEventPayload eventMessage)
     {
+        Console.WriteLine(dialogId);
         ArgumentNullException.ThrowIfNull(eventMessage);
-        return new DialogUpdatedPayload { Id = dialogId };
+        return eventMessage;
     }
 }

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/DomainEvents/Outbox/ConvertDomainEventsToOutboxMessagesInterceptor.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/DomainEvents/Outbox/ConvertDomainEventsToOutboxMessagesInterceptor.cs
@@ -1,6 +1,8 @@
 ﻿using Digdir.Domain.Dialogporten.Application.Common;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Events;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Events.Activities;
 using Digdir.Domain.Dialogporten.Domain.Outboxes;
+using Digdir.Domain.Dialogporten.Infrastructure.GraphQl;
 using Digdir.Library.Entity.Abstractions.Features.EventPublisher;
 using HotChocolate.Subscriptions;
 using Microsoft.EntityFrameworkCore.Diagnostics;
@@ -72,8 +74,28 @@ internal sealed class ConvertDomainEventsToOutboxMessagesInterceptor : SaveChang
                 var task = domainEvent switch
                 {
                     DialogUpdatedDomainEvent dialogUpdatedDomainEvent => _topicEventSender.SendAsync(
-                        $"{Constants.DialogUpdatedTopic}{dialogUpdatedDomainEvent.DialogId}",
-                        dialogUpdatedDomainEvent.DialogId,
+                        $"{Constants.DialogEventsTopic}{dialogUpdatedDomainEvent.DialogId}",
+                        new DialogEventPayload
+                        {
+                            Id = dialogUpdatedDomainEvent.DialogId,
+                            Type = DialogEventType.DialogUpdated
+                        },
+                        cancellationToken),
+                    DialogDeletedDomainEvent dialogDeletedDomainEvent => _topicEventSender.SendAsync(
+                        $"{Constants.DialogEventsTopic}{dialogDeletedDomainEvent.DialogId}",
+                        new DialogEventPayload
+                        {
+                            Id = dialogDeletedDomainEvent.DialogId,
+                            Type = DialogEventType.DialogDeleted
+                        },
+                        cancellationToken),
+                    DialogActivityCreatedDomainEvent dialogActivityCreatedDomainEvent => _topicEventSender.SendAsync(
+                        $"{Constants.DialogEventsTopic}{dialogActivityCreatedDomainEvent.DialogId}",
+                        new DialogEventPayload
+                        {
+                            Id = dialogActivityCreatedDomainEvent.DialogId,
+                            Type = DialogEventType.DialogUpdated
+                        },
                         cancellationToken),
                     _ => ValueTask.CompletedTask
                 };

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/GraphQL/DialogEventPayload.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/GraphQL/DialogEventPayload.cs
@@ -1,0 +1,13 @@
+namespace Digdir.Domain.Dialogporten.Infrastructure.GraphQl;
+
+internal struct DialogEventPayload
+{
+    public Guid Id { get; set; }
+    public DialogEventType Type { get; set; }
+}
+
+internal enum DialogEventType
+{
+    DialogUpdated = 1,
+    DialogDeleted = 2
+}

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/GraphQL/GraphQlSubscriptionConstants.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/GraphQL/GraphQlSubscriptionConstants.cs
@@ -3,5 +3,5 @@ namespace Digdir.Domain.Dialogporten.Infrastructure.GraphQl;
 public static class GraphQlSubscriptionConstants
 {
     public const string SubscriptionTopicPrefix = "graphql_subscriptions_";
-    public const string DialogUpdatedTopic = "dialogUpdated/";
+    public const string DialogEventsTopic = "dialogEvents/";
 }

--- a/tests/Digdir.Domain.Dialogporten.Architecture.Tests/InfrastructureArchitectureTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Architecture.Tests/InfrastructureArchitectureTests.cs
@@ -15,7 +15,7 @@ public class InfrastructureArchitectureTests
         {
             nameof(InfrastructureAssemblyMarker),
             nameof(InfrastructureExtensions),
-            
+
             // These classes are currently public, but should be internal, moved to another assembly, or deleted
             nameof(OutboxScheduler),
             nameof(IUpstreamServiceError)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
The DialogUpdated GraphQL subscription is not triggered when an activity is added, or when the dialog is deleted

* Rename subscription to "dialogEvents"
* Add type field, values are "DialogUpdated" and "DialogDeleted"

## Related Issue(s)

- #1162

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `DialogEventPayload` structure to handle dialog events, including updates and deletions.
	- Updated subscriptions to reflect the new event handling mechanism.

- **Bug Fixes**
	- Renamed and expanded dialog event handling to improve clarity and functionality.

- **Chores**
	- Renamed constants for event topics to better represent the scope of dialog events. 

- **Tests**
	- Minor adjustments in architecture tests for internal class visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->