### PR TITLE
fix: Simplify subject attribute matching

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/Authorization/AltinnAuthorizationClient.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/Authorization/AltinnAuthorizationClient.cs
@@ -1,5 +1,4 @@
 ﻿using System.Diagnostics;
-using System.Security.Claims;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Altinn.Authorization.ABAC.Xacml.JsonProfile;

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/Authorization/DecisionRequestHelper.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/Authorization/DecisionRequestHelper.cs
@@ -112,7 +112,7 @@ internal static class DecisionRequestHelper
             _ => null
         })
         .Where(x => x != null)
-        .MinBy(x => PrioritizedClaimTypes.IndexOf(x!.Attribute.First().AttributeId)) switch
+        .MinBy(x => PrioritizedClaimTypes.IndexOf(x!.Attribute[0].AttributeId)) switch
         {
             { } validCategory => new List<XacmlJsonCategory> { validCategory },
             _ => throw new UnreachableException(

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/Authorization/DecisionRequestHelper.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/Authorization/DecisionRequestHelper.cs
@@ -1,4 +1,5 @@
-﻿using Altinn.Authorization.ABAC.Xacml.JsonProfile;
+﻿using System.Diagnostics;
+using Altinn.Authorization.ABAC.Xacml.JsonProfile;
 using System.Security.Claims;
 
 using Digdir.Domain.Dialogporten.Application.Common.Extensions;
@@ -110,11 +111,9 @@ internal static class DecisionRequestHelper
             }
         }
 
-        var attributes = selectedAttribute != null
-            ? [selectedAttribute]
-            : new List<XacmlJsonAttribute>();
-
-        return [new() { Id = SubjectId, Attribute = attributes }];
+        return selectedAttribute == null
+            ? throw new UnreachableException("Unable to find a suitable subject attribute for the authorization request. Having a known user type should be enforced during authentication (see UserTypeValidationMiddleware).")
+            : ([new() { Id = SubjectId, Attribute = [selectedAttribute] }]);
     }
 
 

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/Authorization/DecisionRequestHelper.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/Authorization/DecisionRequestHelper.cs
@@ -20,14 +20,18 @@ internal static class DecisionRequestHelper
     private const string AttributeIdAction = "urn:oasis:names:tc:xacml:1.0:action:action-id";
     private const string AttributeIdResource = "urn:altinn:resource";
     private const string AttributeIdResourceInstance = "urn:altinn:resourceinstance";
+    private const string AttributeIdSubResource = "urn:altinn:subresource";
+
     private const string AttributeIdOrg = "urn:altinn:org";
     private const string AttributeIdApp = "urn:altinn:app";
-    private const string AttributeIdSystemUser = "urn:altinn:systemuser:uuid";
     private const string AttributeIdAppInstance = "urn:altinn:instance-id";
-    private const string AttributeIdSubResource = "urn:altinn:subresource";
+
     private const string AttributeIdUserId = "urn:altinn:userid";
+    private const string AttributeIdPerson = "urn:altinn:person:identifier-no";
+    private const string AttributeIdSystemUser = "urn:altinn:systemuser:uuid";
+
     // The order of these attribute types is important as we want to prioritize the most specific claim types.
-    private static readonly List<string> PrioritizedClaimTypes = [AttributeIdUserId, NorwegianPersonIdentifier.Prefix, AttributeIdSystemUser];
+    private static readonly List<string> PrioritizedClaimTypes = [AttributeIdUserId, AttributeIdPerson, AttributeIdSystemUser];
 
     private const string ReservedResourcePrefixForApps = "app_";
 
@@ -95,7 +99,7 @@ internal static class DecisionRequestHelper
             PidClaimType => new XacmlJsonCategory
             {
                 Id = SubjectId,
-                Attribute = [new() { AttributeId = NorwegianPersonIdentifier.Prefix, Value = claim.Value }]
+                Attribute = [new() { AttributeId = AttributeIdPerson, Value = claim.Value }]
             },
             RarAuthorizationDetailsClaimType when new ClaimsPrincipal(new ClaimsIdentity(new[] { claim })).TryGetSystemUserId(out var systemUserId) => new XacmlJsonCategory
             {

--- a/tests/Digdir.Domain.Dialogporten.Infrastructure.Unit.Tests/DecisionRequestHelperTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Infrastructure.Unit.Tests/DecisionRequestHelperTests.cs
@@ -23,7 +23,7 @@ public class DecisionRequestHelperTests
                 ("pid", "12345678901"),
 
                 // This should not be copied as subject claim since there's a "pid"-claim
-                ("consumer", ConsumerClaimValue)
+                ("authorization_details", AuthorizationDetailsClaimValue)
             ),
             $"{NorwegianOrganizationIdentifier.PrefixWithSeparator}713330310");
         var dialogId = request.DialogId;
@@ -42,9 +42,8 @@ public class DecisionRequestHelperTests
         // Check AccessSubject attributes
         var accessSubject = result.Request.AccessSubject.First();
         Assert.Equal("s1", accessSubject.Id);
-        Assert.Contains(accessSubject.Attribute, a => a.AttributeId == "urn:altinn:foo" && a.Value == "bar");
         Assert.Contains(accessSubject.Attribute, a => a.AttributeId == "urn:altinn:person:identifier-no" && a.Value == "12345678901");
-        Assert.DoesNotContain(accessSubject.Attribute, a => a.AttributeId == "urn:altinn:organization:identifier-no");
+        Assert.Single(accessSubject.Attribute);
 
         // Check Action attributes.
         var actionIdsByName = new Dictionary<string, string>();
@@ -79,7 +78,7 @@ public class DecisionRequestHelperTests
     }
 
     [Fact]
-    public void CreateDialogDetailsRequestShouldReturnCorrectRequestForLegacyEnterpriseUsers()
+    public void CreateDialogDetailsRequestShouldReturnCorrectRequestForExchangedTokens()
     {
         // Arrange
         var request = CreateDialogDetailsAuthorizationRequest(
@@ -87,7 +86,7 @@ public class DecisionRequestHelperTests
                 ("urn:altinn:userid", "5678901"),
 
                 // This should not be copied as subject claim since there's a "urn:altinn:user-id"-claim
-                ("consumer", ConsumerClaimValue)
+                ("pid", "12345678901")
             ),
             $"{NorwegianOrganizationIdentifier.PrefixWithSeparator}713330310");
 
@@ -98,7 +97,7 @@ public class DecisionRequestHelperTests
         var accessSubject = result.Request.AccessSubject.First();
         Assert.Equal("s1", accessSubject.Id);
         Assert.Contains(accessSubject.Attribute, a => a.AttributeId == "urn:altinn:userid" && a.Value == "5678901");
-        Assert.DoesNotContain(accessSubject.Attribute, a => a.AttributeId == "urn:altinn:organization:identifier-no");
+        Assert.Single(accessSubject.Attribute);
     }
 
     [Fact]
@@ -136,7 +135,9 @@ public class DecisionRequestHelperTests
         // Arrange
         var request = CreateDialogDetailsAuthorizationRequest(
             GetAsClaims(
-                ("authorization_details", AuthorizationDetailsClaimValue)
+                ("authorization_details", AuthorizationDetailsClaimValue),
+                ("pid", "12345678901"),
+                ("consumer", ConsumerClaimValue)
             ),
             $"{NorwegianOrganizationIdentifier.PrefixWithSeparator}713330310"
             );
@@ -151,33 +152,8 @@ public class DecisionRequestHelperTests
 
         var accessSubject = result.Request.AccessSubject.First();
         Assert.Equal("s1", accessSubject.Id);
-        Assert.Contains(accessSubject.Attribute, a => a.AttributeId == "urn:altinn:foo" && a.Value == "bar");
         Assert.Contains(accessSubject.Attribute, a => a.AttributeId == "urn:altinn:systemuser:uuid" && a.Value == "unique_systemuser_id");
-    }
-
-    [Fact]
-    public void CreateDialogDetailsRequestShouldReturnCorrectRequestForConsumerOrgAndPersonParty()
-    {
-        // Arrange
-        var request = CreateDialogDetailsAuthorizationRequest(
-            GetAsClaims(
-                // Should be copied as subject claim since there's not a "pid"-claim
-                ("consumer", ConsumerClaimValue)
-            ),
-            $"{NorwegianPersonIdentifier.PrefixWithSeparator}16073422888");
-
-        // Act
-        var result = DecisionRequestHelper.CreateDialogDetailsRequest(request);
-
-        // Assert
-        // Check that we have the organizationnumber
-        var accessSubject = result.Request.AccessSubject.First();
-        Assert.Contains(accessSubject.Attribute, a => a.AttributeId == "urn:altinn:organization:identifier-no" && a.Value == "991825827");
-
-        // Check that we have the ssn attribute as resource owner
-        var resource1 = result.Request.Resource.FirstOrDefault(r => r.Id == "r1");
-        Assert.NotNull(resource1);
-        Assert.Contains(resource1.Attribute, a => a.AttributeId == "urn:altinn:person:identifier-no" && a.Value == "16073422888");
+        Assert.Single(accessSubject.Attribute);
     }
 
     [Fact]

--- a/tests/Digdir.Domain.Dialogporten.Infrastructure.Unit.Tests/DecisionRequestHelperTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Infrastructure.Unit.Tests/DecisionRequestHelperTests.cs
@@ -19,10 +19,9 @@ public class DecisionRequestHelperTests
         // Arrange
         var request = CreateDialogDetailsAuthorizationRequest(
             GetAsClaims(
-                ("pid", "12345678901"),
-
                 // This should not be copied as subject claim since there's a "pid"-claim
-                ("authorization_details", AuthorizationDetailsClaimValue)
+                ("authorization_details", AuthorizationDetailsClaimValue),
+                ("pid", "12345678901")
             ),
             $"{NorwegianOrganizationIdentifier.PrefixWithSeparator}713330310");
         var dialogId = request.DialogId;
@@ -82,10 +81,9 @@ public class DecisionRequestHelperTests
         // Arrange
         var request = CreateDialogDetailsAuthorizationRequest(
             GetAsClaims(
-                ("urn:altinn:userid", "5678901"),
-
                 // This should not be copied as subject claim since there's a "urn:altinn:user-id"-claim
-                ("pid", "12345678901")
+                ("pid", "12345678901"),
+                ("urn:altinn:userid", "5678901")
             ),
             $"{NorwegianOrganizationIdentifier.PrefixWithSeparator}713330310");
 
@@ -134,8 +132,7 @@ public class DecisionRequestHelperTests
         // Arrange
         var request = CreateDialogDetailsAuthorizationRequest(
             GetAsClaims(
-                ("authorization_details", AuthorizationDetailsClaimValue),
-                ("pid", "12345678901")
+                ("authorization_details", AuthorizationDetailsClaimValue)
             ),
             $"{NorwegianOrganizationIdentifier.PrefixWithSeparator}713330310"
             );

--- a/tests/Digdir.Domain.Dialogporten.Infrastructure.Unit.Tests/DecisionRequestHelperTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Infrastructure.Unit.Tests/DecisionRequestHelperTests.cs
@@ -236,7 +236,6 @@ public class DecisionRequestHelperTests
         // Arrange
         var request = CreateDialogDetailsAuthorizationRequest(
             GetAsClaims(
-                // Should be copied as subject claim since there's not a "pid"-claim
                 ("pid", "12345678901")
             ),
             $"{NorwegianPersonIdentifier.PrefixWithSeparator}12345678901");

--- a/tests/Digdir.Domain.Dialogporten.Infrastructure.Unit.Tests/DecisionRequestHelperTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Infrastructure.Unit.Tests/DecisionRequestHelperTests.cs
@@ -162,7 +162,7 @@ public class DecisionRequestHelperTests
         // Arrange
         var request = CreateDialogDetailsAuthorizationRequest(
             GetAsClaims(
-                ("consumer", ConsumerClaimValue)
+                ("pid", "12345678901")
             ),
             $"{NorwegianPersonIdentifier.PrefixWithSeparator}16073422888");
 
@@ -187,7 +187,7 @@ public class DecisionRequestHelperTests
         // Arrange
         var request = CreateDialogDetailsAuthorizationRequest(
             GetAsClaims(
-                ("consumer", ConsumerClaimValue)
+                ("pid", "12345678901")
             ),
             $"{NorwegianPersonIdentifier.PrefixWithSeparator}16073422888");
 
@@ -209,12 +209,13 @@ public class DecisionRequestHelperTests
     }
 
     [Fact]
+
     public void CreateDialogDetailsRequestShouldReturnCorrectRequestForFullyQualifiedSubresource()
     {
         // Arrange
         var request = CreateDialogDetailsAuthorizationRequest(
             GetAsClaims(
-                ("consumer", ConsumerClaimValue)
+                ("pid", "12345678901")
             ),
             $"{NorwegianPersonIdentifier.PrefixWithSeparator}16073422888");
 
@@ -239,7 +240,7 @@ public class DecisionRequestHelperTests
         var request = CreateDialogDetailsAuthorizationRequest(
             GetAsClaims(
                 // Should be copied as subject claim since there's not a "pid"-claim
-                ("consumer", ConsumerClaimValue)
+                ("pid", "12345678901")
             ),
             $"{NorwegianPersonIdentifier.PrefixWithSeparator}12345678901");
 


### PR DESCRIPTION
## Description

This simplifies the subject attribute mapping to only use a single attribute, as multiple subject attributes are explicitly disallowed by the PDP (eg. for system users). In fact, for external use, only a single subject attribute is ever required (eg. sending the authlvl attribute is not supported, as it is the PEPs responsibility to enforce any obligations returned from the PDP).

In addition, support for allowing pure Maskinporten tokens (using only consumer-claims) has been removed, as this is not officially supported in the Altinn Authorization model; only userid/pid/systemuserid will cause the PDP to resolve roles/access packages in order to match policy rules, so the only way sending organization numbers as subject claims is if the policy itself contains hard coded organization numbers, which is discouraged (should access lists for that).

Note that urn:altinn:org (ie serviceowner acronym claim types) are left out, as authenticated service owners should not use the end user APIs (this would potentially leak information that we only want to make available to the end users).

## Related Issue(s)

See previous PR (#1340) and [slack thread](https://digdir.slack.com/archives/C079ZFUSFMW/p1729772275391209). 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling with the introduction of an `UnreachableException` for invalid user types.
	- Streamlined attribute selection logic for improved performance.

- **Bug Fixes**
	- Updated claims structure in tests to reflect recent changes, ensuring accurate validation.

- **Tests**
	- Added a new test for exception handling.
	- Renamed and consolidated existing tests for clarity and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->