### PR TITLE
chore(graphql): Add model property names test

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Domain/Dialogs/Entities/Transmissions/DialogTransmission.cs
+++ b/src/Digdir.Domain.Dialogporten.Domain/Dialogs/Entities/Transmissions/DialogTransmission.cs
@@ -14,7 +14,7 @@ public sealed class DialogTransmission : IImmutableEntity
     public string? AuthorizationAttribute { get; set; }
     public Uri? ExtendedType { get; set; }
 
-    // === Principal relationships ===t
+    // === Principal relationships ===
     [AggregateChild]
     public List<DialogTransmissionContent> Content { get; set; } = [];
 

--- a/src/Digdir.Domain.Dialogporten.Domain/Dialogs/Entities/Transmissions/DialogTransmission.cs
+++ b/src/Digdir.Domain.Dialogporten.Domain/Dialogs/Entities/Transmissions/DialogTransmission.cs
@@ -14,7 +14,7 @@ public sealed class DialogTransmission : IImmutableEntity
     public string? AuthorizationAttribute { get; set; }
     public Uri? ExtendedType { get; set; }
 
-    // === Principal relationships ===
+    // === Principal relationships ===t
     [AggregateChild]
     public List<DialogTransmissionContent> Content { get; set; } = [];
 

--- a/tests/Digdir.Domain.Dialogporten.GraphQl.Unit.Tests/ObjectTypes/AttachmentTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.GraphQl.Unit.Tests/ObjectTypes/AttachmentTests.cs
@@ -1,0 +1,70 @@
+using Attachment = Digdir.Domain.Dialogporten.GraphQL.EndUser.DialogById.Attachment;
+using DomainAttachmentUrl = Digdir.Domain.Dialogporten.Domain.Attachments.AttachmentUrl;
+
+namespace Digdir.Domain.Dialogporten.GraphQl.Unit.Tests.ObjectTypes;
+
+public class AttachmentTests
+{
+    [Fact]
+    public void Attachment_Object_Type_Should_Match_Property_Names_On_AttachmentEntity()
+    {
+        // Arrange
+        var ignoreList = new List<string>
+        {
+            nameof(Domain.Attachments.Attachment.CreatedAt),
+            nameof(Domain.Attachments.Attachment.UpdatedAt)
+        };
+
+        var attachmentPropertyNames = typeof(Attachment)
+            .GetProperties()
+            .Select(p => p.Name)
+            .ToList();
+
+        var attachmentEntityPropertyNames = typeof(Domain.Attachments.Attachment)
+            .GetProperties()
+            .Select(p => p.Name)
+            .Where(name => !ignoreList.Contains(name))
+            .ToList();
+
+        var missingProperties = attachmentEntityPropertyNames
+            .Except(attachmentPropertyNames, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        // Assert
+        Assert.True(missingProperties.Count == 0,
+            $"Properties missing in graphql Attachment: {string.Join(", ", missingProperties)}");
+    }
+
+    [Fact]
+    public void AttachmentUrl_Object_Type_Should_Match_Property_Names_On_DialogAttachmentUrl()
+    {
+        // Arrange
+        var ignoreList = new List<string>
+        {
+            nameof(DomainAttachmentUrl.CreatedAt),
+            nameof(DomainAttachmentUrl.UpdatedAt),
+            nameof(DomainAttachmentUrl.ConsumerTypeId),
+            nameof(DomainAttachmentUrl.AttachmentId),
+            nameof(DomainAttachmentUrl.Attachment)
+        };
+
+        var attachmentUrlPropertyNames = typeof(GraphQL.EndUser.DialogById.AttachmentUrl)
+            .GetProperties()
+            .Select(p => p.Name)
+            .ToList();
+
+        var domainAttachmentUrl = typeof(DomainAttachmentUrl)
+            .GetProperties()
+            .Select(p => p.Name)
+            .Where(name => !ignoreList.Contains(name))
+            .ToList();
+
+        var missingProperties = domainAttachmentUrl
+            .Except(attachmentUrlPropertyNames, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        // Assert
+        Assert.True(missingProperties.Count == 0,
+            $"Properties missing in graphql AttachmentUrl: {string.Join(", ", missingProperties)}");
+    }
+}

--- a/tests/Digdir.Domain.Dialogporten.GraphQl.Unit.Tests/ObjectTypes/AttachmentTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.GraphQl.Unit.Tests/ObjectTypes/AttachmentTests.cs
@@ -15,19 +15,19 @@ public class AttachmentTests
             nameof(Domain.Attachments.Attachment.UpdatedAt)
         };
 
-        var attachmentPropertyNames = typeof(Attachment)
+        var attachmentProperties = typeof(Attachment)
             .GetProperties()
             .Select(p => p.Name)
             .ToList();
 
-        var attachmentEntityPropertyNames = typeof(Domain.Attachments.Attachment)
+        var domainAttachmentProperties = typeof(Domain.Attachments.Attachment)
             .GetProperties()
             .Select(p => p.Name)
             .Where(name => !ignoreList.Contains(name))
             .ToList();
 
-        var missingProperties = attachmentEntityPropertyNames
-            .Except(attachmentPropertyNames, StringComparer.OrdinalIgnoreCase)
+        var missingProperties = domainAttachmentProperties
+            .Except(attachmentProperties, StringComparer.OrdinalIgnoreCase)
             .ToList();
 
         // Assert
@@ -48,19 +48,19 @@ public class AttachmentTests
             nameof(DomainAttachmentUrl.Attachment)
         };
 
-        var attachmentUrlPropertyNames = typeof(GraphQL.EndUser.DialogById.AttachmentUrl)
+        var attachmentUrlProperties = typeof(GraphQL.EndUser.DialogById.AttachmentUrl)
             .GetProperties()
             .Select(p => p.Name)
             .ToList();
 
-        var domainAttachmentUrl = typeof(DomainAttachmentUrl)
+        var domainAttachmentUrlProperties = typeof(DomainAttachmentUrl)
             .GetProperties()
             .Select(p => p.Name)
             .Where(name => !ignoreList.Contains(name))
             .ToList();
 
-        var missingProperties = domainAttachmentUrl
-            .Except(attachmentUrlPropertyNames, StringComparer.OrdinalIgnoreCase)
+        var missingProperties = domainAttachmentUrlProperties
+            .Except(attachmentUrlProperties, StringComparer.OrdinalIgnoreCase)
             .ToList();
 
         // Assert

--- a/tests/Digdir.Domain.Dialogporten.GraphQl.Unit.Tests/ObjectTypes/DialogEntityTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.GraphQl.Unit.Tests/ObjectTypes/DialogEntityTests.cs
@@ -21,18 +21,18 @@ public class DialogEntityTests
             nameof(DialogEntity.DialogEndUserContext)
         };
 
-        var dialogEntityPropertyNames = typeof(DialogEntity)
+        var dialogProperties = typeof(DialogEntity)
             .GetProperties()
             .Select(p => p.Name)
             .Where(name => !ignoreList.Contains(name))
             .ToList();
 
-        var dialogPropertyNames = typeof(Dialog)
+        var domainDialogProperties = typeof(Dialog)
             .GetProperties()
             .Select(p => p.Name)
             .ToList();
 
-        var missingProperties = dialogEntityPropertyNames.Except(dialogPropertyNames, StringComparer.OrdinalIgnoreCase).ToList();
+        var missingProperties = dialogProperties.Except(domainDialogProperties, StringComparer.OrdinalIgnoreCase).ToList();
 
         // Assert
         Assert.True(missingProperties.Count == 0, $"Properties missing in graphql dialog: {string.Join(", ", missingProperties)}");

--- a/tests/Digdir.Domain.Dialogporten.GraphQl.Unit.Tests/ObjectTypes/DialogEntityTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.GraphQl.Unit.Tests/ObjectTypes/DialogEntityTests.cs
@@ -1,0 +1,60 @@
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities;
+using Digdir.Domain.Dialogporten.GraphQL.EndUser.DialogById;
+using DialogStatus = Digdir.Domain.Dialogporten.GraphQL.EndUser.Common.DialogStatus;
+using DialogStatusValues = Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.DialogStatus.Values;
+
+namespace Digdir.Domain.Dialogporten.GraphQl.Unit.Tests.ObjectTypes;
+
+public class DialogEntityTests
+{
+    [Fact]
+    public void Dialog_Object_Type_Should_Match_Property_Names_On_DialogEntity()
+    {
+        // Arrange
+        var ignoreList = new List<string>
+        {
+            nameof(DialogEntity.Deleted),
+            nameof(DialogEntity.DeletedAt),
+            nameof(DialogEntity.StatusId),
+            nameof(DialogEntity.SearchTags),
+            nameof(DialogEntity.SeenLog),
+            nameof(DialogEntity.DialogEndUserContext)
+        };
+
+        var dialogEntityPropertyNames = typeof(DialogEntity)
+            .GetProperties()
+            .Select(p => p.Name)
+            .Where(name => !ignoreList.Contains(name))
+            .ToList();
+
+        var dialogPropertyNames = typeof(Dialog)
+            .GetProperties()
+            .Select(p => p.Name)
+            .ToList();
+
+        var missingProperties = dialogEntityPropertyNames.Except(dialogPropertyNames, StringComparer.OrdinalIgnoreCase).ToList();
+
+        // Assert
+        Assert.True(missingProperties.Count == 0, $"Properties missing in graphql dialog: {string.Join(", ", missingProperties)}");
+    }
+
+    [Fact]
+    public void DialogStatus_Object_Type_Should_Match_Property_Names_On_DialogStatusValues()
+    {
+        // Arrange
+        var dialogStatusValues = typeof(DialogStatus)
+            .GetProperties()
+            .Select(p => p.Name)
+            .ToList();
+
+        var domainDialogStatusValues = typeof(DialogStatusValues)
+            .GetProperties()
+            .Select(p => p.Name)
+            .ToList();
+
+        var missingProperties = domainDialogStatusValues.Except(dialogStatusValues, StringComparer.OrdinalIgnoreCase).ToList();
+
+        // Assert
+        Assert.True(missingProperties.Count == 0, $"Properties missing in graphql dialog status: {string.Join(", ", missingProperties)}");
+    }
+}

--- a/tests/Digdir.Domain.Dialogporten.GraphQl.Unit.Tests/ObjectTypes/GuiActionTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.GraphQl.Unit.Tests/ObjectTypes/GuiActionTests.cs
@@ -1,0 +1,64 @@
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Actions;
+using Digdir.Domain.Dialogporten.GraphQL.EndUser.DialogById;
+
+namespace Digdir.Domain.Dialogporten.GraphQl.Unit.Tests.ObjectTypes;
+
+public class GuiActionTests
+{
+    [Fact]
+    public void DialogGuiAction_Object_Type_Should_Match_Property_Names_On_GuiAction()
+    {
+        // Arrange
+        var ignoreList = new List<string>
+        {
+            nameof(DialogGuiAction.CreatedAt),
+            nameof(DialogGuiAction.UpdatedAt),
+            nameof(DialogGuiAction.PriorityId),
+            nameof(DialogGuiAction.HttpMethodId),
+            nameof(DialogGuiAction.DialogId),
+            nameof(DialogGuiAction.Dialog)
+        };
+
+        var domainGuiActionProperties = typeof(DialogGuiAction)
+            .GetProperties()
+            .Select(p => p.Name)
+            .Where(name => !ignoreList.Contains(name))
+            .ToList();
+
+        var guiActionProperties = typeof(GuiAction)
+            .GetProperties()
+            .Select(p => p.Name)
+            .ToList();
+
+        var missingProperties = domainGuiActionProperties
+            .Except(guiActionProperties, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        // Assert
+        Assert.True(missingProperties.Count == 0,
+            $"Properties missing in graphql GuiAction: {string.Join(", ", missingProperties)}");
+    }
+
+    [Fact]
+    public void GuiActionPriority_Object_Type_Should_Match_Property_Names_On_DialogGuiActionPriorityValues()
+    {
+        // Arrange
+        var guiActionPriorities = typeof(GuiActionPriority)
+            .GetProperties()
+            .Select(p => p.Name)
+            .ToList();
+
+        var domainGuiActionPriorities = typeof(DialogGuiActionPriority.Values)
+            .GetProperties()
+            .Select(p => p.Name)
+            .ToList();
+
+        var missingProperties = domainGuiActionPriorities
+            .Except(guiActionPriorities, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        // Assert
+        Assert.True(missingProperties.Count == 0,
+            $"Properties missing in graphql GuiActionPriority: {string.Join(", ", missingProperties)}");
+    }
+}

--- a/tests/Digdir.Domain.Dialogporten.GraphQl.Unit.Tests/ObjectTypes/TransmissionTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.GraphQl.Unit.Tests/ObjectTypes/TransmissionTests.cs
@@ -25,12 +25,12 @@ public class DialogTransmissionTests
             .Where(name => !ignoreList.Contains(name))
             .ToList();
 
-        var transmissionPropertyNames = typeof(Transmission)
+        var transmissionProperties = typeof(Transmission)
             .GetProperties()
             .Select(p => p.Name)
             .ToList();
 
-        var missingProperties = domainTransmissionProperties.Except(transmissionPropertyNames, StringComparer.OrdinalIgnoreCase).ToList();
+        var missingProperties = domainTransmissionProperties.Except(transmissionProperties, StringComparer.OrdinalIgnoreCase).ToList();
 
         // Assert
         Assert.True(missingProperties.Count == 0, $"Properties missing in graphql transmission: {string.Join(", ", missingProperties)}");
@@ -50,7 +50,7 @@ public class DialogTransmissionTests
             .Select(f => f.Name)
             .ToList();
 
-        var missingProperties = transmissionTypes.Except(domainTransmissionTypes, StringComparer.OrdinalIgnoreCase).ToList();
+        var missingProperties = domainTransmissionTypes.Except(transmissionTypes, StringComparer.OrdinalIgnoreCase).ToList();
 
         // Assert
         Assert.True(missingProperties.Count == 0, $"Properties missing in graphql TransmissionType: {string.Join(", ", missingProperties)}");

--- a/tests/Digdir.Domain.Dialogporten.GraphQl.Unit.Tests/ObjectTypes/TransmissionTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.GraphQl.Unit.Tests/ObjectTypes/TransmissionTests.cs
@@ -1,0 +1,58 @@
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Transmissions;
+using Digdir.Domain.Dialogporten.GraphQL.EndUser.DialogById;
+
+namespace Digdir.Domain.Dialogporten.GraphQl.Unit.Tests.ObjectTypes;
+
+public class DialogTransmissionTests
+{
+    [Fact]
+    public void Transmission_Object_Type_Should_Match_Property_Names_On_DialogTransmission()
+    {
+        // Arrange
+        var ignoreList = new List<string>
+        {
+            nameof(DialogTransmission.RelatedTransmission),
+            nameof(DialogTransmission.RelatedTransmissions),
+            nameof(DialogTransmission.Activities),
+            nameof(DialogTransmission.Dialog),
+            nameof(DialogTransmission.DialogId),
+            nameof(DialogTransmission.TypeId)
+        };
+
+        var domainTransmissionProperties = typeof(DialogTransmission)
+            .GetProperties()
+            .Select(p => p.Name)
+            .Where(name => !ignoreList.Contains(name))
+            .ToList();
+
+        var transmissionPropertyNames = typeof(Transmission)
+            .GetProperties()
+            .Select(p => p.Name)
+            .ToList();
+
+        var missingProperties = domainTransmissionProperties.Except(transmissionPropertyNames, StringComparer.OrdinalIgnoreCase).ToList();
+
+        // Assert
+        Assert.True(missingProperties.Count == 0, $"Properties missing in graphql transmission: {string.Join(", ", missingProperties)}");
+    }
+
+    [Fact]
+    public void TransmissionType_Object_Type_Should_Match_Property_Names_On_DialogTransmissionTypeValues()
+    {
+        // Arrange
+        var transmissionTypes = typeof(TransmissionType)
+            .GetFields()
+            .Select(f => f.Name)
+            .ToList();
+
+        var domainTransmissionTypes = typeof(DialogTransmissionType.Values)
+            .GetFields()
+            .Select(f => f.Name)
+            .ToList();
+
+        var missingProperties = transmissionTypes.Except(domainTransmissionTypes, StringComparer.OrdinalIgnoreCase).ToList();
+
+        // Assert
+        Assert.True(missingProperties.Count == 0, $"Properties missing in graphql TransmissionType: {string.Join(", ", missingProperties)}");
+    }
+}


### PR DESCRIPTION
Tests ensuring property/enum values are matching from domain => graphql 
Adds test for Dialog, Transmissions, GuiAction, and Attatchments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced unit tests for various GraphQL object types, ensuring property names match their corresponding domain entities.
  - Added tests for `Attachment`, `DialogEntity`, `GuiAction`, and `Transmission` types to enhance reliability and consistency.

- **Tests**
  - Implemented multiple test methods to validate property names and report discrepancies clearly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->