### PR TITLE
feat(webapi): Limit Content-Length / request body size

### DIFF
--- a/src/Digdir.Domain.Dialogporten.WebApi/Common/Authentication/ServiceOwnerOnBehalfOfPersonMiddleware.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Common/Authentication/ServiceOwnerOnBehalfOfPersonMiddleware.cs
@@ -37,7 +37,7 @@ public sealed class ServiceOwnerOnBehalfOfPersonMiddleware
         if (!NorwegianPersonIdentifier.TryParse(endUserIdQuery.First(), out var endUserId))
         {
             context.Response.StatusCode = StatusCodes.Status400BadRequest;
-            context.Response.WriteAsJsonAsync(context.ResponseBuilder(
+            context.Response.WriteAsJsonAsync(context.GetResponseOrDefault(
                 context.Response.StatusCode,
                 [
                     new("EndUserId",

--- a/src/Digdir.Domain.Dialogporten.WebApi/Common/Authentication/UserTypeValidationMiddleware.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Common/Authentication/UserTypeValidationMiddleware.cs
@@ -21,7 +21,7 @@ public sealed class UserTypeValidationMiddleware
             if (userType == UserIdType.Unknown)
             {
                 context.Response.StatusCode = StatusCodes.Status403Forbidden;
-                await context.Response.WriteAsJsonAsync(context.ResponseBuilder(
+                await context.Response.WriteAsJsonAsync(context.GetResponseOrDefault(
                     context.Response.StatusCode,
                     [
                         new("Type",

--- a/src/Digdir.Domain.Dialogporten.WebApi/Common/Constants.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Common/Constants.cs
@@ -5,6 +5,7 @@ internal static class Constants
     internal const string IfMatch = "If-Match";
     internal const string Authorization = "Authorization";
     internal const string CurrentTokenIssuer = "CurrentIssuer";
+    internal const int MaxRequestBodySize = 100_000;
 
     internal static class SwaggerSummary
     {

--- a/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/Dialogs/Patch/PatchDialogsController.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/Dialogs/Patch/PatchDialogsController.cs
@@ -70,10 +70,10 @@ public sealed class PatchDialogsController : ControllerBase
         if (!dialogQueryResult.TryPickT0(out var dialog, out var errors))
         {
             return errors.Match<IActionResult>(
-                notFound => NotFound(HttpContext.ResponseBuilder(StatusCodes.Status404NotFound,
+                notFound => NotFound(HttpContext.GetResponseOrDefault(StatusCodes.Status404NotFound,
                     notFound.ToValidationResults())),
                 validationFailed =>
-                    BadRequest(HttpContext.ResponseBuilder(StatusCodes.Status400BadRequest,
+                    BadRequest(HttpContext.GetResponseOrDefault(StatusCodes.Status400BadRequest,
                         validationFailed.Errors.ToList())));
         }
 
@@ -88,12 +88,12 @@ public sealed class PatchDialogsController : ControllerBase
         var result = await _sender.Send(command, ct);
         return result.Match(
             success => (IActionResult)NoContent(),
-            notFound => NotFound(HttpContext.ResponseBuilder(StatusCodes.Status404NotFound, notFound.ToValidationResults())),
-            badRequest => BadRequest(HttpContext.ResponseBuilder(StatusCodes.Status400BadRequest, badRequest.ToValidationResults())),
-            validationFailed => BadRequest(HttpContext.ResponseBuilder(StatusCodes.Status400BadRequest, validationFailed.Errors.ToList())),
-            forbidden => new ObjectResult(HttpContext.ResponseBuilder(StatusCodes.Status403Forbidden, forbidden.ToValidationResults())),
-            domainError => UnprocessableEntity(HttpContext.ResponseBuilder(StatusCodes.Status422UnprocessableEntity, domainError.ToValidationResults())),
-            concurrencyError => new ObjectResult(HttpContext.ResponseBuilder(StatusCodes.Status412PreconditionFailed)) { StatusCode = StatusCodes.Status412PreconditionFailed }
+            notFound => NotFound(HttpContext.GetResponseOrDefault(StatusCodes.Status404NotFound, notFound.ToValidationResults())),
+            badRequest => BadRequest(HttpContext.GetResponseOrDefault(StatusCodes.Status400BadRequest, badRequest.ToValidationResults())),
+            validationFailed => BadRequest(HttpContext.GetResponseOrDefault(StatusCodes.Status400BadRequest, validationFailed.Errors.ToList())),
+            forbidden => new ObjectResult(HttpContext.GetResponseOrDefault(StatusCodes.Status403Forbidden, forbidden.ToValidationResults())),
+            domainError => UnprocessableEntity(HttpContext.GetResponseOrDefault(StatusCodes.Status422UnprocessableEntity, domainError.ToValidationResults())),
+            concurrencyError => new ObjectResult(HttpContext.GetResponseOrDefault(StatusCodes.Status412PreconditionFailed)) { StatusCode = StatusCodes.Status412PreconditionFailed }
         );
     }
 }

--- a/src/Digdir.Domain.Dialogporten.WebApi/Program.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Program.cs
@@ -52,6 +52,11 @@ static void BuildAndRun(string[] args, TelemetryConfiguration telemetryConfigura
 {
     var builder = WebApplication.CreateBuilder(args);
 
+    builder.WebHost.ConfigureKestrel(kestrelOptions =>
+    {
+        kestrelOptions.Limits.MaxRequestBodySize = Constants.MaxRequestBodySize;
+    });
+
     builder.Host.UseSerilog((context, services, configuration) => configuration
         .MinimumLevel.Warning()
         .ReadFrom.Configuration(context.Configuration)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Large request bodies can be used as a form of DDOS, especially when it comes to transmissions because they have a more complex hierarchy validation
Limiting the body size on requests to 100 kB

## Related Issue(s)

- #1415 

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a maximum request body size limit to enhance server request handling.
  
- **Bug Fixes**
	- Improved error handling for invalid `endUserId` and unknown user types, providing more informative responses.
	- Standardized response generation for various error scenarios in the `PatchDialogsController`.

- **Documentation**
	- Enhanced clarity in error handling processes across multiple middleware components.

- **Refactor**
	- Streamlined error response construction methods for consistency and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->