### PR TITLE
chore: Manually set operationId of Patch

### DIFF
--- a/docs/schema/V1/swagger.verified.json
+++ b/docs/schema/V1/swagger.verified.json
@@ -6501,7 +6501,7 @@
       },
       "patch": {
         "description": "Patches a dialog aggregate with a RFC6902 JSON Patch document. The patch document must be a JSON array of RFC6902 operations.\nSee [https://tools.ietf.org/html/rfc6902](https://tools.ietf.org/html/rfc6902) for more information.\n            \nOptimistic concurrency control is implemented using the If-Match header. Supply the Revision value from the GetDialog endpoint to ensure that the dialog is not modified/deleted by another request in the meantime.",
-        "operationId": "PatchDialogs_Patch",
+        "operationId": "V1ServiceOwnerDialogsPatchDialog",
         "parameters": [
           {
             "in": "path",

--- a/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/Dialogs/Patch/PatchDialogsController.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/Dialogs/Patch/PatchDialogsController.cs
@@ -52,7 +52,6 @@ public sealed class PatchDialogsController : ControllerBase
     /// <response code="422">Domain error occured. See problem details for a list of errors.</response>
     [HttpPatch("{dialogId}")]
 
-    // [OpenApiOperation()]
     [OpenApiOperation("V1ServiceOwnerDialogsPatchDialog")]
     [ProducesResponseType(typeof(void), StatusCodes.Status204NoContent)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]

--- a/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/Dialogs/Patch/PatchDialogsController.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/Dialogs/Patch/PatchDialogsController.cs
@@ -6,6 +6,7 @@ using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.JsonPatch;
 using Microsoft.AspNetCore.Mvc;
+using NSwag.Annotations;
 using DialogportenAuthorizationPolicy = Digdir.Domain.Dialogporten.WebApi.Common.Authorization.AuthorizationPolicy;
 using IMapper = AutoMapper.IMapper;
 using ProblemDetails = FastEndpoints.ProblemDetails;
@@ -51,6 +52,8 @@ public sealed class PatchDialogsController : ControllerBase
     /// <response code="422">Domain error occured. See problem details for a list of errors.</response>
     [HttpPatch("{dialogId}")]
 
+    // [OpenApiOperation()]
+    [OpenApiOperation("V1ServiceOwnerDialogsPatchDialog")]
     [ProducesResponseType(typeof(void), StatusCodes.Status204NoContent)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(void), StatusCodes.Status401Unauthorized)]
@@ -59,10 +62,10 @@ public sealed class PatchDialogsController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status412PreconditionFailed)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
     public async Task<IActionResult> Patch(
-        [FromRoute] Guid dialogId,
-        [FromHeader(Name = Constants.IfMatch)] Guid? etag,
-        [FromBody] JsonPatchDocument<UpdateDialogDto> patchDocument,
-        CancellationToken ct)
+    [FromRoute] Guid dialogId,
+    [FromHeader(Name = Constants.IfMatch)] Guid? etag,
+    [FromBody] JsonPatchDocument<UpdateDialogDto> patchDocument,
+    CancellationToken ct)
     {
         var dialogQueryResult = await _sender.Send(new GetDialogQuery { DialogId = dialogId }, ct);
         if (!dialogQueryResult.TryPickT0(out var dialog, out var errors))

--- a/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/Dialogs/Patch/PatchDialogsController.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/Dialogs/Patch/PatchDialogsController.cs
@@ -61,10 +61,10 @@ public sealed class PatchDialogsController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status412PreconditionFailed)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
     public async Task<IActionResult> Patch(
-    [FromRoute] Guid dialogId,
-    [FromHeader(Name = Constants.IfMatch)] Guid? etag,
-    [FromBody] JsonPatchDocument<UpdateDialogDto> patchDocument,
-    CancellationToken ct)
+        [FromRoute] Guid dialogId,
+        [FromHeader(Name = Constants.IfMatch)] Guid? etag,
+        [FromBody] JsonPatchDocument<UpdateDialogDto> patchDocument,
+        CancellationToken ct)
     {
         var dialogQueryResult = await _sender.Send(new GetDialogQuery { DialogId = dialogId }, ct);
         if (!dialogQueryResult.TryPickT0(out var dialog, out var errors))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->


<!--- Describe your changes in detail -->

## Related Issue(s)

- #{issue number}

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced OpenAPI specification for the Dialogporten API with new schemas for managing dialogs and their activities.
	- Improved clarity in endpoint operations with updated operation IDs for various dialog-related actions.

- **Bug Fixes**
	- Enhanced error handling for dialog updates, ensuring appropriate HTTP responses.

- **Documentation**
	- Expanded descriptions for endpoints and schemas to improve usability and understanding of the API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->