### PR TITLE
chore: Add environment name to logs and alerts

### DIFF
--- a/.azure/modules/functionApp/slackNotifier.bicep
+++ b/.azure/modules/functionApp/slackNotifier.bicep
@@ -165,7 +165,7 @@ var query = '''
                  | where customDimensions.RequestPath !startswith "/health"
              | summarize Count = count()
                  by
-                 Environment = tostring(customDimensions.AspNetCoreEnvironment),
+                 Environment = tostring(customDimensions.EnvironmentName),
                  Type = itemType,
                  problemId,
                  tostring(customDimensions.MessageTemplate),

--- a/src/Digdir.Domain.Dialogporten.GraphQL/Digdir.Domain.Dialogporten.GraphQL.csproj
+++ b/src/Digdir.Domain.Dialogporten.GraphQL/Digdir.Domain.Dialogporten.GraphQL.csproj
@@ -10,6 +10,7 @@
         <PackageReference Include="HotChocolate.AspNetCore.Authorization" Version="13.9.14" />
         <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="8.0.0" />
         <PackageReference Include="Serilog.AspNetCore" Version="8.0.3" />
+        <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
         <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="4.0.0"/>
     </ItemGroup>
 

--- a/src/Digdir.Domain.Dialogporten.GraphQL/Program.cs
+++ b/src/Digdir.Domain.Dialogporten.GraphQL/Program.cs
@@ -24,6 +24,7 @@ var telemetryConfiguration = TelemetryConfiguration.CreateDefault();
 Log.Logger = new LoggerConfiguration()
     .MinimumLevel.Warning()
     .Enrich.FromLogContext()
+    .Enrich.WithEnvironmentName()
     .WriteTo.Console(formatProvider: CultureInfo.InvariantCulture)
     .WriteTo.ApplicationInsights(telemetryConfiguration, TelemetryConverter.Traces)
     .CreateBootstrapLogger();
@@ -51,6 +52,7 @@ static void BuildAndRun(string[] args, TelemetryConfiguration telemetryConfigura
         .ReadFrom.Configuration(context.Configuration)
         .ReadFrom.Services(services)
         .Enrich.FromLogContext()
+        .Enrich.WithEnvironmentName()
         .WriteTo.Console(formatProvider: CultureInfo.InvariantCulture)
         .WriteTo.ApplicationInsights(telemetryConfiguration, TelemetryConverter.Traces));
 

--- a/src/Digdir.Domain.Dialogporten.GraphQL/Properties/launchSettings.json
+++ b/src/Digdir.Domain.Dialogporten.GraphQL/Properties/launchSettings.json
@@ -8,7 +8,7 @@
       "launchUrl": "graphql",
       "applicationUrl": "http://localhost:5181",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "DOTNET_ENVIRONMENT": "Development"
       }
     }
   }

--- a/src/Digdir.Domain.Dialogporten.Janitor/Digdir.Domain.Dialogporten.Janitor.csproj
+++ b/src/Digdir.Domain.Dialogporten.Janitor/Digdir.Domain.Dialogporten.Janitor.csproj
@@ -18,6 +18,7 @@
         <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.4" />
         <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="4.0.0" />
         <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+        <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Digdir.Domain.Dialogporten.Janitor/Program.cs
+++ b/src/Digdir.Domain.Dialogporten.Janitor/Program.cs
@@ -15,6 +15,7 @@ using Serilog;
 Log.Logger = new LoggerConfiguration()
     .MinimumLevel.Warning()
     .Enrich.FromLogContext()
+    .Enrich.WithEnvironmentName()
     .WriteTo.Console(formatProvider: CultureInfo.InvariantCulture)
     .WriteTo.ApplicationInsights(
         TelemetryConfiguration.CreateDefault(),
@@ -51,6 +52,7 @@ static void BuildAndRun(string[] args)
         .ReadFrom.Configuration(context.Configuration)
         .ReadFrom.Services(services)
         .Enrich.FromLogContext()
+        .Enrich.WithEnvironmentName()
         .WriteTo.Console(formatProvider: CultureInfo.InvariantCulture)
         .WriteTo.ApplicationInsights(
             services.GetRequiredService<TelemetryConfiguration>(),

--- a/src/Digdir.Domain.Dialogporten.Service/Digdir.Domain.Dialogporten.Service.csproj
+++ b/src/Digdir.Domain.Dialogporten.Service/Digdir.Domain.Dialogporten.Service.csproj
@@ -2,6 +2,7 @@
 
     <ItemGroup>
         <PackageReference Include="Serilog.AspNetCore" Version="8.0.3" />
+        <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
         <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="4.0.0"/>
     </ItemGroup>
 

--- a/src/Digdir.Domain.Dialogporten.Service/Program.cs
+++ b/src/Digdir.Domain.Dialogporten.Service/Program.cs
@@ -16,6 +16,7 @@ var telemetryConfiguration = TelemetryConfiguration.CreateDefault();
 Log.Logger = new LoggerConfiguration()
     .MinimumLevel.Warning()
     .Enrich.FromLogContext()
+    .Enrich.WithEnvironmentName()
     .WriteTo.Console(formatProvider: CultureInfo.InvariantCulture)
     .WriteTo.ApplicationInsights(telemetryConfiguration, TelemetryConverter.Traces)
     .CreateBootstrapLogger();
@@ -43,6 +44,7 @@ static void BuildAndRun(string[] args, TelemetryConfiguration telemetryConfigura
         .ReadFrom.Configuration(context.Configuration)
         .ReadFrom.Services(services)
         .Enrich.FromLogContext()
+        .Enrich.WithEnvironmentName()
         .WriteTo.ApplicationInsights(telemetryConfiguration, TelemetryConverter.Traces));
 
     builder.Configuration

--- a/src/Digdir.Domain.Dialogporten.Service/Properties/launchSettings.json
+++ b/src/Digdir.Domain.Dialogporten.Service/Properties/launchSettings.json
@@ -4,7 +4,7 @@
       "commandName": "Project",
       "launchBrowser": false,
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "DOTNET_ENVIRONMENT": "Development"
       },
       "applicationUrl": "https://localhost:56841;http://localhost:56842"
     }

--- a/src/Digdir.Domain.Dialogporten.WebApi/Digdir.Domain.Dialogporten.WebApi.csproj
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Digdir.Domain.Dialogporten.WebApi.csproj
@@ -14,6 +14,7 @@
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.10" />
         <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="8.0.0" />
         <PackageReference Include="Serilog.AspNetCore" Version="8.0.3" />
+        <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
         <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="4.0.0"/>
     </ItemGroup>
 

--- a/src/Digdir.Domain.Dialogporten.WebApi/Program.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Program.cs
@@ -29,6 +29,7 @@ using Microsoft.Extensions.Options;
 var telemetryConfiguration = TelemetryConfiguration.CreateDefault();
 Log.Logger = new LoggerConfiguration()
     .MinimumLevel.Warning()
+    .Enrich.WithEnvironmentName()
     .Enrich.FromLogContext()
     .WriteTo.Console(formatProvider: CultureInfo.InvariantCulture)
     .WriteTo.ApplicationInsights(telemetryConfiguration, TelemetryConverter.Traces)
@@ -61,6 +62,7 @@ static void BuildAndRun(string[] args, TelemetryConfiguration telemetryConfigura
         .MinimumLevel.Warning()
         .ReadFrom.Configuration(context.Configuration)
         .ReadFrom.Services(services)
+        .Enrich.WithEnvironmentName()
         .Enrich.FromLogContext()
         .WriteTo.ApplicationInsights(telemetryConfiguration, TelemetryConverter.Traces));
 

--- a/src/Digdir.Domain.Dialogporten.WebApi/Properties/launchSettings.json
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Properties/launchSettings.json
@@ -8,7 +8,7 @@
       "launchUrl": "swagger",
       "applicationUrl": "http://localhost:5123",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "DOTNET_ENVIRONMENT": "Development"
       }
     },
     "https": {
@@ -18,7 +18,7 @@
       "launchUrl": "swagger",
       "applicationUrl": "https://localhost:7214;http://localhost:5123",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "DOTNET_ENVIRONMENT": "Development"
       }
     }
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced logging capabilities across various projects by integrating environment-specific information.
	- Updated Slack Notifier function app configuration for improved environment categorization and accessibility.

- **Bug Fixes**
	- Corrected environment variable usage from `ASPNETCORE_ENVIRONMENT` to `DOTNET_ENVIRONMENT` for consistency across projects.

- **Documentation**
	- Maintained Swagger documentation setup and improved logging details in application initialization.

- **Chores**
	- Added necessary package references for `Serilog.Enrichers.Environment` to multiple projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->