### PR TITLE
fix(azure): ensure postgres configuration run in sequence

### DIFF
--- a/.azure/modules/postgreSql/create.bicep
+++ b/.azure/modules/postgreSql/create.bicep
@@ -128,6 +128,7 @@ resource pg_qs_query_capture_mode 'Microsoft.DBforPostgreSQL/flexibleServers/con
     value: 'all'
     source: 'user-override'
   }
+  dependsOn: [track_io_timing]
 }
 
 resource pgms_wait_sampling_query_capture_mode 'Microsoft.DBforPostgreSQL/flexibleServers/configurations@2024-08-01' = if (enableQueryPerformanceInsight) {
@@ -137,6 +138,7 @@ resource pgms_wait_sampling_query_capture_mode 'Microsoft.DBforPostgreSQL/flexib
     value: 'all'
     source: 'user-override'
   }
+  dependsOn: [pg_qs_query_capture_mode]
 }
 
 resource appInsightsWorkspace 'Microsoft.OperationalInsights/workspaces@2023-09-01' existing = {
@@ -177,6 +179,7 @@ resource diagnosticSetting 'Microsoft.Insights/diagnosticSettings@2021-05-01-pre
       }
     ]
   }
+  dependsOn: [pgms_wait_sampling_query_capture_mode]
 }
 
 module adoConnectionString '../keyvault/upsertSecret.bicep' = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Getting a lot of operation in progress when updating configuration for the postgresql server. Could be that we need to add the configuration in sequence. 

## Related Issue(s)

- #{issue number}

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved dependency management in the PostgreSQL Bicep template for better control over resource creation order.
	- Ensured the correct sequencing of configuration resources related to performance insights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->