### PR TITLE
fix: Add separate settings for parties cache, don't cache invalid response from Altinn 2

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Common/Exceptions/UpstreamServiceException.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Common/Exceptions/UpstreamServiceException.cs
@@ -1,5 +1,8 @@
 namespace Digdir.Domain.Dialogporten.Infrastructure.Common.Exceptions;
 
 public interface IUpstreamServiceError;
-internal sealed class UpstreamServiceException(Exception innerException)
-    : Exception(innerException.Message, innerException), IUpstreamServiceError;
+internal sealed class UpstreamServiceException : Exception, IUpstreamServiceError
+{
+    public UpstreamServiceException(Exception innerException) : base(innerException.Message, innerException) { }
+    public UpstreamServiceException(string message) : base(message) { }
+}

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/InfrastructureExtensions.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/InfrastructureExtensions.cs
@@ -112,6 +112,23 @@ public static class InfrastructureExtensions
             // Timeout for the cache to wait for the factory to complete, which when reached without fail-safe data
             // will cause an exception to be thrown
             FactoryHardTimeout = TimeSpan.FromSeconds(10)
+        })
+        .ConfigureFusionCache(nameof(AuthorizedPartiesResult), new()
+        {
+            // We keep authorized parties in a separate cache key, as this originates from a different API
+            // and has lees cardinality than the dialog authorization cache (only one per user). We therefore
+            // allow a memory cache for this.
+            Duration = TimeSpan.FromMinutes(15),
+            // In case Altinn Access Management is down/overloaded, we allow the re-usage of stale authorization data
+            // for an additional 15 minutes. Using default FailSafeThrottleDuration.
+            FailSafeMaxDuration = TimeSpan.FromMinutes(30),
+            // If the request to Altinn AccessManagement takes too long, we allow the cache to return stale data
+            // temporarily whilst updating the cache in the background. Note that we are also using eager refresh
+            // and a backplane.
+            FactorySoftTimeout = TimeSpan.FromSeconds(2),
+            // Timeout for the cache to wait for the factory to complete, which when reached without fail-safe data
+            // will cause an exception to be thrown
+            FactoryHardTimeout = TimeSpan.FromSeconds(10)
         });
 
         services.AddDbContext<DialogDbContext>((services, options) =>


### PR DESCRIPTION
## Description

Currently, if the user is missing a profile in Altinn 2, the reportee list returned from all auth/am APIs are empty. This is an error condition, so we treat it as such and don't cache the empty response.

Also, this introduces a separate cache setting for parties, as this does not have the cardinality issues as the PDP cache, allowing us to utilize memory cache for this. 

## Related Issue(s)

- N/A

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced caching mechanism for authorized parties, improving performance and response times.
	- Introduced a new exception handling mechanism for upstream service errors.

- **Bug Fixes**
	- Improved error handling in the `UpstreamServiceException` class to allow custom messages.

- **Documentation**
	- Updated configuration parameters for caching authorized parties to ensure clarity on retention and timeout settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->