### PR TITLE
chore(slacknotifier): remove fusion-cache timeout exception from slack alerts

### DIFF
--- a/.azure/modules/functionApp/slackNotifier.bicep
+++ b/.azure/modules/functionApp/slackNotifier.bicep
@@ -158,7 +158,8 @@ resource notifyDevTeam 'Microsoft.Insights/actionGroups@2023-01-01' = {
 var query = '''
             union
                  (exceptions
-                 | where not(customDimensions.['Service Type'] == 'API Management')),
+                 | where not(customDimensions.['Service Type'] == 'API Management')
+                 | where type != "ZiggyCreatures.Caching.Fusion.SyntheticTimeoutException"),
                  (traces
                  | where severityLevel >= 3 or (severityLevel >= 2 and customDimensions.SourceContext startswith "Digdir"))
                  | where operation_Name !startswith "GET /health/"


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

We cannot separate between soft-timeouts and hard-timeouts in fusioncache. If we get a hard-timeout we should get an indication of this through our own exception handling

<!--- Describe your changes in detail -->

## Related Issue(s)

Related issue: https://github.com/ZiggyCreatures/FusionCache/issues/267

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced alerting criteria for exceptions in the Slack Notifier function app.
	- Added a new action group to notify the development team via Slack.
  
- **Improvements**
	- Defined specific allowed values for SKU parameters to ensure valid resource deployment.
	- Configured the function app with a SystemAssigned identity and integrated Key Vault for secure webhook URL storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->