### PR TITLE
chore(azure): Replace traces.message with customDimensions.MessageTemplate in slackNotifier

### DIFF
--- a/.azure/modules/functionApp/slackNotifier.bicep
+++ b/.azure/modules/functionApp/slackNotifier.bicep
@@ -168,7 +168,7 @@ var query = '''
                  Environment = tostring(customDimensions.AspNetCoreEnvironment),
                  Type = itemType,
                  problemId,
-                 message,
+                 tostring(customDimensions.MessageTemplate),
                  severityLevel
              | extend SeverityLevel = case(
                  severityLevel == 0, "Verbose",
@@ -178,7 +178,7 @@ var query = '''
                  severityLevel == 4, "Critical",
                  tostring(severityLevel)
                                       )
-             | extend Details = coalesce(message, problemId)
+             | extend Details = coalesce(customDimensions_MessageTemplate, problemId)
              | extend Details = replace_string(Details, "Digdir.Domain.Dialogporten.", "")
              | project Environment, Type, SeverityLevel, Count, Details
              '''


### PR DESCRIPTION
Replace traces.message with customDimensions.MessageTemplate in the slackNotifier for improved grouping


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved clarity of logged messages in the Slack Notifier function app.
	- Enhanced alert rule computations for better accuracy in logging.

- **Chores**
	- Added comments for future refactoring plans regarding storage account management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->