### PR TITLE
feat(graphql): Set max execution depth to 10

### DIFF
--- a/src/Digdir.Domain.Dialogporten.GraphQL/ServiceCollectionExtensions.cs
+++ b/src/Digdir.Domain.Dialogporten.GraphQL/ServiceCollectionExtensions.cs
@@ -25,6 +25,7 @@ public static class ServiceCollectionExtensions
             .AddType<SearchDialogValidationError>()
             .AddType<SearchDialogForbidden>()
             .AddType<SetSystemLabelEntityNotFound>()
+            .AddMaxExecutionDepthRule(10)
             .AddInstrumentation()
             .InitializeOnStartup()
             .Services;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
We have the possibility for "infinite" recursion in our parties query (sub-parties)

```
  parties {
    subParties {
      subParties {
        subParties {
          subParties {
            ...
          }
        }
      }
    }
  }
```
Capping the global query depth level at 10. 
(Max depth on dialogById seems to be 7) 

```
query q {
  dialogById(dialogId: "c8147d41-936e-4124-8119-ea1add40c4b4") {
    dialog {
      transmissions {
        content {
          title {
            mediaType
            value {
              value
            }
          }
        }
      }
    }
  }
}
```

## Related Issue(s)

- #1430

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a maximum execution depth for GraphQL queries, enhancing server performance and stability by limiting query complexity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->