### PR TITLE
chore: revert function app version updates

### DIFF
--- a/.azure/modules/functionApp/appSettings.bicep
+++ b/.azure/modules/functionApp/appSettings.bicep
@@ -11,7 +11,7 @@ resource webApp 'Microsoft.Web/sites@2023-12-01' existing = {
   name: webAppName
 }
 
-resource siteconfig 'Microsoft.Web/sites/config@2024-04-01' = {
+resource siteconfig 'Microsoft.Web/sites/config@2023-12-01' = {
   parent: webApp
   name: 'appsettings'
   properties: union(currentAppSettings, appSettings)

--- a/.azure/modules/functionApp/slackNotifier.bicep
+++ b/.azure/modules/functionApp/slackNotifier.bicep
@@ -80,7 +80,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2023-04-01' = {
   tags: tags
 }
 
-resource applicationServicePlan 'Microsoft.Web/serverfarms@2024-04-01' = {
+resource applicationServicePlan 'Microsoft.Web/serverfarms@2023-12-01' = {
   name: '${namePrefix}-slacknotifier-asp'
   location: location
   sku: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

For some reason the function app cannot be updated in Bicep. Reverting rest of the changes done to the upgrading of versions for the function app 

<!--- Describe your changes in detail -->

## Related Issue(s)

- #{issue number}

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated resource versions for Azure Function App settings and Slack Notifier function app to a more stable release.
  
- **Bug Fixes**
	- Ensured consistent naming conventions and configurations across application settings without altering core functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->