### PR TITLE
feat(webAPI): Add legacy HTML support for MainContentReference

### DIFF
--- a/docs/schema/V1/swagger.verified.json
+++ b/docs/schema/V1/swagger.verified.json
@@ -70,7 +70,6 @@
         "properties": {
           "mediaType": {
             "description": "Media type of the content (plaintext, Markdown). Can also indicate that the content is embeddable.",
-            "example": "text/plain\ntext/markdown\napplication/vnd.dialogporten.frontchannelembed",
             "type": "string"
           },
           "value": {
@@ -297,7 +296,7 @@
         "additionalProperties": false,
         "properties": {
           "additionalInfo": {
-            "description": "Additional information about the dialog, this may contain Markdown.",
+            "description": "Additional information about the dialog.\nSupported media types: text/plain, text/markdown",
             "nullable": true,
             "oneOf": [
               {
@@ -306,7 +305,7 @@
             ]
           },
           "extendedStatus": {
-            "description": "Used as the human-readable label used to describe the \u0022ExtendedStatus\u0022 field. Must be text/plain.",
+            "description": "Used as the human-readable label used to describe the \u0022ExtendedStatus\u0022 field.\nSupported media types: text/plain",
             "nullable": true,
             "oneOf": [
               {
@@ -315,7 +314,7 @@
             ]
           },
           "mainContentReference": {
-            "description": "Front-channel embedded content. Used to dynamically embed content in the frontend from an external URL.",
+            "description": "Front-channel embedded content. Used to dynamically embed content in the frontend from an external URL.\nSupported media types: application/vnd.dialogporten.frontchannelembed\u002Bjson;type=markdown",
             "nullable": true,
             "oneOf": [
               {
@@ -324,7 +323,7 @@
             ]
           },
           "senderName": {
-            "description": "Overridden sender name. If not supplied, assume \u0022org\u0022 as the sender name. Must be text/plain if supplied.",
+            "description": "Overridden sender name. If not supplied, assume \u0022org\u0022 as the sender name. Must be text/plain if supplied.\nSupported media types: text/plain",
             "nullable": true,
             "oneOf": [
               {
@@ -333,7 +332,7 @@
             ]
           },
           "summary": {
-            "description": "A short summary of the dialog and its current state. Must be text/plain.",
+            "description": "A short summary of the dialog and its current state.\nSupported media types: text/plain",
             "oneOf": [
               {
                 "$ref": "#/components/schemas/ContentValueDto"
@@ -341,7 +340,7 @@
             ]
           },
           "title": {
-            "description": "The title of the dialog. Must be text/plain.",
+            "description": "The title of the dialog.\nSupported media types: text/plain",
             "oneOf": [
               {
                 "$ref": "#/components/schemas/ContentValueDto"

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/Common/Content/ContentValueDto.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/Common/Content/ContentValueDto.cs
@@ -13,10 +13,5 @@ public sealed class ContentValueDto
     /// <summary>
     /// Media type of the content (plaintext, Markdown). Can also indicate that the content is embeddable.
     /// </summary>
-    /// <example>
-    /// text/plain
-    /// text/markdown
-    /// application/vnd.dialogporten.frontchannelembed
-    /// </example>
     public string MediaType { get; set; } = MediaTypes.PlainText;
 }

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/Common/Content/ContentValueDtoValidator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/Common/Content/ContentValueDtoValidator.cs
@@ -18,7 +18,6 @@ internal interface IIgnoreOnAssemblyScan;
 
 internal sealed class ContentValueDtoValidator : AbstractValidator<ContentValueDto>, IIgnoreOnAssemblyScan
 {
-    public const string LegacyHtmlMediaType = "text/html";
 
     public ContentValueDtoValidator(DialogTransmissionContentType contentType)
     {
@@ -74,7 +73,7 @@ internal sealed class ContentValueDtoValidator : AbstractValidator<ContentValueD
         => contentType.Id switch
         {
             DialogContentType.Values.AdditionalInfo when UserHasLegacyHtmlScope(user)
-                => contentType.AllowedMediaTypes.Append(LegacyHtmlMediaType).ToArray(),
+                => contentType.AllowedMediaTypes.Append(MediaTypes.LegacyHtmlMediaType).ToArray(),
             DialogContentType.Values.MainContentReference when UserHasLegacyHtmlScope(user)
                 => contentType.AllowedMediaTypes.Append(MediaTypes.LegacyEmbeddableHtml).ToArray(),
             _ => contentType.AllowedMediaTypes

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/Common/Content/ContentValueDtoValidator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/Common/Content/ContentValueDtoValidator.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Digdir.Domain.Dialogporten.Application.Common.Authorization;
 using Digdir.Domain.Dialogporten.Application.Common.Extensions;
 using Digdir.Domain.Dialogporten.Application.Common.Extensions.FluentValidation;
@@ -68,22 +69,15 @@ internal sealed class ContentValueDtoValidator : AbstractValidator<ContentValueD
             .SetValidator(_ => new LocalizationDtosValidator(contentType.MaxLength));
     }
 
+    [SuppressMessage("Style", "IDE0072:Add missing cases")]
     private static string[] GetAllowedMediaTypes(DialogContentType contentType, IUser? user)
-    {
-        if (user == null)
+        => contentType.Id switch
         {
-            return contentType.AllowedMediaTypes;
-        }
-
-        if (contentType.Id != DialogContentType.Values.AdditionalInfo)
-        {
-            return contentType.AllowedMediaTypes;
-        }
-
-        var allowHtmlSupport = user.GetPrincipal().HasScope(Constants.LegacyHtmlScope);
-
-        return allowHtmlSupport
-            ? contentType.AllowedMediaTypes.Append(LegacyHtmlMediaType).ToArray()
-            : contentType.AllowedMediaTypes;
-    }
+            DialogContentType.Values.AdditionalInfo when UserHasLegacyHtmlScope(user)
+                => contentType.AllowedMediaTypes.Append(LegacyHtmlMediaType).ToArray(),
+            DialogContentType.Values.MainContentReference when UserHasLegacyHtmlScope(user)
+                => contentType.AllowedMediaTypes.Append(MediaTypes.LegacyEmbeddableHtml).ToArray(),
+            _ => contentType.AllowedMediaTypes
+        };
+    private static bool UserHasLegacyHtmlScope(IUser? user) => user is not null && user.GetPrincipal().HasScope(Constants.LegacyHtmlScope);
 }

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/Common/Content/ContentValueDtoValidator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/Common/Content/ContentValueDtoValidator.cs
@@ -73,7 +73,7 @@ internal sealed class ContentValueDtoValidator : AbstractValidator<ContentValueD
         => contentType.Id switch
         {
             DialogContentType.Values.AdditionalInfo when UserHasLegacyHtmlScope(user)
-                => contentType.AllowedMediaTypes.Append(MediaTypes.LegacyHtmlMediaType).ToArray(),
+                => contentType.AllowedMediaTypes.Append(MediaTypes.LegacyHtml).ToArray(),
             DialogContentType.Values.MainContentReference when UserHasLegacyHtmlScope(user)
                 => contentType.AllowedMediaTypes.Append(MediaTypes.LegacyEmbeddableHtml).ToArray(),
             _ => contentType.AllowedMediaTypes

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Create/CreateDialogDto.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Create/CreateDialogDto.cs
@@ -209,32 +209,38 @@ public sealed class CreateDialogDialogTransmissionDto
 public sealed class CreateDialogContentDto
 {
     /// <summary>
-    /// The title of the dialog. Must be text/plain.
+    /// The title of the dialog.
+    /// Supported media types: text/plain
     /// </summary>
     public ContentValueDto Title { get; set; } = null!;
 
     /// <summary>
-    /// A short summary of the dialog and its current state. Must be text/plain.
+    /// A short summary of the dialog and its current state.
+    /// Supported media types: text/plain
     /// </summary>
     public ContentValueDto Summary { get; set; } = null!;
 
     /// <summary>
     /// Overridden sender name. If not supplied, assume "org" as the sender name. Must be text/plain if supplied.
+    /// Supported media types: text/plain
     /// </summary>
     public ContentValueDto? SenderName { get; set; }
 
     /// <summary>
-    /// Additional information about the dialog, this may contain Markdown.
+    /// Additional information about the dialog.
+    /// Supported media types: text/plain, text/markdown
     /// </summary>
     public ContentValueDto? AdditionalInfo { get; set; }
 
     /// <summary>
-    /// Used as the human-readable label used to describe the "ExtendedStatus" field. Must be text/plain.
+    /// Used as the human-readable label used to describe the "ExtendedStatus" field.
+    /// Supported media types: text/plain
     /// </summary>
     public ContentValueDto? ExtendedStatus { get; set; }
 
     /// <summary>
     /// Front-channel embedded content. Used to dynamically embed content in the frontend from an external URL.
+    /// Supported media types: application/vnd.dialogporten.frontchannelembed+json;type=markdown
     /// </summary>
     public ContentValueDto? MainContentReference { get; set; }
 }

--- a/src/Digdir.Domain.Dialogporten.Domain/MediaTypes.cs
+++ b/src/Digdir.Domain.Dialogporten.Domain/MediaTypes.cs
@@ -4,6 +4,7 @@ public static class MediaTypes
 {
     public const string EmbeddablePrefix = "application/vnd.dialogporten.frontchannelembed";
     public const string EmbeddableMarkdown = $"{EmbeddablePrefix}+json;type=markdown";
+    public const string LegacyEmbeddableHtml = $"{EmbeddablePrefix}+json;type=html";
 
     public const string Markdown = "text/markdown";
     public const string PlainText = "text/plain";

--- a/src/Digdir.Domain.Dialogporten.Domain/MediaTypes.cs
+++ b/src/Digdir.Domain.Dialogporten.Domain/MediaTypes.cs
@@ -6,6 +6,7 @@ public static class MediaTypes
     public const string EmbeddableMarkdown = $"{EmbeddablePrefix}+json;type=markdown";
     public const string LegacyEmbeddableHtml = $"{EmbeddablePrefix}+json;type=html";
 
+    public const string LegacyHtmlMediaType = "text/html";
     public const string Markdown = "text/markdown";
     public const string PlainText = "text/plain";
 }

--- a/src/Digdir.Domain.Dialogporten.Domain/MediaTypes.cs
+++ b/src/Digdir.Domain.Dialogporten.Domain/MediaTypes.cs
@@ -6,7 +6,7 @@ public static class MediaTypes
     public const string EmbeddableMarkdown = $"{EmbeddablePrefix}+json;type=markdown";
     public const string LegacyEmbeddableHtml = $"{EmbeddablePrefix}+json;type=html";
 
-    public const string LegacyHtmlMediaType = "text/html";
+    public const string LegacyHtml = "text/html";
     public const string Markdown = "text/markdown";
     public const string PlainText = "text/plain";
 }

--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/ServiceOwner/Dialogs/Commands/CreateDialogTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/ServiceOwner/Dialogs/Commands/CreateDialogTests.cs
@@ -331,11 +331,7 @@ public class CreateDialogTests : ApplicationCollectionFixture
     {
         // Arrange
         var createDialogCommand = DialogGenerator.GenerateSimpleFakeDialog();
-        createDialogCommand.Content.Title = new ContentValueDto
-        {
-            MediaType = MediaTypes.LegacyEmbeddableHtml,
-            Value = [new LocalizationDto { LanguageCode = "en", Value = "https://external.html" }]
-        };
+        createDialogCommand.Content.Title = CreateHtmlContentValueDto();
 
         var userWithLegacyScope = new IntegrationTestUser([new("scope", Constants.LegacyHtmlScope)]);
         Application.ConfigureServiceCollection(services =>

--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/ServiceOwner/Dialogs/Commands/CreateDialogTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/ServiceOwner/Dialogs/Commands/CreateDialogTests.cs
@@ -277,7 +277,7 @@ public class CreateDialogTests : ApplicationCollectionFixture
             .Be(2);
     }
 
-    private const string LegacyHtmlMediaType = MediaTypes.LegacyHtmlMediaType;
+    private const string LegacyHtmlMediaType = MediaTypes.LegacyHtml;
 
     private static ContentValueDto CreateHtmlContentValueDto() => new()
     {

--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/ServiceOwner/Dialogs/Commands/CreateDialogTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/ServiceOwner/Dialogs/Commands/CreateDialogTests.cs
@@ -277,7 +277,7 @@ public class CreateDialogTests : ApplicationCollectionFixture
             .Be(2);
     }
 
-    private const string LegacyHtmlMediaType = ContentValueDtoValidator.LegacyHtmlMediaType;
+    private const string LegacyHtmlMediaType = MediaTypes.LegacyHtmlMediaType;
 
     private static ContentValueDto CreateHtmlContentValueDto() => new()
     {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue(s)

- #1255

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new media type constant for legacy embeddable HTML.
	- Enhanced XML documentation for supported media types in dialog properties.
	- Added new enum schemas for improved API structure.

- **Bug Fixes**
	- Improved validation for dialog creation with specific media types based on user scopes.

- **Tests**
	- Added new test cases to ensure correct dialog creation behavior with HTML media types. 

- **Documentation**
	- Updated API schemas and descriptions in the Swagger documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->