### PR TITLE
fix: Return distinct actions in GetAlinnActions

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/Authorization/DialogEntityExtensions.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/Authorization/DialogEntityExtensions.cs
@@ -20,6 +20,8 @@ internal static class DialogEntityExtensions
                 .Select(x => new AltinnAction(GetReadActionForAuthorizationAttribute(x.AuthorizationAttribute!), x.AuthorizationAttribute)))
             // We always need to check if the user can read the main resource
             .Append(new AltinnAction(Constants.ReadAction, Constants.MainResource))
+            .GroupBy(x => new { x.Name, x.AuthorizationAttribute })
+            .Select(g => g.First()) // Remove duplicates by grouping
             .ToList();
     }
 

--- a/tests/Digdir.Domain.Dialogporten.Infrastructure.Unit.Tests/DialogEntityExtensionsTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Infrastructure.Unit.Tests/DialogEntityExtensionsTests.cs
@@ -1,5 +1,6 @@
 ﻿using Digdir.Domain.Dialogporten.Application.Common.Authorization;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Actions;
 using Digdir.Domain.Dialogporten.Infrastructure.Altinn.Authorization;
 using Xunit;
 
@@ -13,11 +14,23 @@ public class DialogEntityExtensionsTests
         // Arrange
         var dialogEntity = new DialogEntity
         {
-            ApiActions = [],
-            GuiActions = [],
+            ApiActions = [
+                new DialogApiAction { Action = "read" },
+                new DialogApiAction { Action = "read" },
+                new DialogApiAction { Action = "read", AuthorizationAttribute = "foo" },
+                new DialogApiAction { Action = "transmissionread", AuthorizationAttribute = "bar" },
+                new DialogApiAction { Action = "apiread" },
+            ],
+            GuiActions = [
+                new DialogGuiAction { Action = "read" },
+                new DialogGuiAction { Action = "read" },
+                new DialogGuiAction { Action = "read", AuthorizationAttribute = "foo" },
+                new DialogGuiAction { Action = "transmissionread", AuthorizationAttribute = "bar" },
+                new DialogGuiAction { Action = "guiread" },
+            ],
             Transmissions =
             [
-                new() { AuthorizationAttribute = "foo" },
+                new() { AuthorizationAttribute = "bar" },
                 new() { AuthorizationAttribute = "urn:altinn:subresource:bar" },
                 new() { AuthorizationAttribute = "urn:altinn:task:Task_1" },
                 new() { AuthorizationAttribute = "urn:altinn:resource:some-service:element1" },
@@ -30,8 +43,12 @@ public class DialogEntityExtensionsTests
 
         // Assert
         Assert.NotNull(actions);
-        Assert.NotEmpty(actions);
-        Assert.Contains(actions, a => a is { Name: Constants.TransmissionReadAction, AuthorizationAttribute: "foo" });
+        Assert.Equal(9, actions.Count);
+        Assert.Contains(actions, a => a is { Name: Constants.ReadAction, AuthorizationAttribute: Constants.MainResource });
+        Assert.Contains(actions, a => a is { Name: Constants.ReadAction, AuthorizationAttribute: "foo" });
+        Assert.Contains(actions, a => a is { Name: Constants.TransmissionReadAction, AuthorizationAttribute: "bar" });
+        Assert.Contains(actions, a => a is { Name: "apiread", AuthorizationAttribute: Constants.MainResource });
+        Assert.Contains(actions, a => a is { Name: "guiread", AuthorizationAttribute: Constants.MainResource });
         Assert.Contains(actions, a => a is { Name: Constants.TransmissionReadAction, AuthorizationAttribute: "urn:altinn:subresource:bar" });
         Assert.Contains(actions, a => a is { Name: Constants.TransmissionReadAction, AuthorizationAttribute: "urn:altinn:task:Task_1" });
         Assert.Contains(actions, a => a is { Name: Constants.ReadAction, AuthorizationAttribute: "urn:altinn:resource:some-service:element1" });


### PR DESCRIPTION
## Description

GetAltinnActions now removes duplicate action/resource tuples, which results in simpler XACML requests and dialog tokens.

## Related Issue(s)

- N/A

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved handling of duplicate actions in the Altinn authorization process, ensuring a cleaner and more accurate list of actions.
  
- **Bug Fixes**
	- Enhanced test coverage for action retrieval, ensuring the correct actions and attributes are validated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->