### PR TITLE
feat(performance): create a k6 purge script to run after creating dialogs

### DIFF
--- a/tests/k6/tests/serviceowner/performance/purge-dialogs.js
+++ b/tests/k6/tests/serviceowner/performance/purge-dialogs.js
@@ -1,13 +1,25 @@
+/**
+ * This script purges dialogs that have not been cleaned up by the tests.
+ * The script is intended to be run after the main tests have completed.
+ * 
+ * The script retrieves all dialogs that contain a sentinel value in the search query.
+ * It then purges these dialogs.
+ * 
+ * Run: k6 run tests/k6/tests/serviceowner/performance/purge-dialogs.js -e env=yt01
+ */
 import { getSO, purgeSO } from '../../../common/request.js';
 import { serviceOwners } from '../../performancetest_common/readTestdata.js';
 import { expect, expectStatusFor } from "../../../common/testimports.js";
 import { getDefaultThresholds } from '../../performancetest_common/getDefaultThresholds.js';
 import { describe } from '../../../common/describe.js';
-import { randomItem } from 'https://jslib.k6.io/k6-utils/1.4.0/index.js';
+import { sentinelValue } from '../../../common/config.js';
 
-const sentinelValue = "Performance-created-dialog";
-const sentinelValue1 = "dialogporten-e2e-sentinel";
-
+/**
+ * Retrieves the dialog ids to purge.
+ * 
+ * @param {Object} serviceOwner - The service owner object.
+ * @returns {Array} - The dialog ids to purge.
+ */
 function getDialogs(serviceOwner) {
     var paramsWithToken = {
         headers: {
@@ -60,6 +72,11 @@ export function setup() {
     return data;
 }
 
+/**
+ * Purges dialogs.
+ * In single user mode, the first service owner is used. Only one iteration is performed.
+ * In multi user mode, all service owners are used.
+ */
 export default function(serviceOwners) {
     if (!serviceOwners || serviceOwners.length === 0) {
         throw new Error('No service owners loaded for testing');
@@ -76,6 +93,11 @@ export default function(serviceOwners) {
     }
   }
 
+/**
+ * Purges dialogs.
+ * 
+ * @param {Object} serviceOwner - The service owner object.
+ */
 export function purgeDialogs(serviceOwner) {
     var paramsWithToken = {
         headers: {

--- a/tests/k6/tests/serviceowner/performance/purge-dialogs.js
+++ b/tests/k6/tests/serviceowner/performance/purge-dialogs.js
@@ -1,0 +1,106 @@
+import { getSO, purgeSO } from '../../../common/request.js';
+import { serviceOwners } from '../../performancetest_common/readTestdata.js';
+import { expect, expectStatusFor } from "../../../common/testimports.js";
+import { getDefaultThresholds } from '../../performancetest_common/getDefaultThresholds.js';
+import { describe } from '../../../common/describe.js';
+import { randomItem } from 'https://jslib.k6.io/k6-utils/1.4.0/index.js';
+
+const sentinelValue = "Performance-created-dialog";
+const sentinelValue1 = "dialogporten-e2e-sentinel";
+
+function getDialogs(serviceOwner) {
+    var paramsWithToken = {
+        headers: {
+            Authorization: "Bearer " + serviceOwner.token
+        }
+    }
+    let hasNextPage = false;
+    let continuationToken = "";
+    let dialogIdsToPurge = [];
+    do {
+        let r = getSO('dialogs/?Search=' + sentinelValue + continuationToken, paramsWithToken);
+        expectStatusFor(r).to.equal(200);
+        expect(r, 'response').to.have.validJsonBody();
+        let response = r.json();
+        if (response.items && response.items.length > 0) {
+            response.items.forEach((item) => {
+                dialogIdsToPurge.push(item.id);
+            });
+            continuationToken = "&continuationToken=" + response.continuationToken;
+        }
+        console.log("Found " + dialogIdsToPurge.length + " unpurged dialogs");  
+        if (dialogIdsToPurge.length < 200) {
+            hasNextPage = response.hasNextPage;
+        }
+        else {
+            hasNextPage = false;
+        }
+    } while (hasNextPage);
+    return dialogIdsToPurge;
+}
+
+export let options = {
+    summaryTrendStats: ['avg', 'min', 'med', 'max', 'p(95)', 'p(99)', 'p(99.5)', 'p(99.9)', 'count'],
+    thresholds: getDefaultThresholds(['http_req_duration', 'http_reqs'],[
+      'purge dialog'
+    ]),
+    setupTimeout: '4m',
+};
+
+export function setup() {
+    let data = [];
+    if (!serviceOwners || serviceOwners.length === 0) {
+        throw new Error('No service owners loaded for testing');
+    }
+    for (const serviceOwner of serviceOwners) {
+        let dialogIdsToPurge = getDialogs(serviceOwner);
+        data.push({token: serviceOwner.token, dialogIdsToPurge: dialogIdsToPurge});
+    }
+    
+    return data;
+}
+
+export default function(serviceOwners) {
+    if (!serviceOwners || serviceOwners.length === 0) {
+        throw new Error('No service owners loaded for testing');
+    }
+
+    const isSingleUserMode = (options.vus ?? 1) === 1 && (options.iterations ?? 1) === 1 && (options.duration ?? 0) === 0;
+    if (isSingleUserMode) {
+      purgeDialogs(serviceOwners[0]);
+    }
+    else {
+        for (const serviceOwner of serviceOwners) {
+            purgeDialogs(serviceOwner);
+        }
+    }
+  }
+
+export function purgeDialogs(serviceOwner) {
+    var paramsWithToken = {
+        headers: {
+            Authorization: "Bearer " + serviceOwner.token
+        },
+        tags: { name: 'purge dialog' }
+    }
+    describe('Post run: checking for unpurged dialogs', () => {
+        let dialogIdsToPurge = serviceOwner.dialogIdsToPurge;
+        if (dialogIdsToPurge.length > 0) {
+            console.error("Found " + dialogIdsToPurge.length + " unpurged dialogs, make sure that all tests clean up after themselves. Purging ...");
+            for(var i = dialogIdsToPurge.length - 1; i>=0; i--) {
+                let r = purgeSO('dialogs/' + dialogIdsToPurge[i], paramsWithToken);
+                if (r.status != 204) {
+                    console.error("Failed to purge dialog with id: " + id);
+                    console.log(r);
+                }
+                else {
+                    console.log("Purged dialog with id: " + dialogIdsToPurge[i]);
+                    dialogIdsToPurge.splice(i, 1);
+                }
+            }
+        }
+
+        // Fail the test after purging for visibility
+        expect(dialogIdsToPurge.length, 'unpurged dialogs').to.equal(0);
+    });
+}


### PR DESCRIPTION
A script that purges dialogs created by performance tests. Much is copied from common/sentinet.js, put that script didn't quite fit in

## Description

<!--- Describe your changes in detail -->

## Related Issue(s)

- #1326 

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
