### PR TITLE
fix(slack-notifier): exclude health checks from alerts

### DIFF
--- a/.azure/modules/functionApp/slackNotifier.bicep
+++ b/.azure/modules/functionApp/slackNotifier.bicep
@@ -162,7 +162,7 @@ var query = '''
                  | where type != "ZiggyCreatures.Caching.Fusion.SyntheticTimeoutException"),
                  (traces
                  | where severityLevel >= 3 or (severityLevel >= 2 and customDimensions.SourceContext startswith "Digdir"))
-                 | where operation_Name !startswith "GET /health/"
+                 | where customDimensions.RequestPath !startswith "/health"
              | summarize Count = count()
                  by
                  Environment = tostring(customDimensions.AspNetCoreEnvironment),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Logging has changed a bit so need to change the endpoint to exclude from alerts. We don't want to log the health-check endpoint traces, but that has to be tweaked in another PR

## Related Issue(s)

- N/A

Slack discussion: https://digdir.slack.com/archives/C079XRW5G5A/p1729643530959569

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced alerting logic for the Slack Notifier function app to broaden the scope of monitored requests.
	- Defined SKU parameters to ensure valid options for resource deployment.

- **Bug Fixes**
	- Adjusted criteria for exception alerting to improve monitoring accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->