### PR TITLE
chore: Install jq if missing in revision check

### DIFF
--- a/.github/tools/revisionVerifier.sh
+++ b/.github/tools/revisionVerifier.sh
@@ -1,3 +1,10 @@
+if ! command -v jq 2>&1 >/dev/null
+then
+    echo "jq could not be found, attempting to install from tdnf ..."
+    tdnf install -y jq
+fi
+
+
 if [ -z "$1" ]; then
   echo "Usage: $0 <revision-name>"
   exit 1
@@ -14,10 +21,11 @@ query_filter="{name:name, runningState:properties.runningState, healthState:prop
 
 verify_revision() {
   local json_output
-  
+
   # Fetch app revision
   json_output=$(az containerapp revision show -g "$resource_group" --revision "$revision_name" --query "$query_filter" 2>/dev/null)
-  
+
+
   health_state=$(echo $json_output | jq -r '.healthState')
   running_state=$(echo $json_output | jq -r '.runningState')
 
@@ -26,7 +34,7 @@ verify_revision() {
   echo "Health state: $health_state"
   echo "Running state: $running_state"
   echo " "
-  
+
   # Check health and running status
   if [[ $health_state == "Healthy" && ($running_state == "Running" || $running_state == "RunningAtMaxScale") ]]; then
     return 0  # OK!

--- a/.github/tools/revisionVerifier.sh
+++ b/.github/tools/revisionVerifier.sh
@@ -4,7 +4,6 @@ then
     tdnf install -y jq
 fi
 
-
 if [ -z "$1" ]; then
   echo "Usage: $0 <revision-name>"
   exit 1
@@ -24,7 +23,6 @@ verify_revision() {
 
   # Fetch app revision
   json_output=$(az containerapp revision show -g "$resource_group" --revision "$revision_name" --query "$query_filter" 2>/dev/null)
-
 
   health_state=$(echo $json_output | jq -r '.healthState')
   running_state=$(echo $json_output | jq -r '.runningState')


### PR DESCRIPTION
https://github.com/Azure/azure-cli/issues/29830

jq was removed when they switched base image on the az cli

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved the `revisionVerifier.sh` script to check for the `jq` tool and attempt installation if missing.
	- Enhanced script readability by removing unnecessary blank lines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->