### PR TITLE
feat(azure): enable index tuning for postgres in YT

### DIFF
--- a/.azure/infrastructure/main.bicep
+++ b/.azure/infrastructure/main.bicep
@@ -58,6 +58,7 @@ import { Sku as PostgresSku } from '../modules/postgreSql/create.bicep'
 
 param postgresConfiguration {
   sku: PostgresSku
+  enableIndexTuning: bool
   enableQueryPerformanceInsight: bool
 }
 
@@ -205,6 +206,7 @@ module postgresql '../modules/postgreSql/create.bicep' = {
       : secrets.dialogportenPgAdminPassword
     sku: postgresConfiguration.sku
     appInsightWorkspaceName: appInsights.outputs.appInsightsWorkspaceName
+    enableIndexTuning: postgresConfiguration.enableIndexTuning
     enableQueryPerformanceInsight: postgresConfiguration.enableQueryPerformanceInsight
     subnetId: vnet.outputs.postgresqlSubnetId
     vnetId: vnet.outputs.virtualNetworkId

--- a/.azure/infrastructure/prod.bicepparam
+++ b/.azure/infrastructure/prod.bicepparam
@@ -35,6 +35,7 @@ param postgresConfiguration = {
     tier: 'GeneralPurpose'
   }
   enableQueryPerformanceInsight: false
+  enableIndexTuning: false
 }
 
 param redisSku = {

--- a/.azure/infrastructure/staging.bicepparam
+++ b/.azure/infrastructure/staging.bicepparam
@@ -34,6 +34,7 @@ param postgresConfiguration = {
     name: 'Standard_B1ms'
     tier: 'Burstable'
   }
+  enableIndexTuning: false
   enableQueryPerformanceInsight: true
 }
 

--- a/.azure/infrastructure/test.bicepparam
+++ b/.azure/infrastructure/test.bicepparam
@@ -34,6 +34,7 @@ param postgresConfiguration = {
     name: 'Standard_B2s'
     tier: 'Burstable'
   }
+  enableIndexTuning: false
   enableQueryPerformanceInsight: true
 }
 

--- a/.azure/infrastructure/yt01.bicepparam
+++ b/.azure/infrastructure/yt01.bicepparam
@@ -34,6 +34,7 @@ param postgresConfiguration = {
     name: 'Standard_D4ads_v5'
     tier: 'GeneralPurpose'
   }
+  enableIndexTuning: true
   enableQueryPerformanceInsight: true
 }
 

--- a/.azure/modules/postgreSql/create.bicep
+++ b/.azure/modules/postgreSql/create.bicep
@@ -34,6 +34,9 @@ param sku Sku
 @description('Enable query performance insight')
 param enableQueryPerformanceInsight bool
 
+@description('Enable index tuning')
+param enableIndexTuning bool
+
 @description('The name of the Application Insights workspace')
 param appInsightWorkspaceName string
 
@@ -136,6 +139,16 @@ resource pgms_wait_sampling_query_capture_mode 'Microsoft.DBforPostgreSQL/flexib
   name: 'pgms_wait_sampling.query_capture_mode'
   properties: {
     value: 'all'
+    source: 'user-override'
+  }
+  dependsOn: [pg_qs_query_capture_mode]
+}
+
+resource index_tuning_mode 'Microsoft.DBforPostgreSQL/flexibleServers/configurations@2024-08-01' = if (enableIndexTuning) {
+  parent: postgres
+  name: 'index_tuning.mode'
+  properties: {
+    value: 'report'
     source: 'user-override'
   }
   dependsOn: [pg_qs_query_capture_mode]

--- a/.azure/modules/postgreSql/create.bicep
+++ b/.azure/modules/postgreSql/create.bicep
@@ -151,7 +151,7 @@ resource index_tuning_mode 'Microsoft.DBforPostgreSQL/flexibleServers/configurat
     value: 'report'
     source: 'user-override'
   }
-  dependsOn: [pg_qs_query_capture_mode]
+  dependsOn: [pgms_wait_sampling_query_capture_mode]
 }
 
 resource appInsightsWorkspace 'Microsoft.OperationalInsights/workspaces@2023-09-01' existing = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/concepts-index-tuning

Index tuning is a feature in Azure Database for PostgreSQL flexible server that automatically improves the performance of your workload by analyzing the tracked queries and providing index recommendations.

## Related Issue(s)

- #{issue number}

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an `enableIndexTuning` parameter for PostgreSQL configuration, allowing users to control index tuning during setup.
	- Enhanced PostgreSQL resource management with the addition of an `index_tuning_mode` resource, which can be conditionally deployed based on the new parameter.

- **Bug Fixes**
	- None.

- **Documentation**
	- Updated parameter descriptions to reflect the new indexing capabilities.

- **Chores**
	- Updated various parameter files to include the new `enableIndexTuning` parameter with default values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->