### PR TITLE
ci: alert slack on failing k6 tests

### DIFF
--- a/.github/workflows/action-run-k6-tests.yml
+++ b/.github/workflows/action-run-k6-tests.yml
@@ -39,7 +39,9 @@ jobs:
         API_VERSION: ${{ inputs.apiVersion }}
         TOKEN_GENERATOR_USERNAME: ${{ secrets.TOKEN_GENERATOR_USERNAME }}
         TOKEN_GENERATOR_PASSWORD: ${{ secrets.TOKEN_GENERATOR_PASSWORD }}  
-    
+      id: k6_tests
+      continue-on-error: true  # Allow the workflow to continue even if tests fail
+
     - name: Store test summary
       uses: actions/upload-artifact@v4
       with:
@@ -53,3 +55,37 @@ jobs:
         action_fail: true
         files: |
           junit.xml
+
+    - name: Send Slack message on K6 test failure
+      if: failure()
+      uses: slackapi/slack-github-action@v1.27.0
+      env:
+        SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      with:
+        channel-id: ${{ secrets.SLACK_CHANNEL_ID_FOR_K6_TESTS }}
+        payload: |
+            {
+                "blocks": [
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "mrkdwn",
+                      "text": "*:rotating_light: K6 Tests Failed for environment *${{ inputs.environment }}* :rotating_light:*\n\nPlease check the workflow for more details."
+                    }
+                  },
+                  { "type": "divider" },
+                  {
+                    "type": "actions",
+                    "elements": [
+                      {
+                        "type": "button",
+                        "text": {
+                          "type": "plain_text",
+                          "text": "View Run"
+                        },
+                        "url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                      }
+                    ]
+                  }
+                ]
+            }

--- a/.github/workflows/action-run-k6-tests.yml
+++ b/.github/workflows/action-run-k6-tests.yml
@@ -29,6 +29,8 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
+    # todo: change to use the new https://github.com/grafana/setup-k6-action and https://github.com/grafana/run-k6-action
+    # grafana/k6-action is deprecated
     - name: Run K6 tests (${{ inputs.testSuitePath }})
       uses: grafana/k6-action@v0.3.1
       with:
@@ -39,8 +41,6 @@ jobs:
         API_VERSION: ${{ inputs.apiVersion }}
         TOKEN_GENERATOR_USERNAME: ${{ secrets.TOKEN_GENERATOR_USERNAME }}
         TOKEN_GENERATOR_PASSWORD: ${{ secrets.TOKEN_GENERATOR_PASSWORD }}  
-      id: k6_tests
-      continue-on-error: true  # Allow the workflow to continue even if tests fail
 
     - name: Store test summary
       uses: actions/upload-artifact@v4
@@ -57,7 +57,7 @@ jobs:
           junit.xml
 
     - name: Send Slack message on K6 test failure
-      if: failure()
+      if: always() && failure()
       uses: slackapi/slack-github-action@v1.27.0
       env:
         SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

- Alerts us if the k6-tests are failing in the specified channel (team-dialogporten-github-backend for now.) 

## Related Issue(s)

- #230 

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a notification system that sends Slack messages when K6 tests fail, improving incident response.
- **Chores**
	- Updated workflow configuration to transition from deprecated actions to new ones for K6 testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->