### PR TITLE
feat(webapi): Return 410 GONE for notification checks on deleted dialogs

### DIFF
--- a/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/DialogActivities/NotificationCondition/NotificationConditionEndpoint.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/DialogActivities/NotificationCondition/NotificationConditionEndpoint.cs
@@ -28,6 +28,7 @@ public sealed class NotificationConditionEndpoint : Endpoint<NotificationConditi
         await result.Match(
             dto => SendOkAsync(dto, ct),
             validationError => this.BadRequestAsync(validationError, ct),
-            notFound => this.NotFoundAsync(notFound, ct));
+            notFound => this.NotFoundAsync(notFound, ct),
+            deleted => this.GoneAsync(deleted, ct));
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue(s)

- #1386 

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling for deleted entities in the notification condition query.
	- Added a new response type for deleted dialogs, improving clarity in error reporting.

- **Bug Fixes**
	- Improved response handling for scenarios where a requested dialog has been deleted.

- **Tests**
	- Introduced a new test case to verify correct behavior when querying a deleted dialog.
	- Refactored test methods for improved readability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->