### PR TITLE
ci: ensure unique revisions for deployments

### DIFF
--- a/.azure/applications/graphql/main.bicep
+++ b/.azure/applications/graphql/main.bicep
@@ -16,6 +16,10 @@ param location string
 @minLength(3)
 param apimIp string
 
+@description('The suffix for the revision of the container app')
+@minLength(3)
+param revisionSuffix string
+
 @description('CPU and memory resources for the container app')
 param resources object?
 
@@ -87,7 +91,7 @@ module containerApp '../../modules/containerApp/main.bicep' = {
     apimIp: apimIp
     tags: tags
     resources: resources
-    revisionSuffix: imageTag
+    revisionSuffix: revisionSuffix
   }
 }
 

--- a/.azure/applications/graphql/prod.bicepparam
+++ b/.azure/applications/graphql/prod.bicepparam
@@ -4,6 +4,7 @@ param environment = 'prod'
 param location = 'norwayeast'
 param apimIp = '51.120.88.54'
 param imageTag = readEnvironmentVariable('IMAGE_TAG')
+param revisionSuffix = readEnvironmentVariable('REVISION_SUFFIX')
 
 // secrets
 param environmentKeyVaultName = readEnvironmentVariable('AZURE_ENVIRONMENT_KEY_VAULT_NAME')

--- a/.azure/applications/graphql/staging.bicepparam
+++ b/.azure/applications/graphql/staging.bicepparam
@@ -4,6 +4,7 @@ param environment = 'staging'
 param location = 'norwayeast'
 param apimIp = '51.13.86.131'
 param imageTag = readEnvironmentVariable('IMAGE_TAG')
+param revisionSuffix = readEnvironmentVariable('REVISION_SUFFIX')
 
 // secrets
 param environmentKeyVaultName = readEnvironmentVariable('AZURE_ENVIRONMENT_KEY_VAULT_NAME')

--- a/.azure/applications/graphql/test.bicepparam
+++ b/.azure/applications/graphql/test.bicepparam
@@ -4,6 +4,7 @@ param environment = 'test'
 param location = 'norwayeast'
 param apimIp = '51.120.88.69'
 param imageTag = readEnvironmentVariable('IMAGE_TAG')
+param revisionSuffix = readEnvironmentVariable('REVISION_SUFFIX')
 
 // secrets
 param environmentKeyVaultName = readEnvironmentVariable('AZURE_ENVIRONMENT_KEY_VAULT_NAME')

--- a/.azure/applications/web-api-eu/main.bicep
+++ b/.azure/applications/web-api-eu/main.bicep
@@ -16,6 +16,10 @@ param location string
 @minLength(3)
 param apimIp string
 
+@description('The suffix for the revision of the container app')
+@minLength(3)
+param revisionSuffix string
+
 @description('CPU and memory resources for the container app')
 param resources object?
 
@@ -90,7 +94,7 @@ module containerApp '../../modules/containerApp/main.bicep' = {
     apimIp: apimIp
     tags: tags
     resources: resources
-    revisionSuffix: imageTag
+    revisionSuffix: revisionSuffix
   }
 }
 

--- a/.azure/applications/web-api-eu/prod.bicepparam
+++ b/.azure/applications/web-api-eu/prod.bicepparam
@@ -4,6 +4,7 @@ param environment = 'prod'
 param location = 'norwayeast'
 param apimIp = '51.120.88.54'
 param imageTag = readEnvironmentVariable('IMAGE_TAG')
+param revisionSuffix = readEnvironmentVariable('REVISION_SUFFIX')
 
 // secrets
 param environmentKeyVaultName = readEnvironmentVariable('AZURE_ENVIRONMENT_KEY_VAULT_NAME')

--- a/.azure/applications/web-api-eu/staging.bicepparam
+++ b/.azure/applications/web-api-eu/staging.bicepparam
@@ -4,6 +4,7 @@ param environment = 'staging'
 param location = 'norwayeast'
 param apimIp = '51.13.86.131'
 param imageTag = readEnvironmentVariable('IMAGE_TAG')
+param revisionSuffix = readEnvironmentVariable('REVISION_SUFFIX')
 
 // secrets
 param environmentKeyVaultName = readEnvironmentVariable('AZURE_ENVIRONMENT_KEY_VAULT_NAME')

--- a/.azure/applications/web-api-eu/test.bicepparam
+++ b/.azure/applications/web-api-eu/test.bicepparam
@@ -4,6 +4,7 @@ param environment = 'test'
 param location = 'norwayeast'
 param apimIp = '51.120.88.69'
 param imageTag = readEnvironmentVariable('IMAGE_TAG')
+param revisionSuffix = readEnvironmentVariable('REVISION_SUFFIX')
 
 // secrets
 param environmentKeyVaultName = readEnvironmentVariable('AZURE_ENVIRONMENT_KEY_VAULT_NAME')

--- a/.azure/applications/web-api-so/main.bicep
+++ b/.azure/applications/web-api-so/main.bicep
@@ -16,6 +16,10 @@ param location string
 @minLength(3)
 param apimIp string
 
+@description('The suffix for the revision of the container app')
+@minLength(3)
+param revisionSuffix string
+
 @description('CPU and memory resources for the container app')
 param resources object?
 

--- a/.azure/applications/web-api-so/main.bicep
+++ b/.azure/applications/web-api-so/main.bicep
@@ -98,7 +98,7 @@ module containerApp '../../modules/containerApp/main.bicep' = {
     apimIp: apimIp
     tags: tags
     resources: resources
-    revisionSuffix: imageTag
+    revisionSuffix: revisionSuffix
   }
 }
 

--- a/.azure/applications/web-api-so/prod.bicepparam
+++ b/.azure/applications/web-api-so/prod.bicepparam
@@ -4,6 +4,7 @@ param environment = 'prod'
 param location = 'norwayeast'
 param apimIp = '51.120.88.54'
 param imageTag = readEnvironmentVariable('IMAGE_TAG')
+param revisionSuffix = readEnvironmentVariable('REVISION_SUFFIX')
 
 // secrets
 param environmentKeyVaultName = readEnvironmentVariable('AZURE_ENVIRONMENT_KEY_VAULT_NAME')

--- a/.azure/applications/web-api-so/staging.bicepparam
+++ b/.azure/applications/web-api-so/staging.bicepparam
@@ -4,6 +4,7 @@ param environment = 'staging'
 param location = 'norwayeast'
 param apimIp = '51.13.86.131'
 param imageTag = readEnvironmentVariable('IMAGE_TAG')
+param revisionSuffix = readEnvironmentVariable('REVISION_SUFFIX')
 
 // secrets
 param environmentKeyVaultName = readEnvironmentVariable('AZURE_ENVIRONMENT_KEY_VAULT_NAME')

--- a/.azure/applications/web-api-so/test.bicepparam
+++ b/.azure/applications/web-api-so/test.bicepparam
@@ -4,6 +4,7 @@ param environment = 'test'
 param location = 'norwayeast'
 param apimIp = '51.120.88.69'
 param imageTag = readEnvironmentVariable('IMAGE_TAG')
+param revisionSuffix = readEnvironmentVariable('REVISION_SUFFIX')
 
 // secrets
 param environmentKeyVaultName = readEnvironmentVariable('AZURE_ENVIRONMENT_KEY_VAULT_NAME')

--- a/.github/workflows/action-deploy-apps.yml
+++ b/.github/workflows/action-deploy-apps.yml
@@ -75,7 +75,6 @@ jobs:
         env:
           # parameters
           IMAGE_TAG: ${{ inputs.version }}
-          REVISION_SUFFIX: "${{ github.run_id }}-${{ inputs.version }}-${{ github.run_attempt}}"
           # secrets
           AZURE_CONTAINER_APP_ENVIRONMENT_NAME: ${{ secrets.AZURE_CONTAINER_APP_ENVIRONMENT_NAME }}
           AZURE_ENVIRONMENT_KEY_VAULT_NAME: ${{ secrets.AZURE_ENVIRONMENT_KEY_VAULT_NAME }}
@@ -97,7 +96,6 @@ jobs:
         env:
           # parameters
           IMAGE_TAG: ${{ inputs.version }}
-          REVISION_SUFFIX: "${{ github.run_id }}-${{ inputs.version }}-${{ github.run_attempt}}"
           # secrets
           AZURE_CONTAINER_APP_ENVIRONMENT_NAME: ${{ secrets.AZURE_CONTAINER_APP_ENVIRONMENT_NAME }}
           AZURE_ENVIRONMENT_KEY_VAULT_NAME: ${{ secrets.AZURE_ENVIRONMENT_KEY_VAULT_NAME }}
@@ -256,7 +254,6 @@ jobs:
         env:
           # parameters
           IMAGE_TAG: ${{ inputs.version }}
-          REVISION_SUFFIX: "${{ github.run_id }}-${{ inputs.version }}-${{ github.run_attempt}}"
           # secrets
           AZURE_CONTAINER_APP_ENVIRONMENT_NAME: ${{ secrets.AZURE_CONTAINER_APP_ENVIRONMENT_NAME }}
           AZURE_ENVIRONMENT_KEY_VAULT_NAME: ${{ secrets.AZURE_ENVIRONMENT_KEY_VAULT_NAME }}
@@ -279,7 +276,6 @@ jobs:
         env:
           # parameters
           IMAGE_TAG: ${{ inputs.version }}
-          REVISION_SUFFIX: "${{ github.run_id }}-${{ inputs.version }}-${{ github.run_attempt}}"
           # secrets
           AZURE_CONTAINER_APP_ENVIRONMENT_NAME: ${{ secrets.AZURE_CONTAINER_APP_ENVIRONMENT_NAME }}
           AZURE_ENVIRONMENT_KEY_VAULT_NAME: ${{ secrets.AZURE_ENVIRONMENT_KEY_VAULT_NAME }}

--- a/.github/workflows/action-deploy-apps.yml
+++ b/.github/workflows/action-deploy-apps.yml
@@ -75,7 +75,7 @@ jobs:
         env:
           # parameters
           IMAGE_TAG: ${{ inputs.version }}
-          REVISION_SUFFIX: "${{ inputs.version }}-${{ github.run_id }}-${{ github.run_attempt}}"
+          REVISION_SUFFIX: "${{ github.run_id }}-${{ inputs.version }}-${{ github.run_attempt}}"
           # secrets
           AZURE_CONTAINER_APP_ENVIRONMENT_NAME: ${{ secrets.AZURE_CONTAINER_APP_ENVIRONMENT_NAME }}
           AZURE_ENVIRONMENT_KEY_VAULT_NAME: ${{ secrets.AZURE_ENVIRONMENT_KEY_VAULT_NAME }}
@@ -97,7 +97,7 @@ jobs:
         env:
           # parameters
           IMAGE_TAG: ${{ inputs.version }}
-          REVISION_SUFFIX: "${{ inputs.version }}-${{ github.run_id }}-${{ github.run_attempt}}"
+          REVISION_SUFFIX: "${{ github.run_id }}-${{ inputs.version }}-${{ github.run_attempt}}"
           # secrets
           AZURE_CONTAINER_APP_ENVIRONMENT_NAME: ${{ secrets.AZURE_CONTAINER_APP_ENVIRONMENT_NAME }}
           AZURE_ENVIRONMENT_KEY_VAULT_NAME: ${{ secrets.AZURE_ENVIRONMENT_KEY_VAULT_NAME }}
@@ -168,7 +168,7 @@ jobs:
         env:
           # parameters
           IMAGE_TAG: ${{ inputs.version }}
-          REVISION_SUFFIX: "${{ inputs.version }}-${{ github.run_id }}-${{ github.run_attempt}}"
+          REVISION_SUFFIX: "${{ github.run_id }}-${{ inputs.version }}-${{ github.run_attempt}}"
           # secrets
           AZURE_CONTAINER_APP_ENVIRONMENT_NAME: ${{ secrets.AZURE_CONTAINER_APP_ENVIRONMENT_NAME }}
           AZURE_APP_INSIGHTS_CONNECTION_STRING: ${{ secrets.AZURE_APP_INSIGHTS_CONNECTION_STRING }}
@@ -192,7 +192,7 @@ jobs:
         env:
           # parameters
           IMAGE_TAG: ${{ inputs.version }}
-          REVISION_SUFFIX: "${{ inputs.version }}-${{ github.run_id }}-${{ github.run_attempt}}"
+          REVISION_SUFFIX: "${{ github.run_id }}-${{ inputs.version }}-${{ github.run_attempt}}"
           # secrets
           AZURE_CONTAINER_APP_ENVIRONMENT_NAME: ${{ secrets.AZURE_CONTAINER_APP_ENVIRONMENT_NAME }}
           AZURE_APP_INSIGHTS_CONNECTION_STRING: ${{ secrets.AZURE_APP_INSIGHTS_CONNECTION_STRING }}
@@ -256,7 +256,7 @@ jobs:
         env:
           # parameters
           IMAGE_TAG: ${{ inputs.version }}
-          REVISION_SUFFIX: "${{ inputs.version }}-${{ github.run_id }}-${{ github.run_attempt}}"
+          REVISION_SUFFIX: "${{ github.run_id }}-${{ inputs.version }}-${{ github.run_attempt}}"
           # secrets
           AZURE_CONTAINER_APP_ENVIRONMENT_NAME: ${{ secrets.AZURE_CONTAINER_APP_ENVIRONMENT_NAME }}
           AZURE_ENVIRONMENT_KEY_VAULT_NAME: ${{ secrets.AZURE_ENVIRONMENT_KEY_VAULT_NAME }}
@@ -279,7 +279,7 @@ jobs:
         env:
           # parameters
           IMAGE_TAG: ${{ inputs.version }}
-          REVISION_SUFFIX: "${{ inputs.version }}-${{ github.run_id }}-${{ github.run_attempt}}"
+          REVISION_SUFFIX: "${{ github.run_id }}-${{ inputs.version }}-${{ github.run_attempt}}"
           # secrets
           AZURE_CONTAINER_APP_ENVIRONMENT_NAME: ${{ secrets.AZURE_CONTAINER_APP_ENVIRONMENT_NAME }}
           AZURE_ENVIRONMENT_KEY_VAULT_NAME: ${{ secrets.AZURE_ENVIRONMENT_KEY_VAULT_NAME }}

--- a/.github/workflows/action-deploy-apps.yml
+++ b/.github/workflows/action-deploy-apps.yml
@@ -149,6 +149,8 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    env:
+      REVISION_SUFFIX: "${{ github.run_id }}-${{ inputs.version }}-${{ github.run_attempt}}"
     steps:
       - name: "Checkout GitHub Action"
         uses: actions/checkout@v4
@@ -166,7 +168,7 @@ jobs:
         env:
           # parameters
           IMAGE_TAG: ${{ inputs.version }}
-          REVISION_SUFFIX: "${{ github.run_id }}-${{ inputs.version }}-${{ github.run_attempt}}"
+          REVISION_SUFFIX: ${{ env.REVISION_SUFFIX }}
           # secrets
           AZURE_CONTAINER_APP_ENVIRONMENT_NAME: ${{ secrets.AZURE_CONTAINER_APP_ENVIRONMENT_NAME }}
           AZURE_APP_INSIGHTS_CONNECTION_STRING: ${{ secrets.AZURE_APP_INSIGHTS_CONNECTION_STRING }}
@@ -190,7 +192,7 @@ jobs:
         env:
           # parameters
           IMAGE_TAG: ${{ inputs.version }}
-          REVISION_SUFFIX: "${{ github.run_id }}-${{ inputs.version }}-${{ github.run_attempt}}"
+          REVISION_SUFFIX: ${{ env.REVISION_SUFFIX }}
           # secrets
           AZURE_CONTAINER_APP_ENVIRONMENT_NAME: ${{ secrets.AZURE_CONTAINER_APP_ENVIRONMENT_NAME }}
           AZURE_APP_INSIGHTS_CONNECTION_STRING: ${{ secrets.AZURE_APP_INSIGHTS_CONNECTION_STRING }}

--- a/.github/workflows/action-deploy-apps.yml
+++ b/.github/workflows/action-deploy-apps.yml
@@ -75,6 +75,7 @@ jobs:
         env:
           # parameters
           IMAGE_TAG: ${{ inputs.version }}
+          REVISION_SUFFIX: "${{ inputs.version }}-${{ github.run_id }}-${{ github.run_attempt}}"
           # secrets
           AZURE_CONTAINER_APP_ENVIRONMENT_NAME: ${{ secrets.AZURE_CONTAINER_APP_ENVIRONMENT_NAME }}
           AZURE_ENVIRONMENT_KEY_VAULT_NAME: ${{ secrets.AZURE_ENVIRONMENT_KEY_VAULT_NAME }}
@@ -96,6 +97,7 @@ jobs:
         env:
           # parameters
           IMAGE_TAG: ${{ inputs.version }}
+          REVISION_SUFFIX: "${{ inputs.version }}-${{ github.run_id }}-${{ github.run_attempt}}"
           # secrets
           AZURE_CONTAINER_APP_ENVIRONMENT_NAME: ${{ secrets.AZURE_CONTAINER_APP_ENVIRONMENT_NAME }}
           AZURE_ENVIRONMENT_KEY_VAULT_NAME: ${{ secrets.AZURE_ENVIRONMENT_KEY_VAULT_NAME }}
@@ -159,7 +161,6 @@ jobs:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
       - name: Dryrun Deploy app ${{ matrix.name }}(${{ inputs.environment }})
         uses: azure/arm-deploy@v2
         if: ${{ inputs.dryRun }}
@@ -167,6 +168,7 @@ jobs:
         env:
           # parameters
           IMAGE_TAG: ${{ inputs.version }}
+          REVISION_SUFFIX: "${{ inputs.version }}-${{ github.run_id }}-${{ github.run_attempt}}"
           # secrets
           AZURE_CONTAINER_APP_ENVIRONMENT_NAME: ${{ secrets.AZURE_CONTAINER_APP_ENVIRONMENT_NAME }}
           AZURE_APP_INSIGHTS_CONNECTION_STRING: ${{ secrets.AZURE_APP_INSIGHTS_CONNECTION_STRING }}
@@ -190,6 +192,7 @@ jobs:
         env:
           # parameters
           IMAGE_TAG: ${{ inputs.version }}
+          REVISION_SUFFIX: "${{ inputs.version }}-${{ github.run_id }}-${{ github.run_attempt}}"
           # secrets
           AZURE_CONTAINER_APP_ENVIRONMENT_NAME: ${{ secrets.AZURE_CONTAINER_APP_ENVIRONMENT_NAME }}
           AZURE_APP_INSIGHTS_CONNECTION_STRING: ${{ secrets.AZURE_APP_INSIGHTS_CONNECTION_STRING }}
@@ -253,6 +256,7 @@ jobs:
         env:
           # parameters
           IMAGE_TAG: ${{ inputs.version }}
+          REVISION_SUFFIX: "${{ inputs.version }}-${{ github.run_id }}-${{ github.run_attempt}}"
           # secrets
           AZURE_CONTAINER_APP_ENVIRONMENT_NAME: ${{ secrets.AZURE_CONTAINER_APP_ENVIRONMENT_NAME }}
           AZURE_ENVIRONMENT_KEY_VAULT_NAME: ${{ secrets.AZURE_ENVIRONMENT_KEY_VAULT_NAME }}
@@ -275,6 +279,7 @@ jobs:
         env:
           # parameters
           IMAGE_TAG: ${{ inputs.version }}
+          REVISION_SUFFIX: "${{ inputs.version }}-${{ github.run_id }}-${{ github.run_attempt}}"
           # secrets
           AZURE_CONTAINER_APP_ENVIRONMENT_NAME: ${{ secrets.AZURE_CONTAINER_APP_ENVIRONMENT_NAME }}
           AZURE_ENVIRONMENT_KEY_VAULT_NAME: ${{ secrets.AZURE_ENVIRONMENT_KEY_VAULT_NAME }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

There was an issue where if we re-run the same workflow for deployment, it would fail because of using the same revision suffix. Changing to passing in a revision suffix and using workflow run id and workflow attempt to ensure uniqueness. 

<!--- Describe your changes in detail -->

## Related Issue(s)

- #{issue number}

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new environment variable `REVISION_SUFFIX` for improved tracking of deployment revisions.
	- Added a `revisionSuffix` parameter across various Bicep configuration files to enhance deployment customization and versioning.
	- Standardized deployment names to include environment and version for consistency.

- **Chores**
	- Enhanced deployment workflow structure without altering the overall functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->