### PR TITLE
fix: Use yt01 token generator environment for k6 tests running on yt01

### DIFF
--- a/tests/k6/common/config.js
+++ b/tests/k6/common/config.js
@@ -41,5 +41,6 @@ if (!baseUrls[__ENV.API_VERSION]["serviceowner"][__ENV.API_ENVIRONMENT]) {
 
 export const baseUrlEndUser = baseUrls[__ENV.API_VERSION]["enduser"][__ENV.API_ENVIRONMENT];
 export const baseUrlServiceOwner = baseUrls[__ENV.API_VERSION]["serviceowner"][__ENV.API_ENVIRONMENT];
+export const tokenGeneratorEnv = __ENV.API_ENVIRONMENT == "yt01" ? "yt01" : "tt02"; // yt01 is the only environment that has a separate token generator environment
 
 export const sentinelValue = "dialogporten-e2e-sentinel";

--- a/tests/k6/common/token.js
+++ b/tests/k6/common/token.js
@@ -1,7 +1,7 @@
 import http from "k6/http";
 import encoding from "k6/encoding";
 import { extend } from "./extend.js";
-import { defaultEndUserSsn, defaultServiceOwnerOrgNo } from "./config.js";
+import { defaultEndUserSsn, defaultServiceOwnerOrgNo, tokenGeneratorEnv } from "./config.js";
 
 let defaultTokenOptions = {
   scopes: "digdir:dialogporten digdir:dialogporten.serviceprovider digdir:dialogporten.serviceprovider.search",
@@ -57,14 +57,14 @@ function fetchToken(url, tokenOptions, type) {
 
 export function getServiceOwnerTokenFromGenerator(tokenOptions = null) {
   let fullTokenOptions = extend({}, defaultTokenOptions, tokenOptions);
-  const url = `http://altinn-testtools-token-generator.azurewebsites.net/api/GetEnterpriseToken?env=tt02&scopes=${encodeURIComponent(fullTokenOptions.scopes)}&org=${fullTokenOptions.orgName}&orgNo=${fullTokenOptions.orgNo}&ttl=${tokenTtl}`;
-  return fetchToken(url, fullTokenOptions, `service owner (orgno:${fullTokenOptions.orgNo} orgName:${fullTokenOptions.orgName})`);
+  const url = `http://altinn-testtools-token-generator.azurewebsites.net/api/GetEnterpriseToken?env=${tokenGeneratorEnv}&scopes=${encodeURIComponent(fullTokenOptions.scopes)}&org=${fullTokenOptions.orgName}&orgNo=${fullTokenOptions.orgNo}&ttl=${tokenTtl}`;
+  return fetchToken(url, fullTokenOptions, `service owner (orgno:${fullTokenOptions.orgNo} orgName:${fullTokenOptions.orgName} tokenGeneratorEnv:${tokenGeneratorEnv})`);
 }
 
 export function getEnduserTokenFromGenerator(tokenOptions = null) {
   let fullTokenOptions = extend({}, defaultTokenOptions, tokenOptions);
-  const url = `http://altinn-testtools-token-generator.azurewebsites.net/api/GetPersonalToken?env=tt02&scopes=${encodeURIComponent(fullTokenOptions.scopes)}&pid=${fullTokenOptions.ssn}&ttl=${tokenTtl}`;
-  return fetchToken(url, fullTokenOptions, `end user (ssn:${fullTokenOptions.ssn})`);
+  const url = `http://altinn-testtools-token-generator.azurewebsites.net/api/GetPersonalToken?env=${tokenGeneratorEnv}&scopes=${encodeURIComponent(fullTokenOptions.scopes)}&pid=${fullTokenOptions.ssn}&ttl=${tokenTtl}`;
+  return fetchToken(url, fullTokenOptions, `end user (ssn:${fullTokenOptions.ssn}, tokenGeneratorEnv:${tokenGeneratorEnv})`);
 }
 
 export function getDefaultEnduserOrgNo() {


### PR DESCRIPTION
## Description

This updates the token generator to use the yt01 token generator when running against the yt01.

## Related Issue(s)

- N/A

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new environment variable for dynamic token generation based on the API environment.
	- Enhanced token generation functionality to use the new environment variable in URL construction.

- **Bug Fixes**
	- Improved logging for token generation to provide clearer context about the environment used.

- **Documentation**
	- Updated comments to reflect the changes in token generation logic and environment handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->