### PR TITLE
feat(azure): enable query performance insights for postgres

### DIFF
--- a/.azure/infrastructure/main.bicep
+++ b/.azure/infrastructure/main.bicep
@@ -55,7 +55,11 @@ import { Sku as SlackNotifierSku } from '../modules/functionApp/slackNotifier.bi
 param slackNotifierSku SlackNotifierSku
 
 import { Sku as PostgresSku } from '../modules/postgreSql/create.bicep'
-param postgresSku PostgresSku
+
+param postgresConfiguration {
+  sku: PostgresSku
+  enableQueryPerformanceInsight: bool
+}
 
 import { Sku as ServiceBusSku } from '../modules/serviceBus/main.bicep'
 param serviceBusSku ServiceBusSku
@@ -199,7 +203,8 @@ module postgresql '../modules/postgreSql/create.bicep' = {
     administratorLoginPassword: contains(keyVaultSourceKeys, 'dialogportenPgAdminPassword${environment}')
       ? srcKeyVaultResource.getSecret('dialogportenPgAdminPassword${environment}')
       : secrets.dialogportenPgAdminPassword
-    sku: postgresSku
+    sku: postgresConfiguration.sku
+    enableQueryPerformanceInsight: postgresConfiguration.enableQueryPerformanceInsight
     subnetId: vnet.outputs.postgresqlSubnetId
     vnetId: vnet.outputs.virtualNetworkId
     tags: tags

--- a/.azure/infrastructure/prod.bicepparam
+++ b/.azure/infrastructure/prod.bicepparam
@@ -29,9 +29,12 @@ param slackNotifierSku = {
   applicationServicePlanName: 'Y1'
   applicationServicePlanTier: 'Dynamic'
 }
-param postgresSku = {
-  name: 'Standard_B1ms'
-  tier: 'Burstable'
+param postgresConfiguration = {
+  sku: {
+    name: 'Standard_B1ms'
+    tier: 'Burstable'
+  }
+  enableQueryPerformanceInsight: false
 }
 
 param redisSku = {

--- a/.azure/infrastructure/staging.bicepparam
+++ b/.azure/infrastructure/staging.bicepparam
@@ -29,9 +29,12 @@ param slackNotifierSku = {
   applicationServicePlanName: 'Y1'
   applicationServicePlanTier: 'Dynamic'
 }
-param postgresSku = {
-  name: 'Standard_B1ms'
-  tier: 'Burstable'
+param postgresConfiguration = {
+  sku: {
+    name: 'Standard_B1ms'
+    tier: 'Burstable'
+  }
+  enableQueryPerformanceInsight: true
 }
 
 param redisSku = {

--- a/.azure/infrastructure/test.bicepparam
+++ b/.azure/infrastructure/test.bicepparam
@@ -34,7 +34,7 @@ param postgresConfiguration = {
     name: 'Standard_B2s'
     tier: 'Burstable'
   }
-  enableQueryPerformanceInsight: false
+  enableQueryPerformanceInsight: true
 }
 
 param redisSku = {

--- a/.azure/infrastructure/test.bicepparam
+++ b/.azure/infrastructure/test.bicepparam
@@ -29,9 +29,12 @@ param slackNotifierSku = {
   applicationServicePlanName: 'Y1'
   applicationServicePlanTier: 'Dynamic'
 }
-param postgresSku = {
-  name: 'Standard_B2s'
-  tier: 'Burstable'
+param postgresConfiguration = {
+  sku: {
+    name: 'Standard_B2s'
+    tier: 'Burstable'
+  }
+  enableQueryPerformanceInsight: false
 }
 
 param redisSku = {

--- a/.azure/infrastructure/yt01.bicepparam
+++ b/.azure/infrastructure/yt01.bicepparam
@@ -29,9 +29,12 @@ param slackNotifierSku = {
   applicationServicePlanName: 'Y1'
   applicationServicePlanTier: 'Dynamic'
 }
-param postgresSku = {
-  name: 'Standard_B1ms'
-  tier: 'Burstable'
+param postgresConfiguration = {
+  sku: {
+    name: 'Standard_B1ms'
+    tier: 'Burstable'
+  }
+  enableQueryPerformanceInsight: true
 }
 
 param redisSku = {

--- a/.azure/modules/postgreSql/create.bicep
+++ b/.azure/modules/postgreSql/create.bicep
@@ -31,6 +31,9 @@ type Sku = {
 @description('The SKU of the PostgreSQL server')
 param sku Sku
 
+@description('Enable query performance insight')
+param enableQueryPerformanceInsight bool
+
 @description('The Key Vault to store the PostgreSQL administrator login password')
 @secure()
 param srcKeyVault object
@@ -104,6 +107,33 @@ resource postgres 'Microsoft.DBforPostgreSQL/flexibleServers@2024-08-01' = {
     }
   }
   tags: tags
+}
+
+resource track_io_timing 'Microsoft.DBforPostgreSQL/flexibleServers/configurations@2023-12-01-preview' = if (enableQueryPerformanceInsight) {
+  parent: postgres
+  name: 'track_io_timing'
+  properties: {
+    value: 'on'
+    source: 'user-override'
+  }
+}
+
+resource pg_qs_query_capture_mode 'Microsoft.DBforPostgreSQL/flexibleServers/configurations@2023-12-01-preview' = if (enableQueryPerformanceInsight) {
+  parent: postgres
+  name: 'pg_qs.query_capture_mode'
+  properties: {
+    value: 'all'
+    source: 'user-override'
+  }
+}
+
+resource pgms_wait_sampling_query_capture_mode 'Microsoft.DBforPostgreSQL/flexibleServers/configurations@2023-12-01-preview' = if (enableQueryPerformanceInsight) {
+  parent: postgres
+  name: 'pgms_wait_sampling.query_capture_mode'
+  properties: {
+    value: 'all'
+    source: 'user-override'
+  }
 }
 
 module adoConnectionString '../keyvault/upsertSecret.bicep' = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

- Sets the necessary server properties to enable Query Performance Insights
- Enabled on Test, Staging and YT01
- Minor refactor to make things a tad cleaner

## Related Issue(s)

- #{issue number}

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration structure for PostgreSQL with enhanced settings, including the ability to enable query performance insights.
	- Added parameters to manage PostgreSQL SKU details more effectively.
- **Bug Fixes**
	- Resolved inconsistencies in PostgreSQL parameter definitions across multiple configuration files.
- **Documentation**
	- Updated documentation to reflect changes in PostgreSQL configuration management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->