### PR TITLE
fix(webapi): ensure correct health checks are used in probes

### DIFF
--- a/.azure/applications/web-api-eu/main.bicep
+++ b/.azure/applications/web-api-eu/main.bicep
@@ -91,7 +91,7 @@ var probes = [
     initialDelaySeconds: 2
     type: 'Liveness'
     httpGet: {
-      path: '/liveness'
+      path: '/health/liveness'
       port: port
     }
   }
@@ -100,7 +100,7 @@ var probes = [
     initialDelaySeconds: 2
     type: 'Readiness'
     httpGet: {
-      path: '/readiness'
+      path: '/health/readiness'
       port: port
     }
   }
@@ -109,7 +109,7 @@ var probes = [
     initialDelaySeconds: 2
     type: 'Startup'
     httpGet: {
-      path: '/startup'
+      path: '/health/startup'
       port: port
     }
   }

--- a/.azure/applications/web-api-so/main.bicep
+++ b/.azure/applications/web-api-so/main.bicep
@@ -95,7 +95,7 @@ var probes = [
     initialDelaySeconds: 2
     type: 'Liveness'
     httpGet: {
-      path: '/liveness'
+      path: '/health/liveness'
       port: port
     }
   }
@@ -104,7 +104,7 @@ var probes = [
     initialDelaySeconds: 2
     type: 'Readiness'
     httpGet: {
-      path: '/readiness'
+      path: '/health/readiness'
       port: port
     }
   }
@@ -113,7 +113,7 @@ var probes = [
     initialDelaySeconds: 2
     type: 'Startup'
     httpGet: {
-      path: '/startup'
+      path: '/health/startup'
       port: port
     }
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Changed the paths of health checks, so have to ensure we use the same endpoints in the probes
## Related Issue(s)

- #292 

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated health probe paths for container apps to include a new `/health` prefix, enhancing health check organization.
- **Bug Fixes**
	- Improved accuracy of health status checks by modifying probe endpoints to ensure proper monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->