### PR TITLE
fix(webapi): Require base service provider scope on search endpoint

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Application/Common/Extensions/ClaimsPrincipalExtensions.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Common/Extensions/ClaimsPrincipalExtensions.cs
@@ -29,10 +29,11 @@ public static class ClaimsPrincipalExtensions
     private const string PidClaim = "pid";
 
 
-    // TODO: This scope is also defined in WebAPI/GQL. Can this be fetched from a common auth lib?
+    // TODO: These scopes are also defined in WebAPI/GQL. Can this be fetched from a common auth lib?
     // https://github.com/digdir/dialogporten/issues/647
     // This could be done for all claims/scopes/prefixes etc, there are duplicates
-    public const string ServiceProviderScope = "digdir:dialogporten.serviceprovider";
+    private const string ServiceProviderScope = "digdir:dialogporten.serviceprovider";
+    private const string ServiceProviderSearchScope = "digdir:dialogporten.serviceprovider.search";
 
     public static bool TryGetClaimValue(this ClaimsPrincipal claimsPrincipal, string claimType,
         [NotNullWhen(true)] out string? value)
@@ -244,7 +245,7 @@ public static class ClaimsPrincipalExtensions
             return (UserIdType.SystemUser, externalId);
         }
 
-        if (claimsPrincipal.HasScope(ServiceProviderScope) &&
+        if ((claimsPrincipal.HasScope(ServiceProviderScope) || claimsPrincipal.HasScope(ServiceProviderSearchScope)) &&
             claimsPrincipal.TryGetOrganizationNumber(out externalId))
         {
             return (UserIdType.ServiceOwner, externalId);

--- a/src/Digdir.Domain.Dialogporten.Application/Common/Extensions/ClaimsPrincipalExtensions.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Common/Extensions/ClaimsPrincipalExtensions.cs
@@ -29,11 +29,10 @@ public static class ClaimsPrincipalExtensions
     private const string PidClaim = "pid";
 
 
-    // TODO: These scopes are also defined in WebAPI/GQL. Can this be fetched from a common auth lib?
+    // TODO: This scope is also defined in WebAPI/GQL. Can this be fetched from a common auth lib?
     // https://github.com/digdir/dialogporten/issues/647
     // This could be done for all claims/scopes/prefixes etc, there are duplicates
-    private const string ServiceProviderScope = "digdir:dialogporten.serviceprovider";
-    private const string ServiceProviderSearchScope = "digdir:dialogporten.serviceprovider.search";
+    public const string ServiceProviderScope = "digdir:dialogporten.serviceprovider";
 
     public static bool TryGetClaimValue(this ClaimsPrincipal claimsPrincipal, string claimType,
         [NotNullWhen(true)] out string? value)
@@ -245,7 +244,7 @@ public static class ClaimsPrincipalExtensions
             return (UserIdType.SystemUser, externalId);
         }
 
-        if ((claimsPrincipal.HasScope(ServiceProviderScope) || claimsPrincipal.HasScope(ServiceProviderSearchScope)) &&
+        if (claimsPrincipal.HasScope(ServiceProviderScope) &&
             claimsPrincipal.TryGetOrganizationNumber(out externalId))
         {
             return (UserIdType.ServiceOwner, externalId);

--- a/src/Digdir.Domain.Dialogporten.GraphQL/Common/Authorization/AuthorizationOptionsSetup.cs
+++ b/src/Digdir.Domain.Dialogporten.GraphQL/Common/Authorization/AuthorizationOptionsSetup.cs
@@ -39,7 +39,7 @@ internal sealed class AuthorizationOptionsSetup : IConfigureOptions<Authorizatio
             .RequireScope(AuthorizationScope.ServiceProvider));
 
         options.AddPolicy(AuthorizationPolicy.ServiceProviderSearch, builder => builder
-            .Combine(options.DefaultPolicy)
+            .Combine(options.GetPolicy(AuthorizationPolicy.ServiceProvider)!)
             .RequireScope(AuthorizationScope.ServiceProviderSearch));
 
         options.AddPolicy(AuthorizationPolicy.Testing, builder => builder

--- a/src/Digdir.Domain.Dialogporten.WebApi/Common/Authorization/AuthorizationOptionsSetup.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Common/Authorization/AuthorizationOptionsSetup.cs
@@ -35,7 +35,7 @@ internal sealed class AuthorizationOptionsSetup : IConfigureOptions<Authorizatio
             .RequireScope(AuthorizationScope.ServiceProvider));
 
         options.AddPolicy(AuthorizationPolicy.ServiceProviderSearch, builder => builder
-            .Combine(options.DefaultPolicy)
+            .Combine(options.GetPolicy(AuthorizationPolicy.ServiceProvider)!)
             .RequireScope(AuthorizationScope.ServiceProviderSearch));
 
         options.AddPolicy(AuthorizationPolicy.Testing, builder => builder


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue(s)

- #1475 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced authorization logic for the `ServiceProviderSearch` policy, improving specificity and security.
- **Bug Fixes**
	- Refined error handling during initialization to ensure valid settings are used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->