### PR TITLE
fix(graphQL): Missing MediaType on dialog attachment url

### DIFF
--- a/docs/schema/V1/schema.verified.graphql
+++ b/docs/schema/V1/schema.verified.graphql
@@ -62,6 +62,7 @@ type Attachment {
 type AttachmentUrl {
   id: UUID!
   url: URL!
+  mediaType: String
   consumerType: AttachmentUrlConsumer!
 }
 

--- a/src/Digdir.Domain.Dialogporten.GraphQL/EndUser/DialogById/ObjectTypes.cs
+++ b/src/Digdir.Domain.Dialogporten.GraphQL/EndUser/DialogById/ObjectTypes.cs
@@ -194,6 +194,7 @@ public sealed class AttachmentUrl
 {
     public Guid Id { get; set; }
     public Uri Url { get; set; } = null!;
+    public string? MediaType { get; set; }
 
     public AttachmentUrlConsumer ConsumerType { get; set; }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue(s)

- #1263

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `mediaType` field in the `AttachmentUrl` type for specifying the media type of attachments.
  
- **Bug Fixes**
	- Corrected formatting issue by ensuring the `UUID` scalar type definition ends with a newline character.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->