### PR TITLE
fix: avoid crash if testdata file is empty

### DIFF
--- a/tests/k6/tests/enduser/performance/enduser-search.js
+++ b/tests/k6/tests/enduser/performance/enduser-search.js
@@ -17,6 +17,9 @@ export let options = {
 };
 
 export default function() {
+    if (!endUsersWithTokens || endUsersWithTokens.length === 0) {
+        throw new Error('No end users loaded for testing');
+    }   
     if ((options.vus === undefined || options.vus === 1) && (options.iterations === undefined || options.iterations === 1)) {
         enduserSearch(endUsersWithTokens[0]);
     }

--- a/tests/k6/tests/performancetest_common/readTestdata.js
+++ b/tests/k6/tests/performancetest_common/readTestdata.js
@@ -9,6 +9,15 @@
 import papaparse from 'https://jslib.k6.io/papaparse/5.1.1/index.js';
 import { SharedArray } from "k6/data";
 
+function readCsv(filename) {
+  try {
+    return papaparse.parse(open(filename), { header: true, skipEmptyLines: true }).data;
+  } catch (error) {
+    console.log(`Error reading CSV file: ${error}`);
+    return [];
+  } 
+}
+
 const filenameServiceowners = '../performancetest_data/.serviceowners-with-tokens.csv';
 if (!__ENV.API_ENVIRONMENT) {
   throw new Error('API_ENVIRONMENT must be set');
@@ -24,7 +33,7 @@ const filenameEndusersWithTokens = '../performancetest_data/.endusers-with-token
  * @type {SharedArray}
  */
 export const serviceOwners = new SharedArray('serviceOwners', function () {
-  return papaparse.parse(open(filenameServiceowners), { header: true, skipEmptyLines: true }).data;
+  return readCsv(filenameServiceowners);
 });
 
 /**
@@ -36,7 +45,7 @@ export const serviceOwners = new SharedArray('serviceOwners', function () {
  * @type {SharedArray}
  */
 export const endUsers = new SharedArray('endUsers', function () {
-  return papaparse.parse(open(filenameEndusers), { header: true, skipEmptyLines: true }).data;
+  return readCsv(filenameEndusers); 
 });
 
 /**
@@ -47,6 +56,6 @@ export const endUsers = new SharedArray('endUsers', function () {
  * @type {SharedArray}
  */
 export const endUsersWithTokens = new SharedArray('endUsersWithTokens', function () {
-  return papaparse.parse(open(filenameEndusersWithTokens), { header: true, skipEmptyLines: true }).data;
+  return readCsv(filenameEndusersWithTokens);
 });
 

--- a/tests/k6/tests/performancetest_common/readTestdata.js
+++ b/tests/k6/tests/performancetest_common/readTestdata.js
@@ -9,6 +9,11 @@
 import papaparse from 'https://jslib.k6.io/papaparse/5.1.1/index.js';
 import { SharedArray } from "k6/data";
 
+/**
+ * Function to read the CSV file specified by the filename parameter.
+ * @param {} filename 
+ * @returns 
+ */
 function readCsv(filename) {
   try {
     return papaparse.parse(open(filename), { header: true, skipEmptyLines: true }).data;

--- a/tests/k6/tests/scenarios/performance/create-dialog-and-search.js
+++ b/tests/k6/tests/scenarios/performance/create-dialog-and-search.js
@@ -57,9 +57,18 @@ export const options = {
 };
 
 export function createDialogs() {
-    createDialog(randomItem(serviceOwners), randomItem(endUsersWithTokens));
+  if (!endUsersWithTokens || endUsersWithTokens.length === 0) { 
+    throw new Error('No end users loaded for testing');
+  }
+  if (!serviceOwners || serviceOwners.length === 0) {
+    throw new Error('No service owners loaded for testing');
+  } 
+  createDialog(randomItem(serviceOwners), randomItem(endUsersWithTokens));
 }
 
 export function enduserSearches() {
-    enduserSearch(randomItem(endUsersWithTokens));
+  if (!endUsersWithTokens || endUsersWithTokens.length === 0) { 
+    throw new Error('No end users loaded for testing'); 
+  }
+  enduserSearch(randomItem(endUsersWithTokens));
 }

--- a/tests/k6/tests/serviceowner/performance/create-dialog.js
+++ b/tests/k6/tests/serviceowner/performance/create-dialog.js
@@ -13,6 +13,12 @@ export let options = {
 };
 
 export default function() {
+    if (!endUsers || endUsers.length === 0) {
+        throw new Error('No end users loaded for testing');
+    }
+    if (!serviceOwners || serviceOwners.length === 0) {
+        throw new Error('No service owners loaded for testing');
+    } 
     if ((options.vus === undefined || options.vus === 1) && (options.iterations === undefined || options.iterations === 1)) {
       createDialog(serviceOwners[0], endUsers[0]);
     }

--- a/tests/k6/tests/serviceowner/performance/create-remove-dialog.js
+++ b/tests/k6/tests/serviceowner/performance/create-remove-dialog.js
@@ -16,6 +16,12 @@ export let options = {
 };
 
 export default function() {
+    if (!endUsers || endUsers.length === 0) {
+        throw new Error('No end users loaded for testing');
+    } 
+    if (!serviceOwners || serviceOwners.length === 0) {
+        throw new Error('No service owners loaded for testing');
+    }
     if ((options.vus === undefined || options.vus === 1) && (options.iterations === undefined || options.iterations === 1)) {
       createAndRemoveDialog(serviceOwners[0], endUsers[0]);
     }


### PR DESCRIPTION
return an empty array if testdatafile not found, check for empty testdata in k6 tests

<!--- Provide a general summary of your changes in the Title above -->

## Description



## Related Issue(s)

- #1402 

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced error handling in various performance testing scripts to ensure required data arrays are populated before execution.
	- Added a new function for reading and parsing CSV files, improving error handling during file operations.

- **Bug Fixes**
	- Enhanced robustness of performance tests by preventing execution with empty datasets, which could lead to runtime errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->