### PR TITLE
fix: Add system user id to identifying claims

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Application/Common/Extensions/ClaimsPrincipalExtensions.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Common/Extensions/ClaimsPrincipalExtensions.cs
@@ -220,13 +220,11 @@ public static class ClaimsPrincipalExtensions
 
         // If we have a RAR-claim, this is most likely a system user. We need to extract the systemuser-uuid
         // from the authorization_details claim
-        if (claimsList.Any(c => c.Type == AuthorizationDetailsClaim))
+        // Extract the systemuser-uuid from the authorization_details claim if present
+        var rarClaim = claimsList.FirstOrDefault(c => c.Type == AuthorizationDetailsClaim);
+        if (rarClaim != null && rarClaim.TryGetSystemUserId(out var systemUserId))
         {
-            var rarClaim = claimsList.First(c => c.Type == AuthorizationDetailsClaim);
-            if (rarClaim.TryGetSystemUserId(out var systemUserId))
-            {
-                identifyingClaims.Add(new Claim(AuthorizationDetailsType, systemUserId));
-            }
+            identifyingClaims.Add(new Claim(AuthorizationDetailsType, systemUserId));
         }
 
         return identifyingClaims;

--- a/src/Digdir.Domain.Dialogporten.Application/Common/Extensions/ClaimsPrincipalExtensions.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Common/Extensions/ClaimsPrincipalExtensions.cs
@@ -218,9 +218,8 @@ public static class ClaimsPrincipalExtensions
             c.Type.StartsWith(AltinnClaimPrefix, StringComparison.Ordinal)
         ).OrderBy(c => c.Type).ToList();
 
-        // If we have a RAR-claim, this is most likely a system user. We need to extract the systemuser-uuid
-        // from the authorization_details claim
-        // Extract the systemuser-uuid from the authorization_details claim if present
+        // If we have a RAR-claim, this is most likely a system user. Attempt to extract the
+        // systemuser-uuid from the authorization_details claim and add to the list.
         var rarClaim = claimsList.FirstOrDefault(c => c.Type == AuthorizationDetailsClaim);
         if (rarClaim != null && rarClaim.TryGetSystemUserId(out var systemUserId))
         {

--- a/src/Digdir.Domain.Dialogporten.Application/Common/Extensions/ClaimsPrincipalExtensions.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Common/Extensions/ClaimsPrincipalExtensions.cs
@@ -110,6 +110,14 @@ public static class ClaimsPrincipalExtensions
         return authorizationDetails is not null;
     }
 
+    public static bool TryGetSystemUserId(this Claim claim,
+        [NotNullWhen(true)] out string? systemUserId) =>
+        new List<Claim> { claim }.TryGetSystemUserId(out systemUserId);
+
+    public static bool TryGetSystemUserId(this List<Claim> claimsList,
+        [NotNullWhen(true)] out string? systemUserId) =>
+        new ClaimsPrincipal(new ClaimsIdentity(claimsList.ToArray())).TryGetSystemUserId(out systemUserId);
+
     public static bool TryGetSystemUserId(this ClaimsPrincipal claimsPrincipal,
         [NotNullWhen(true)] out string? systemUserId)
     {
@@ -198,14 +206,31 @@ public static class ClaimsPrincipalExtensions
         return false;
     }
 
-    public static IEnumerable<Claim> GetIdentifyingClaims(this List<Claim> claims) =>
-        claims.Where(c =>
+    public static IEnumerable<Claim> GetIdentifyingClaims(this IEnumerable<Claim> claims)
+    {
+        var claimsList = claims.ToList();
+
+        var identifyingClaims = claimsList.Where(c =>
             c.Type == PidClaim ||
             c.Type == ConsumerClaim ||
             c.Type == SupplierClaim ||
             c.Type == IdportenAuthLevelClaim ||
             c.Type.StartsWith(AltinnClaimPrefix, StringComparison.Ordinal)
-        ).OrderBy(c => c.Type);
+        ).OrderBy(c => c.Type).ToList();
+
+        // If we have a RAR-claim, this is most likely a system user. We need to extract the systemuser-uuid
+        // from the authorization_details claim
+        if (claimsList.Any(c => c.Type == AuthorizationDetailsClaim))
+        {
+            var rarClaim = claimsList.First(c => c.Type == AuthorizationDetailsClaim);
+            if (rarClaim.TryGetSystemUserId(out var systemUserId))
+            {
+                identifyingClaims.Add(new Claim(AuthorizationDetailsType, systemUserId));
+            }
+        }
+
+        return identifyingClaims;
+    }
 
     public static (UserIdType, string externalId) GetUserType(this ClaimsPrincipal claimsPrincipal)
     {

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/Authorization/DecisionRequestHelper.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/Authorization/DecisionRequestHelper.cs
@@ -101,7 +101,7 @@ internal static class DecisionRequestHelper
                 Id = SubjectId,
                 Attribute = [new() { AttributeId = AttributeIdPerson, Value = claim.Value }]
             },
-            RarAuthorizationDetailsClaimType when new ClaimsPrincipal(new ClaimsIdentity(new[] { claim })).TryGetSystemUserId(out var systemUserId) => new XacmlJsonCategory
+            RarAuthorizationDetailsClaimType when claim.TryGetSystemUserId(out var systemUserId) => new XacmlJsonCategory
             {
                 Id = SubjectId,
                 Attribute =

--- a/tests/Digdir.Domain.Dialogporten.Application.Unit.Tests/Features/V1/Common/Extensions/ClaimsPrincipalExtensionsTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Unit.Tests/Features/V1/Common/Extensions/ClaimsPrincipalExtensionsTests.cs
@@ -53,4 +53,19 @@ public class ClaimsPrincipalExtensionsTests
         Assert.True(result);
         Assert.Equal(5, authenticationLevel);
     }
+
+    [Fact]
+    public void GetIdentifyingClaims_Should_Include_SystemUserIdentifier_From_AuthorizationDetails()
+    {
+        // Arrange
+        var claimsPrincipal = new ClaimsPrincipal(new ClaimsIdentity([
+            new Claim("authorization_details", "[{\"type\":\"urn:altinn:systemuser\",\"systemuser_id\":[\"e3b87b08-dce6-4edd-8308-db887950a83b\"],\"systemuser_org\":{\"authority\":\"iso6523-actorid-upis\",\"ID\":\"0192:991825827\"},\"system_id\":\"1d81b874-f139-4842-bd0a-e5cc64319272\"}]")
+        ]));
+
+        // Act
+        var identifyingClaims = claimsPrincipal.Claims.GetIdentifyingClaims();
+
+        // Assert
+        Assert.Contains(identifyingClaims, c => c.Type == "urn:altinn:systemuser" && c.Value == "e3b87b08-dce6-4edd-8308-db887950a83b");
+    }
 }


### PR DESCRIPTION
## Description

This adds a check to include the system user id in the list of identifiable claims, which is in turn used to generate a cache key for authorization requests on dialog details accesses.

## Related Issue(s)

- #1363

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced methods to simplify the retrieval of system user IDs from claims.
  - Enhanced claims processing to include system user identifiers from authorization details.

- **Bug Fixes**
  - Streamlined logic in handling user ID extraction, improving efficiency.

- **Tests**
  - Added a test to verify the correct extraction of system user identifiers from claims.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->