### PR TITLE
fix(e2e): Use pagination in sentinel

### DIFF
--- a/tests/k6/common/sentinel.js
+++ b/tests/k6/common/sentinel.js
@@ -8,23 +8,37 @@ export default function () {
         scopes: "digdir:dialogporten.serviceprovider digdir:dialogporten.serviceprovider.search digdir:dialogporten.serviceprovider.admin digdir:dialogporten.correspondence"
     }
     describe('Post run: checking for unpurged dialogs', () => {
-        let r = getSO('dialogs/?Search=' + sentinelValue, null, tokenOptions);
-        expectStatusFor(r).to.equal(200);
-        expect(r, 'response').to.have.validJsonBody();
-        var response = r.json();
-        if (response.items && response.items.length > 0) {
-            console.error("Found " + response.items.length + " unpurged dialogs, make sure that all tests clean up after themselves. Purging ...");
-            response.items.forEach((item) => {
-                console.warn("Sentinel purging dialog with id: " + item.id)
-                let r = purgeSO('dialogs/' + item.id, null, tokenOptions);
+        let hasNextPage = false;
+        let continuationToken = "";
+        let dialogIdsToPurge = [];
+        do {
+            let r = getSO('dialogs/?Search=' + sentinelValue + continuationToken, null, tokenOptions);
+            expectStatusFor(r).to.equal(200);
+            expect(r, 'response').to.have.validJsonBody();
+            let response = r.json();
+            if (response.items && response.items.length > 0) {
+                response.items.forEach((item) => {
+                    dialogIdsToPurge.push(item.id);
+                });
+
+                hasNextPage = response.hasNextPage;
+                continuationToken = "&continuationToken=" + response.continuationToken;
+            }
+        } while (hasNextPage);
+
+        if (dialogIdsToPurge.length > 0) {
+            console.error("Found " + dialogIdsToPurge.length + " unpurged dialogs, make sure that all tests clean up after themselves. Purging ...");
+            dialogIdsToPurge.forEach((id) => {
+                console.warn("Sentinel purging dialog with id: " + id)
+                let r = purgeSO('dialogs/' + id, null, tokenOptions);
                 if (r.status != 204) {
-                    console.error("Failed to purge dialog with id: " + item.id);
+                    console.error("Failed to purge dialog with id: " + id);
                     console.log(r);
                 }
             });
-
-            // Fail the test after purging for visibility
-            expect(response.items.length, 'unpurged dialogs').to.equal(0);
         }
+
+        // Fail the test after purging for visibility
+        expect(dialogIdsToPurge.length, 'unpurged dialogs').to.equal(0);
     });
 }

--- a/tests/k6/common/sentinel.js
+++ b/tests/k6/common/sentinel.js
@@ -20,10 +20,9 @@ export default function () {
                 response.items.forEach((item) => {
                     dialogIdsToPurge.push(item.id);
                 });
-
-                hasNextPage = response.hasNextPage;
                 continuationToken = "&continuationToken=" + response.continuationToken;
             }
+            hasNextPage = response.hasNextPage;
         } while (hasNextPage);
 
         if (dialogIdsToPurge.length > 0) {


### PR DESCRIPTION
## Description

This fixes the sentinel to clean all unpurged dialogs, not just the first 100

## Related Issue(s)

- #{issue number}

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of unpurged dialogs by implementing pagination, ensuring all dialogs are properly fetched and purged.
	- Enhanced error handling to provide clearer references to dialog IDs during purge failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->