### PR TITLE
chore: Add transmission content values test

### DIFF
--- a/src/Digdir.Tool.Dialogporten.GenerateFakeData/DialogGenerator.cs
+++ b/src/Digdir.Tool.Dialogporten.GenerateFakeData/DialogGenerator.cs
@@ -36,7 +36,8 @@ public static class DialogGenerator
         List<CreateDialogDialogAttachmentDto>? attachments = null,
         List<CreateDialogDialogGuiActionDto>? guiActions = null,
         List<CreateDialogDialogApiActionDto>? apiActions = null,
-        List<CreateDialogDialogActivityDto>? activities = null)
+        List<CreateDialogDialogActivityDto>? activities = null,
+        List<CreateDialogDialogTransmissionDto>? transmissions = null)
     {
         return GenerateFakeDialogs(
             seed,
@@ -60,12 +61,12 @@ public static class DialogGenerator
             attachments,
             guiActions,
             apiActions,
-            activities
+            activities,
+            transmissions
         )[0];
     }
 
-    public static List<CreateDialogCommand> GenerateFakeDialogs(
-        int? seed = null,
+    public static List<CreateDialogCommand> GenerateFakeDialogs(int? seed = null,
         int count = 1,
         Guid? id = null,
         string? serviceResource = null,
@@ -86,7 +87,8 @@ public static class DialogGenerator
         List<CreateDialogDialogAttachmentDto>? attachments = null,
         List<CreateDialogDialogGuiActionDto>? guiActions = null,
         List<CreateDialogDialogApiActionDto>? apiActions = null,
-        List<CreateDialogDialogActivityDto>? activities = null)
+        List<CreateDialogDialogActivityDto>? activities = null,
+        List<CreateDialogDialogTransmissionDto>? transmissions = null)
     {
         Randomizer.Seed = seed.HasValue ? new Random(seed.Value) : new Random();
         return new Faker<CreateDialogCommand>()
@@ -108,6 +110,7 @@ public static class DialogGenerator
             .RuleFor(o => o.ApiActions, _ => apiActions ?? GenerateFakeDialogApiActions())
             .RuleFor(o => o.Activities, _ => activities ?? GenerateFakeDialogActivities())
             .RuleFor(o => o.Process, f => process ?? GenerateFakeProcessUri())
+            .RuleFor(o => o.Transmissions, f => transmissions ?? GenerateFakeDialogTransmissions())
             .Generate(count);
     }
 
@@ -121,7 +124,8 @@ public static class DialogGenerator
             attachments: [],
             guiActions: [],
             apiActions: [],
-            searchTags: []);
+            searchTags: [],
+            transmissions: []);
     }
 
     public static string GenerateFakeResource(Func<string?>? generator = null)

--- a/src/Digdir.Tool.Dialogporten.GenerateFakeData/Program.cs
+++ b/src/Digdir.Tool.Dialogporten.GenerateFakeData/Program.cs
@@ -35,9 +35,7 @@ public static class Program
             Randomizer.Seed = new Random(options.Seed);
             var dialogs = DialogGenerator.GenerateFakeDialogs(
                 seed: new Randomizer().Number(int.MaxValue),
-                serviceResourceGenerator: () => MaybeGetRandomResource(options),
-                partyGenerator: () => MaybeGetRandomParty(options),
-                count: options.Count);
+                count: options.Count, serviceResourceGenerator: () => MaybeGetRandomResource(options), partyGenerator: () => MaybeGetRandomParty(options));
             var serialized = JsonSerializer.Serialize(dialogs, JsonSerializerOptions);
             Console.WriteLine(serialized);
             return;
@@ -118,9 +116,7 @@ public static class Program
             var dialogsToGenerate = Math.Min(DialogsPerBatch, totalDialogs - dialogCounter);
             var dialogs = DialogGenerator.GenerateFakeDialogs(
                 seed: new Randomizer().Number(int.MaxValue),
-                serviceResourceGenerator: () => MaybeGetRandomResource(options),
-                partyGenerator: () => MaybeGetRandomParty(options),
-                count: dialogsToGenerate).Take(dialogsToGenerate);
+                count: dialogsToGenerate, serviceResourceGenerator: () => MaybeGetRandomResource(options), partyGenerator: () => MaybeGetRandomParty(options)).Take(dialogsToGenerate);
             foreach (var dialog in dialogs)
             {
                 dialogQueue.Add((dialogCounter + 1, dialog), cancellationToken);

--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/ServiceOwner/Dialogs/Commands/CreateDialogTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/ServiceOwner/Dialogs/Commands/CreateDialogTests.cs
@@ -1,4 +1,5 @@
-﻿using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Localizations;
+﻿using Castle.Core.Logging;
+using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Localizations;
 using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialogs.Queries.Get;
 using Digdir.Domain.Dialogporten.Application.Integration.Tests.Common;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Transmissions;
@@ -204,6 +205,26 @@ public class CreateDialogTests : ApplicationCollectionFixture
         // Assert
         response.TryPickT0(out var success, out _).Should().BeTrue();
         success.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task Cannot_Create_Transmission_Without_Content()
+    {
+        // Arrange
+        var transmission = DialogGenerator.GenerateFakeDialogTransmissions(1)[0];
+        transmission.Content = null!;
+
+        var createDialogCommand = DialogGenerator.GenerateSimpleFakeDialog();
+        createDialogCommand.Transmissions = [transmission];
+
+        // Act
+        var response = await Application.Send(createDialogCommand);
+
+        // Assert
+        response.TryPickT2(out var validationError, out _).Should().BeTrue();
+        validationError.Should().NotBeNull();
+        validationError.Errors.Should().HaveCount(1);
+        validationError.Errors.First().ErrorMessage.Should().Contain("'Content' must not be empty");
     }
 
     [Fact]

--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/ServiceOwner/Dialogs/Commands/CreateDialogTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/ServiceOwner/Dialogs/Commands/CreateDialogTests.cs
@@ -1,5 +1,7 @@
-﻿using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialogs.Queries.Get;
+﻿using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Localizations;
+using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialogs.Queries.Get;
 using Digdir.Domain.Dialogporten.Application.Integration.Tests.Common;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Transmissions;
 using Digdir.Tool.Dialogporten.GenerateFakeData;
 using FluentAssertions;
 using static Digdir.Domain.Dialogporten.Application.Integration.Tests.UuiDv7Utils;
@@ -202,5 +204,51 @@ public class CreateDialogTests : ApplicationCollectionFixture
         // Assert
         response.TryPickT0(out var success, out _).Should().BeTrue();
         success.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task Cannot_Create_Transmission_Without_Content_Value()
+    {
+        // Arrange
+        var transmission = DialogGenerator.GenerateFakeDialogTransmissions(1)[0];
+        transmission.Content.Summary.Value = [];
+        transmission.Content.Title.Value = [];
+
+        var createDialogCommand = DialogGenerator.GenerateSimpleFakeDialog();
+        createDialogCommand.Transmissions = [transmission];
+
+        // Act
+        var response = await Application.Send(createDialogCommand);
+
+        // Assert
+        response.TryPickT2(out var validationError, out _).Should().BeTrue();
+        validationError.Should().NotBeNull();
+        validationError.Errors
+            .Count(e => e.PropertyName.Contains(nameof(createDialogCommand.Content)))
+            .Should()
+            .Be(2);
+    }
+
+    [Fact]
+    public async Task Cannot_Create_Transmission_With_Empty_Content_Localization_Values()
+    {
+        // Arrange
+        var transmission = DialogGenerator.GenerateFakeDialogTransmissions(1)[0];
+        transmission.Content.Summary.Value = [new LocalizationDto { LanguageCode = "nb", Value = "" }];
+        transmission.Content.Title.Value = [new LocalizationDto { LanguageCode = "nb", Value = "" }];
+
+        var createDialogCommand = DialogGenerator.GenerateSimpleFakeDialog();
+        createDialogCommand.Transmissions = [transmission];
+
+        // Act
+        var response = await Application.Send(createDialogCommand);
+
+        // Assert
+        response.TryPickT2(out var validationError, out _).Should().BeTrue();
+        validationError.Should().NotBeNull();
+        validationError.Errors
+            .Count(e => e.PropertyName.Contains(nameof(createDialogCommand.Content)))
+            .Should()
+            .Be(2);
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adding test for required content on transmissions

## Related Issue(s)

- #1197 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for generating fake dialog transmissions with new parameters in dialog generation methods.

- **Bug Fixes**
	- Introduced validation tests to ensure that dialog transmissions cannot be created without required content values.

- **Tests**
	- Added new test cases to validate the creation of dialog transmissions under specific conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->