### PR TITLE
feat(performance): Performance/create serviceowner search

### DIFF
--- a/.github/workflows/dispatch-k6-performance.yml
+++ b/.github/workflows/dispatch-k6-performance.yml
@@ -49,6 +49,7 @@ on:
         options:
           - 'tests/k6/tests/serviceowner/performance/create-dialog.js'
           - 'tests/k6/tests/serviceowner/performance/create-remove-dialog.js'
+          - 'tests/k6/tests/serviceowner/performance/serviceowner-search.js'
           - 'tests/k6/tests/enduser/performance/enduser-search.js'
           - 'tests/k6/tests/graphql/performance/graphql-search.js'
 

--- a/tests/k6/tests/performancetest_common/simpleSearch.js
+++ b/tests/k6/tests/performancetest_common/simpleSearch.js
@@ -5,7 +5,7 @@
 import { randomItem, uuidv4 } from 'https://jslib.k6.io/k6-utils/1.4.0/index.js';
 import { expect, expectStatusFor } from "../../common/testimports.js";
 import { describe } from '../../common/describe.js';
-import { getEU, postGQ } from '../../common/request.js';
+import { getEU, postGQ, getSO } from '../../common/request.js';
 import { getGraphqlParty } from '../performancetest_data/graphql-search.js';
 
 
@@ -31,7 +31,7 @@ function retrieveDialogContent(response, paramsWithToken) {
 }
 
 /**
- * Performs a simple search.
+ * Performs a enduser search.
  * @param {Object} enduser - The end user.
  * @returns {void}
  */
@@ -123,6 +123,30 @@ export function graphqlSearch(enduser) {
     };
     describe('Perform graphql dialog list', () => {
         let r = postGQ(getGraphqlParty(enduser.ssn), paramsWithToken);
+        expectStatusFor(r).to.equal(200);
+        expect(r, 'response').to.have.validJsonBody();
+    });
+}
+
+/**
+ * Performs a serviceowner search.
+ * @param {P} serviceowner 
+ * @param {*} enduser 
+ */
+export function serviceownerSearch(serviceowner, enduser, tag_name) {
+    let paramsWithToken = {
+        headers: {
+            Authorization: "Bearer " + serviceowner.token,
+            traceparent: uuidv4()
+        },
+        tags: { name: tag_name }
+    }
+
+    let enduserid = "urn:altinn:person:identifier-no:" + enduser.ssn;
+    let serviceResource = "urn:altinn:resource:" + serviceowner.resource;
+    let defaultFilter = "?enduserid=" + enduserid + "&serviceResource=" + serviceResource;
+    describe('Perform serviceowner dialog list', () => {
+        let r = getSO('dialogs' + defaultFilter, paramsWithToken);
         expectStatusFor(r).to.equal(200);
         expect(r, 'response').to.have.validJsonBody();
     });

--- a/tests/k6/tests/performancetest_common/simpleSearch.js
+++ b/tests/k6/tests/performancetest_common/simpleSearch.js
@@ -142,9 +142,9 @@ export function serviceownerSearch(serviceowner, enduser, tag_name) {
         tags: { name: tag_name }
     }
 
-    let enduserid = "urn:altinn:person:identifier-no:" + enduser.ssn;
-    let serviceResource = "urn:altinn:resource:" + serviceowner.resource;
-    let defaultFilter = "?enduserid=" + enduserid + "&serviceResource=" + serviceResource;
+    let enduserid = encodeURIComponent(`urn:altinn:person:identifier-no:${enduser.ssn}`);
+    let serviceResource = encodeURIComponent(`urn:altinn:resource:${serviceowner.resource}`);
+    let defaultFilter = `?enduserid=${enduserid}&serviceResource=${serviceResource}`;
     describe('Perform serviceowner dialog list', () => {
         let r = getSO('dialogs' + defaultFilter, paramsWithToken);
         expectStatusFor(r).to.equal(200);

--- a/tests/k6/tests/performancetest_data/serviceowners-yt01.csv
+++ b/tests/k6/tests/performancetest_data/serviceowners-yt01.csv
@@ -1,2 +1,2 @@
 org,orgno,scopes,resource
-digdir,991825827,digdir:dialogporten.serviceprovider,super-simple-service
+digdir,991825827,digdir:dialogporten.serviceprovider digdir:dialogporten.serviceprovider.search,ttd-dialogporten-performance-test-01

--- a/tests/k6/tests/scenarios/performance/create-dialog-and-search.js
+++ b/tests/k6/tests/scenarios/performance/create-dialog-and-search.js
@@ -42,7 +42,7 @@ export const options = {
     },
     summaryTrendStats: ['avg', 'min', 'med', 'max', 'p(95)', 'p(99)', 'p(99.5)', 'p(99.9)', 'count'],
     thresholds: getDefaultThresholds(['http_req_duration', 'http_reqs'],[
-      'simple search',
+      'enduser search',
       'create dialog',
       'get dialog', 
       'get dialog activities', 

--- a/tests/k6/tests/scripts/generate_tokens.sh
+++ b/tests/k6/tests/scripts/generate_tokens.sh
@@ -57,8 +57,8 @@ if [ "$tokens" = "both" ] || [ "$tokens" = "enterprise" ]; then
     echo "org,orgno,scopes,resource,token" > $serviceowner_tokenfile
     while IFS=, read -r org orgno scopes resource
     do
-        url="https://altinn-testtools-token-generator.azurewebsites.net/api/GetEnterpriseToken?org=$org&env=$env&scopes=$scopes&orgno=$orgno&ttl=3600"
-        token=$(curl -s -f $url -u "$tokengenuser:$tokengenpasswd" )
+        url="https://altinn-testtools-token-generator.azurewebsites.net/api/GetEnterpriseToken?org=$org&env=$env&orgno=$orgno&ttl=3600"
+        token=$(curl -s -f --get --data-urlencode "scopes=$scopes" $url -u "$tokengenuser:$tokengenpasswd" )
         if [ $? -ne 0 ]; then
             echo "Error: Failed to generate enterprise token for: $env, $org, $orgno, $scopes "
             continue

--- a/tests/k6/tests/serviceowner/performance/serviceowner-search.js
+++ b/tests/k6/tests/serviceowner/performance/serviceowner-search.js
@@ -1,0 +1,23 @@
+import { serviceownerSearch } from '../../performancetest_common/simpleSearch.js'
+import { getDefaultThresholds } from '../../performancetest_common/getDefaultThresholds.js';
+import { serviceOwners ,endUsersWithTokens } from '../../performancetest_common/readTestdata.js';
+
+const tag_name = 'serviceowner search';
+
+export let options = {
+    summaryTrendStats: ['avg', 'min', 'med', 'max', 'p(95)', 'p(99)', 'p(99.5)', 'p(99.9)', 'count'],
+    thresholds: getDefaultThresholds(['http_req_duration', 'http_reqs'],[tag_name])
+};
+
+export default function() {
+    if (!endUsersWithTokens || endUsersWithTokens.length === 0) {
+        throw new Error('No end users loaded for testing');
+    }   
+    if ((options.vus === undefined || options.vus === 1) && (options.iterations === undefined || options.iterations === 1)) {
+        serviceownerSearch(serviceOwners[0], endUsersWithTokens[0], tag_name);
+    }
+    else {
+        serviceownerSearch(randomItem(serviceOwners) ,randomItem(endUsersWithTokens), tag_name);
+    }
+}
+

--- a/tests/k6/tests/serviceowner/performance/serviceowner-search.js
+++ b/tests/k6/tests/serviceowner/performance/serviceowner-search.js
@@ -12,7 +12,11 @@ export let options = {
 export default function() {
     if (!endUsersWithTokens || endUsersWithTokens.length === 0) {
         throw new Error('No end users loaded for testing');
-    }   
+    } 
+    if (!serviceOwners || serviceOwners.length === 0) {
+        throw new Error('No service owners loaded for testing');
+    }
+      
     if ((options.vus === undefined || options.vus === 1) && (options.iterations === undefined || options.iterations === 1)) {
         serviceownerSearch(serviceOwners[0], endUsersWithTokens[0], tag_name);
     }

--- a/tests/k6/tests/serviceowner/performance/serviceowner-search.js
+++ b/tests/k6/tests/serviceowner/performance/serviceowner-search.js
@@ -1,3 +1,4 @@
+import { randomItem } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
 import { serviceownerSearch } from '../../performancetest_common/simpleSearch.js'
 import { getDefaultThresholds } from '../../performancetest_common/getDefaultThresholds.js';
 import { serviceOwners ,endUsersWithTokens } from '../../performancetest_common/readTestdata.js';
@@ -9,6 +10,11 @@ export let options = {
     thresholds: getDefaultThresholds(['http_req_duration', 'http_reqs'],[tag_name])
 };
 
+/**
+ * Perform a service owner search.
+ * In single user mode, the first service owner and end user with token is used. Only one iteration is performed.
+ * In multi user mode, a random service owner and end user with token is used.
+ */
 export default function() {
     if (!endUsersWithTokens || endUsersWithTokens.length === 0) {
         throw new Error('No end users loaded for testing');
@@ -16,12 +22,13 @@ export default function() {
     if (!serviceOwners || serviceOwners.length === 0) {
         throw new Error('No service owners loaded for testing');
     }
-      
-    if ((options.vus === undefined || options.vus === 1) && (options.iterations === undefined || options.iterations === 1)) {
+
+    const isSingleUserMode = (options.vus ?? 1) === 1 && (options.iterations ?? 1) === 1 && (options.duration ?? 0) === 0;
+    if (isSingleUserMode) {
         serviceownerSearch(serviceOwners[0], endUsersWithTokens[0], tag_name);
     }
     else {
-        serviceownerSearch(randomItem(serviceOwners) ,randomItem(endUsersWithTokens), tag_name);
+        serviceownerSearch(randomItem(serviceOwners), randomItem(endUsersWithTokens), tag_name);
     }
 }
 


### PR DESCRIPTION
Add a simple serviceowner search on enduser(ssn) and service resource

## Description

<!--- Describe your changes in detail -->

## Related Issue(s)

- #1326 

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new performance testing script for service owner searches.
	- Added functionality to perform searches specifically for service owners.
- **Improvements**
	- Enhanced existing search functionality for end users.
	- Updated performance metrics tracking to reflect the new focus on end user searches.
- **Bug Fixes**
	- Improved URL construction in the token generation script for better handling of special characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->