### PR TITLE
Reenable party list cache, log party name look failure with negative cache TTL

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/Authorization/AltinnAuthorizationClient.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/Authorization/AltinnAuthorizationClient.cs
@@ -81,9 +81,8 @@ internal sealed class AltinnAuthorizationClient : IAltinnAuthorization
         CancellationToken cancellationToken = default)
     {
         var authorizedPartiesRequest = new AuthorizedPartiesRequest(authenticatedParty);
-        // var authorizedParties = await _partiesCache.GetOrSetAsync(authorizedPartiesRequest.GenerateCacheKey(), async token
-        //     => await PerformAuthorizedPartiesRequest(authorizedPartiesRequest, token), token: cancellationToken);
-        var authorizedParties = await PerformAuthorizedPartiesRequest(authorizedPartiesRequest, cancellationToken);
+        var authorizedParties = await _partiesCache.GetOrSetAsync(authorizedPartiesRequest.GenerateCacheKey(), async token
+             => await PerformAuthorizedPartiesRequest(authorizedPartiesRequest, token), token: cancellationToken);
         return flatten ? GetFlattenedAuthorizedParties(authorizedParties) : authorizedParties;
     }
 


### PR DESCRIPTION
## Description

Party list cache was by a mistake disabled, this reenables it. Also, add a log entry when party name lookup fails due to remote API response indicates no name (usually due to missing party profile). Cache negative responses for just 10 seconds (instead of the default 24 hours). 

## Related Issue(s)

- N/A

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
