### PR TITLE
fix: Fix ID-porten acr claim parsing

### DIFF
--- a/tests/Digdir.Domain.Dialogporten.Application.Unit.Tests/Features/V1/Common/Extensions/ClaimsPrincipalExtensionsTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Unit.Tests/Features/V1/Common/Extensions/ClaimsPrincipalExtensionsTests.cs
@@ -1,0 +1,59 @@
+using System.Security.Claims;
+using Digdir.Domain.Dialogporten.Application.Common.Extensions;
+
+namespace Digdir.Domain.Dialogporten.Application.Unit.Tests.Features.V1.Common.Extensions;
+
+public class ClaimsPrincipalExtensionsTests
+{
+    [Fact]
+    public void TryGetAuthenticationLevel_Should_Parse_Idporten_Acr_Claim_For_Level3()
+    {
+        // Arrange
+        var claimsPrincipal = new ClaimsPrincipal(new ClaimsIdentity(new[]
+        {
+            new Claim("acr", "idporten-loa-substantial")
+        }));
+
+        // Act
+        var result = claimsPrincipal.TryGetAuthenticationLevel(out var authenticationLevel);
+
+        // Assert
+        Assert.True(result);
+        Assert.Equal(3, authenticationLevel);
+    }
+
+    [Fact]
+    public void TryGetAuthenticationLevel_Should_Parse_Idporten_Acr_Claim_For_Level4()
+    {
+        // Arrange
+        var claimsPrincipal = new ClaimsPrincipal(new ClaimsIdentity(new[]
+        {
+            new Claim("acr", "idporten-loa-high")
+        }));
+
+        // Act
+        var result = claimsPrincipal.TryGetAuthenticationLevel(out var authenticationLevel);
+
+        // Assert
+        Assert.True(result);
+        Assert.Equal(4, authenticationLevel);
+    }
+
+    [Fact]
+    public void TryGetAuthenticationLevel_Should_Parse_Altinn_Authlevel_First()
+    {
+        // Arrange
+        var claimsPrincipal = new ClaimsPrincipal(new ClaimsIdentity(new[]
+        {
+            new Claim("acr", "idporten-loa-high"),
+            new Claim("urn:altinn:authlevel", "5")
+        }));
+
+        // Act
+        var result = claimsPrincipal.TryGetAuthenticationLevel(out var authenticationLevel);
+
+        // Assert
+        Assert.True(result);
+        Assert.Equal(5, authenticationLevel);
+    }
+}


### PR DESCRIPTION
## Description

This fixes acr-parsing (authentication level) for real ID-porten tokens

## Related Issue(s)

N/A

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Note 

There is a bug in the token generator in https://github.com/Altinn/AltinnTestTools, which is still producing the old "Level3" and "Level4" acr-values.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced logic for determining authentication levels, improving efficiency and clarity.
	- Improved handling of authorization details for better data management.

- **Tests**
	- Introduced unit tests for the authentication level parsing, ensuring accuracy and reliability of the new logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->