### PR TITLE
chore: Remove related activity

### DIFF
--- a/docs/schema/V1/schema.verified.graphql
+++ b/docs/schema/V1/schema.verified.graphql
@@ -21,7 +21,6 @@ type Activity {
   createdAt: DateTime
   extendedType: URL
   type: ActivityType!
-  relatedActivityId: UUID
   transmissionId: UUID
   performedBy: Actor!
   description: [Localization!]!

--- a/docs/schema/V1/swagger.verified.json
+++ b/docs/schema/V1/swagger.verified.json
@@ -120,12 +120,6 @@
               }
             ]
           },
-          "relatedActivityId": {
-            "description": "The related activity identifier, if applicable. Must be present in the request body.",
-            "format": "guid",
-            "nullable": true,
-            "type": "string"
-          },
           "transmissionId": {
             "description": "If the activity is related to a particular transmission, this field will contain the transmission identifier.\nMust be present in the request body.",
             "format": "guid",
@@ -386,12 +380,6 @@
                 "$ref": "#/components/schemas/CreateDialogDialogActivityPerformedByActorDto"
               }
             ]
-          },
-          "relatedActivityId": {
-            "description": "The related activity identifier, if applicable. Must be present in the request body.",
-            "format": "guid",
-            "nullable": true,
-            "type": "string"
           },
           "transmissionId": {
             "description": "If the activity is related to a particular transmission, this field will contain the transmission identifier.\nMust be present in the request body.",
@@ -965,11 +953,6 @@
           "performedBy": {
             "$ref": "#/components/schemas/GetDialogActivityPerformedByActorDto"
           },
-          "relatedActivityId": {
-            "format": "guid",
-            "nullable": true,
-            "type": "string"
-          },
           "transmissionId": {
             "format": "guid",
             "nullable": true,
@@ -1011,11 +994,6 @@
           },
           "performedBy": {
             "$ref": "#/components/schemas/GetDialogActivityPerformedByActorDtoSO"
-          },
-          "relatedActivityId": {
-            "format": "guid",
-            "nullable": true,
-            "type": "string"
           },
           "transmissionId": {
             "format": "guid",
@@ -1221,12 +1199,6 @@
               }
             ]
           },
-          "relatedActivityId": {
-            "description": "The related activity identifier, if applicable. Must be present in the current dialog.",
-            "format": "guid",
-            "nullable": true,
-            "type": "string"
-          },
           "transmissionId": {
             "description": "If the activity is related to a particular transmission, this field will contain the transmission identifier.",
             "format": "guid",
@@ -1278,12 +1250,6 @@
                 "$ref": "#/components/schemas/GetDialogDialogActivityPerformedByActorDtoSO"
               }
             ]
-          },
-          "relatedActivityId": {
-            "description": "The related activity identifier, if applicable. Must be present in the current dialog.",
-            "format": "guid",
-            "nullable": true,
-            "type": "string"
           },
           "transmissionId": {
             "description": "If the activity is related to a particular transmission, this field will contain the transmission identifier.",
@@ -3293,11 +3259,6 @@
             "format": "guid",
             "type": "string"
           },
-          "relatedActivityId": {
-            "format": "guid",
-            "nullable": true,
-            "type": "string"
-          },
           "seenByEndUserIdHash": {
             "nullable": true,
             "type": "string"
@@ -3332,11 +3293,6 @@
           },
           "id": {
             "format": "guid",
-            "type": "string"
-          },
-          "relatedActivityId": {
-            "format": "guid",
-            "nullable": true,
             "type": "string"
           },
           "transmissionId": {
@@ -3465,12 +3421,6 @@
               }
             ]
           },
-          "relatedActivityId": {
-            "description": "The related activity identifier, if applicable. Must be present in the current dialog.",
-            "format": "guid",
-            "nullable": true,
-            "type": "string"
-          },
           "transmissionId": {
             "description": "If the activity is related to a particular transmission, this field will contain the transmission identifier.",
             "format": "guid",
@@ -3522,12 +3472,6 @@
                 "$ref": "#/components/schemas/SearchDialogDialogActivityPerformedByActorDtoSO"
               }
             ]
-          },
-          "relatedActivityId": {
-            "description": "The related activity identifier, if applicable. Must be present in the current dialog.",
-            "format": "guid",
-            "nullable": true,
-            "type": "string"
           },
           "transmissionId": {
             "description": "If the activity is related to a particular transmission, this field will contain the transmission identifier.",
@@ -4400,12 +4344,6 @@
                 "$ref": "#/components/schemas/UpdateDialogDialogActivityPerformedByActorDto"
               }
             ]
-          },
-          "relatedActivityId": {
-            "description": "The related activity identifier, if applicable. Must be present in the request body.",
-            "format": "guid",
-            "nullable": true,
-            "type": "string"
           },
           "transmissionId": {
             "description": "If the activity is related to a particular transmission, this field will contain the transmission identifier.\nMust be present in the request body.",
@@ -6439,7 +6377,6 @@
                       "ActorName": null,
                       "ActorType": 2
                     },
-                    "RelatedActivityId": null,
                     "TransmissionId": null,
                     "Type": 3
                   }

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/Common/Events/DialogActivityEventToAltinnForwarder.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/Common/Events/DialogActivityEventToAltinnForwarder.cs
@@ -40,11 +40,6 @@ internal sealed class DialogActivityEventToAltinnForwarder : DomainEventToAltinn
             data["extendedActivityType"] = domainEvent.ExtendedType.ToString();
         }
 
-        if (domainEvent.RelatedActivityId is not null)
-        {
-            data["relatedActivityId"] = domainEvent.RelatedActivityId.ToString()!;
-        }
-
         if (domainEvent.Process is not null)
         {
             data["process"] = domainEvent.Process;

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/DialogActivities/Queries/Get/GetDialogActivityDto.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/DialogActivities/Queries/Get/GetDialogActivityDto.cs
@@ -12,7 +12,6 @@ public sealed class GetDialogActivityDto
 
     public DialogActivityType.Values Type { get; set; }
 
-    public Guid? RelatedActivityId { get; set; }
     public Guid? TransmissionId { get; set; }
 
     public GetDialogActivityPerformedByActorDto PerformedBy { get; set; } = null!;

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/DialogActivities/Queries/Search/SearchDialogActivityDto.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/DialogActivities/Queries/Search/SearchDialogActivityDto.cs
@@ -11,6 +11,5 @@ public sealed class SearchDialogActivityDto
 
     public DialogActivityType.Values Type { get; set; }
 
-    public Guid? RelatedActivityId { get; set; }
     public Guid? TransmissionId { get; set; }
 }

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/Get/GetDialogDto.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/Get/GetDialogDto.cs
@@ -368,11 +368,6 @@ public sealed class GetDialogDialogActivityDto
     public DialogActivityType.Values Type { get; set; }
 
     /// <summary>
-    /// The related activity identifier, if applicable. Must be present in the current dialog.
-    /// </summary>
-    public Guid? RelatedActivityId { get; set; }
-
-    /// <summary>
     /// If the activity is related to a particular transmission, this field will contain the transmission identifier.
     /// </summary>
     public Guid? TransmissionId { get; set; }

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/Search/SearchDialogDtoBase.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/Search/SearchDialogDtoBase.cs
@@ -181,11 +181,6 @@ public sealed class SearchDialogDialogActivityDto
     public DialogActivityType.Values Type { get; set; }
 
     /// <summary>
-    /// The related activity identifier, if applicable. Must be present in the current dialog.
-    /// </summary>
-    public Guid? RelatedActivityId { get; set; }
-
-    /// <summary>
     /// If the activity is related to a particular transmission, this field will contain the transmission identifier.
     /// </summary>
     public Guid? TransmissionId { get; set; }

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/DialogActivities/Queries/Get/GetDialogActivityDto.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/DialogActivities/Queries/Get/GetDialogActivityDto.cs
@@ -14,7 +14,6 @@ public sealed class GetDialogActivityDto
 
     public DateTimeOffset? DeletedAt { get; set; }
 
-    public Guid? RelatedActivityId { get; set; }
     public Guid? TransmissionId { get; set; }
 
     public GetDialogActivityPerformedByActorDto PerformedBy { get; set; } = null!;

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/DialogActivities/Queries/Search/SearchDialogActivityDto.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/DialogActivities/Queries/Search/SearchDialogActivityDto.cs
@@ -12,6 +12,5 @@ public sealed class SearchDialogActivityDto
 
     public DateTimeOffset? DeletedAt { get; set; }
 
-    public Guid? RelatedActivityId { get; set; }
     public Guid? TransmissionId { get; set; }
 }

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Create/CreateDialogCommandValidator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Create/CreateDialogCommandValidator.cs
@@ -128,9 +128,6 @@ internal sealed class CreateDialogCommandValidator : AbstractValidator<CreateDia
             .IsIn(x => x.Transmissions,
                 dependentKeySelector: activity => activity.TransmissionId,
                 principalKeySelector: transmission => transmission.Id)
-            .IsIn(x => x.Activities,
-                dependentKeySelector: activity => activity.RelatedActivityId,
-                principalKeySelector: activity => activity.Id)
             .SetValidator(activityValidator);
 
         RuleFor(x => x.Process)
@@ -401,10 +398,6 @@ internal sealed class CreateDialogDialogActivityDtoValidator : AbstractValidator
             .MaximumLength(Constants.DefaultMaxUriLength);
         RuleFor(x => x.Type)
             .IsInEnum();
-        RuleFor(x => x.RelatedActivityId)
-            .NotEqual(x => x.Id)
-            .WithMessage(x => $"An activity cannot reference itself ({nameof(x.RelatedActivityId)} is equal to {nameof(x.Id)}, '{x.Id}').")
-            .When(x => x.RelatedActivityId.HasValue);
         RuleFor(x => x.PerformedBy)
             .NotNull()
             .SetValidator(actorValidator);

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Create/CreateDialogDto.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Create/CreateDialogDto.cs
@@ -291,11 +291,6 @@ public sealed class CreateDialogDialogActivityDto
     public DialogActivityType.Values Type { get; set; }
 
     /// <summary>
-    /// The related activity identifier, if applicable. Must be present in the request body.
-    /// </summary>
-    public Guid? RelatedActivityId { get; set; }
-
-    /// <summary>
     /// If the activity is related to a particular transmission, this field will contain the transmission identifier.
     /// Must be present in the request body.
     /// </summary>

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/UpdateDialogCommand.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/UpdateDialogCommand.cs
@@ -102,7 +102,6 @@ internal sealed class UpdateDialogCommandHandler : IRequestHandler<UpdateDialogC
         ValidateTimeFields(dialog);
 
         await AppendActivity(dialog, request.Dto, cancellationToken);
-        VerifyActivityRelations(dialog);
 
         await AppendTransmission(dialog, request.Dto, cancellationToken);
         VerifyTransmissionRelations(dialog);
@@ -241,33 +240,6 @@ internal sealed class UpdateDialogCommandHandler : IRequestHandler<UpdateDialogC
                 nameof(UpdateDialogDto.Activities),
                 $"Invalid '{nameof(DialogActivity.TransmissionId)}, entity '{nameof(DialogTransmission)}'" +
                 $" with the following key(s) does not exist: ({string.Join(", ", invalidTransmissionIds)}) in '{nameof(dialog.Transmissions)}'");
-        }
-    }
-
-    private void VerifyActivityRelations(DialogEntity dialog)
-    {
-        var relatedActivityIds = dialog.Activities
-            .Where(x => x.RelatedActivityId is not null)
-            .Select(x => x.RelatedActivityId)
-            .ToList();
-
-        if (relatedActivityIds.Count == 0)
-        {
-            return;
-        }
-
-        var activityIds = dialog.Activities.Select(x => x.Id).ToList();
-
-        var invalidRelatedActivityIds = relatedActivityIds
-            .Where(id => !activityIds.Contains(id!.Value))
-            .ToList();
-
-        if (invalidRelatedActivityIds.Count != 0)
-        {
-            _domainContext.AddError(
-                nameof(UpdateDialogDto.Activities),
-                $"Invalid '{nameof(DialogActivity.RelatedActivityId)}, entity '{nameof(DialogActivity)}'" +
-                $" with the following key(s) does not exist: ({string.Join(", ", invalidRelatedActivityIds)}) in '{nameof(dialog.Activities)}'");
         }
     }
 

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/UpdateDialogCommandValidator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/UpdateDialogCommandValidator.cs
@@ -385,10 +385,6 @@ internal sealed class UpdateDialogDialogActivityDtoValidator : AbstractValidator
             .MaximumLength(Constants.DefaultMaxUriLength);
         RuleFor(x => x.Type)
             .IsInEnum();
-        RuleFor(x => x.RelatedActivityId)
-            .NotEqual(x => x.Id)
-            .WithMessage(x => $"An activity cannot reference itself ({nameof(x.RelatedActivityId)} is equal to {nameof(x.Id)}, '{x.Id}').")
-            .When(x => x.RelatedActivityId.HasValue);
         RuleFor(x => x.PerformedBy)
             .NotNull()
             .SetValidator(actorValidator);

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/UpdateDialogDto.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/UpdateDialogDto.cs
@@ -260,11 +260,6 @@ public class UpdateDialogDialogActivityDto
     public DialogActivityType.Values Type { get; set; }
 
     /// <summary>
-    /// The related activity identifier, if applicable. Must be present in the request body.
-    /// </summary>
-    public Guid? RelatedActivityId { get; set; }
-
-    /// <summary>
     /// If the activity is related to a particular transmission, this field will contain the transmission identifier.
     /// Must be present in the request body.
     /// </summary>

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/Get/GetDialogDto.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/Get/GetDialogDto.cs
@@ -386,11 +386,6 @@ public sealed class GetDialogDialogActivityDto
     public DialogActivityType.Values Type { get; set; }
 
     /// <summary>
-    /// The related activity identifier, if applicable. Must be present in the current dialog.
-    /// </summary>
-    public Guid? RelatedActivityId { get; set; }
-
-    /// <summary>
     /// If the activity is related to a particular transmission, this field will contain the transmission identifier.
     /// </summary>
     public Guid? TransmissionId { get; set; }

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/Search/SearchDialogDtoBase.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/Search/SearchDialogDtoBase.cs
@@ -193,11 +193,6 @@ public sealed class SearchDialogDialogActivityDto
     public DialogActivityType.Values Type { get; set; }
 
     /// <summary>
-    /// The related activity identifier, if applicable. Must be present in the current dialog.
-    /// </summary>
-    public Guid? RelatedActivityId { get; set; }
-
-    /// <summary>
     /// If the activity is related to a particular transmission, this field will contain the transmission identifier.
     /// </summary>
     public Guid? TransmissionId { get; set; }

--- a/src/Digdir.Domain.Dialogporten.Domain/Dialogs/Entities/Activities/DialogActivity.cs
+++ b/src/Digdir.Domain.Dialogporten.Domain/Dialogs/Entities/Activities/DialogActivity.cs
@@ -21,9 +21,6 @@ public sealed class DialogActivity : IImmutableEntity, IAggregateCreatedHandler,
     public Guid DialogId { get; set; }
     public DialogEntity Dialog { get; set; } = null!;
 
-    public Guid? RelatedActivityId { get; set; }
-    public DialogActivity? RelatedActivity { get; set; }
-
     public Guid? TransmissionId { get; set; }
     public DialogTransmission? Transmission { get; set; }
 
@@ -34,14 +31,11 @@ public sealed class DialogActivity : IImmutableEntity, IAggregateCreatedHandler,
     [AggregateChild]
     public DialogActivityPerformedByActor PerformedBy { get; set; } = null!;
 
-    public List<DialogActivity> RelatedActivities { get; set; } = [];
-
     public void OnCreate(AggregateNode self, DateTimeOffset utcNow)
     {
         _domainEvents.Add(new DialogActivityCreatedDomainEvent(
             DialogId, Id, TypeId, Dialog.Party,
-            Dialog.ServiceResource, Dialog.Process, Dialog.PrecedingProcess, ExtendedType,
-            RelatedActivityId));
+            Dialog.ServiceResource, Dialog.Process, Dialog.PrecedingProcess, ExtendedType));
     }
 
     private readonly List<IDomainEvent> _domainEvents = [];

--- a/src/Digdir.Domain.Dialogporten.Domain/Dialogs/Events/Activities/DialogActivityCreatedDomainEvent.cs
+++ b/src/Digdir.Domain.Dialogporten.Domain/Dialogs/Events/Activities/DialogActivityCreatedDomainEvent.cs
@@ -11,5 +11,4 @@ public sealed record DialogActivityCreatedDomainEvent(
     string ServiceResource,
     string? Process,
     string? PrecedingProcess,
-    Uri? ExtendedType,
-    Guid? RelatedActivityId) : DomainEvent;
+    Uri? ExtendedType) : DomainEvent;

--- a/src/Digdir.Domain.Dialogporten.GraphQL/EndUser/Common/ObjectTypes.cs
+++ b/src/Digdir.Domain.Dialogporten.GraphQL/EndUser/Common/ObjectTypes.cs
@@ -30,7 +30,6 @@ public sealed class Activity
 
     public ActivityType Type { get; set; }
 
-    public Guid? RelatedActivityId { get; set; }
     public Guid? TransmissionId { get; set; }
 
     public Actor PerformedBy { get; set; } = null!;

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Configurations/Dialogs/Activities/DialogActivityConfiguration.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Configurations/Dialogs/Activities/DialogActivityConfiguration.cs
@@ -8,10 +8,6 @@ internal sealed class DialogActivityConfiguration : IEntityTypeConfiguration<Dia
 {
     public void Configure(EntityTypeBuilder<DialogActivity> builder)
     {
-        builder.HasOne(x => x.RelatedActivity)
-            .WithMany(x => x.RelatedActivities)
-            .OnDelete(DeleteBehavior.SetNull);
-
         builder.HasOne(x => x.Transmission)
             .WithMany(x => x.Activities)
             .OnDelete(DeleteBehavior.SetNull);

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Migrations/20241011235344_RemoveRelatedActivity.Designer.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Migrations/20241011235344_RemoveRelatedActivity.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Digdir.Domain.Dialogporten.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Digdir.Domain.Dialogporten.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(DialogDbContext))]
-    partial class DialogDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241011235344_RemoveRelatedActivity")]
+    partial class RemoveRelatedActivity
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Migrations/20241011235344_RemoveRelatedActivity.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Migrations/20241011235344_RemoveRelatedActivity.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Digdir.Domain.Dialogporten.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class RemoveRelatedActivity : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_DialogActivity_DialogActivity_RelatedActivityId",
+                table: "DialogActivity");
+
+            migrationBuilder.DropIndex(
+                name: "IX_DialogActivity_RelatedActivityId",
+                table: "DialogActivity");
+
+            migrationBuilder.DropColumn(
+                name: "RelatedActivityId",
+                table: "DialogActivity");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "RelatedActivityId",
+                table: "DialogActivity",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DialogActivity_RelatedActivityId",
+                table: "DialogActivity",
+                column: "RelatedActivityId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_DialogActivity_DialogActivity_RelatedActivityId",
+                table: "DialogActivity",
+                column: "RelatedActivityId",
+                principalTable: "DialogActivity",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+        }
+    }
+}

--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/ServiceOwner/Dialogs/Commands/UpdateDialogTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/ServiceOwner/Dialogs/Commands/UpdateDialogTests.cs
@@ -14,36 +14,6 @@ namespace Digdir.Domain.Dialogporten.Application.Integration.Tests.Features.V1.S
 public class UpdateDialogTests(DialogApplication application) : ApplicationCollectionFixture(application)
 {
     [Fact]
-    public async Task New_Activity_Should_Be_Able_To_Refer_To_Old_Activity()
-    {
-        // Arrange
-        var (_, createCommandResponse) = await GenerateDialogWithActivity();
-        var getDialogQuery = new GetDialogQuery { DialogId = createCommandResponse.AsT0.Value };
-        var getDialogDto = await Application.Send(getDialogQuery);
-
-        var mapper = Application.GetMapper();
-        var updateDialogDto = mapper.Map<UpdateDialogDto>(getDialogDto.AsT0);
-
-        // New activity refering to old activity
-        updateDialogDto.Activities.Add(new UpdateDialogDialogActivityDto
-        {
-            Type = DialogActivityType.Values.DialogClosed,
-            RelatedActivityId = getDialogDto.AsT0.Activities.First().Id,
-            PerformedBy = new UpdateDialogDialogActivityPerformedByActorDto
-            {
-                ActorType = ActorType.Values.ServiceOwner
-            }
-        });
-
-        // Act
-        var updateResponse = await Application.Send(new UpdateDialogCommand { Id = createCommandResponse.AsT0.Value, Dto = updateDialogDto });
-
-        // Assert
-        updateResponse.TryPickT0(out var result, out _).Should().BeTrue();
-        result.Should().NotBeNull();
-    }
-
-    [Fact]
     public async Task Cannot_Include_Old_Activities_To_UpdateCommand()
     {
         // Arrange


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Marking this as a `chore`. "Silently" removing this feat, there are no dialogs in staging that uses this.
Removes related activity on DialogActivity.

<!--- Describe your changes in detail -->

## Related Issue(s)

- #1224 

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified data structures by removing the `relatedActivityId` field from various models, enhancing clarity in dialog and activity management.

- **Bug Fixes**
	- Removed outdated validation rules related to `relatedActivityId`, streamlining the validation process for dialog activities.

- **Documentation**
	- Updated API specifications to reflect the removal of `relatedActivityId` across multiple data structures, improving documentation clarity.

- **Tests**
	- Removed a test related to referencing old activities, aligning tests with the updated activity structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->