### PR TITLE
ci: ensure version is stored when deploying apps

### DIFF
--- a/.github/workflows/ci-cd-prod.yml
+++ b/.github/workflows/ci-cd-prod.yml
@@ -130,7 +130,7 @@ jobs:
   store-apps-version:
     name: Store Latest Deployed Apps Version as GitHub Variable
     needs: [deploy-apps, get-current-version]
-    if: ${{ needs.deploy-apps.result == 'success' }}
+    if: ${{ always() && !failure() && !cancelled() && (github.event_name == 'workflow_dispatch' || needs.deploy-apps.outputs.deployment_executed == 'true') }}
     uses: ./.github/workflows/workflow-store-github-env-variable.yml
     with:
       variable_name: LATEST_DEPLOYED_APPS_VERSION

--- a/.github/workflows/ci-cd-staging.yml
+++ b/.github/workflows/ci-cd-staging.yml
@@ -96,7 +96,7 @@ jobs:
   store-apps-version:
     name: Store Latest Deployed Apps Version as GitHub Variable
     needs: [deploy-apps, get-current-version]
-    if: ${{ needs.deploy-apps.result == 'success' }}
+    if: ${{ always() && !failure() && !cancelled() && (github.event_name == 'workflow_dispatch' || needs.deploy-apps.outputs.deployment_executed == 'true') }}
     uses: ./.github/workflows/workflow-store-github-env-variable.yml
     with:
       variable_name: LATEST_DEPLOYED_APPS_VERSION

--- a/.github/workflows/ci-cd-yt01.yml
+++ b/.github/workflows/ci-cd-yt01.yml
@@ -98,7 +98,7 @@ jobs:
   store-apps-version:
     name: Store Latest Deployed Apps Version as GitHub Variable
     needs: [deploy-apps, get-current-version]
-    if: ${{ needs.deploy-apps.result == 'success' }}
+    if: ${{ always() && !failure() && !cancelled() && (github.event_name == 'workflow_dispatch' || needs.deploy-apps.outputs.deployment_executed == 'true') }}
     uses: ./.github/workflows/workflow-store-github-env-variable.yml
     with:
       variable_name: LATEST_DEPLOYED_APPS_VERSION

--- a/.github/workflows/workflow-deploy-apps.yml
+++ b/.github/workflows/workflow-deploy-apps.yml
@@ -3,6 +3,10 @@ env:
   AZ_CLI_VERSION: 2.64.0
 on:
   workflow_call:
+    outputs:
+      deployment_executed:
+        description: "Indicates if the deployment was actually executed"
+        value: ${{ jobs.deploy-apps.result == 'success' }}
     secrets:
       AZURE_CLIENT_ID:
         required: true

--- a/.github/workflows/workflow-deploy-apps.yml
+++ b/.github/workflows/workflow-deploy-apps.yml
@@ -6,7 +6,7 @@ on:
     outputs:
       deployment_executed:
         description: "Indicates if the deployment was actually executed"
-        value: ${{ jobs.deploy-apps.result == 'success' }}
+        value: ${{ jobs.deploy-apps.result == 'success' && jobs.deploy-jobs.result == 'success' && !inputs.dryRun }}
     secrets:
       AZURE_CLIENT_ID:
         required: true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

There is a case where if the migration deployment was skipped, the whole deploy-apps workflow status will also be "skipped". This results in that the store-apps-version will never get run. Rather storing the deployment status excplicitly in the deploy-apps workflow instead. 

## Related Issue(s)

- #{issue number}

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced CI/CD workflows for production, staging, and YT01 with improved job execution conditions, allowing for more resilient deployments and testing.
	- Introduced a new output variable `deployment_executed` to indicate the success of deployments.

- **Bug Fixes**
	- Adjusted conditions for running end-to-end tests to ensure they execute under broader circumstances.

- **Documentation**
	- Updated workflow configurations to reflect the new job parameters and outputs for better clarity on deployment processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->