### PR TITLE
chore: Appsettings comment typo

### DIFF
--- a/src/Digdir.Domain.Dialogporten.GraphQL/appsettings.Development.json
+++ b/src/Digdir.Domain.Dialogporten.GraphQL/appsettings.Development.json
@@ -11,7 +11,7 @@
       "Environment": "test",
       // 2. Client Id/integration as configured in Maskinporten
       "ClientId": "TODO: Add to local secrets",
-      // 3. Scope(s) requested, space seperated. Must be provisioned on supplied client id.
+      // 3. Scope(s) requested, space separated. Must be provisioned on the supplied client id.
       "Scope": "altinn:events.publish altinn:events.publish.admin altinn:register/partylookup.admin altinn:authorization/authorize.admin altinn:accessmanagement/authorizedparties.admin",
       // --------------------------
       // Any additional settings are specific for the selected client definition type.

--- a/src/Digdir.Domain.Dialogporten.GraphQL/appsettings.prod.json
+++ b/src/Digdir.Domain.Dialogporten.GraphQL/appsettings.prod.json
@@ -11,7 +11,7 @@
       "Environment": "prod",
       // 2. Client Id/integration as configured in Maskinporten
       "ClientId": "TODO: Add to local secrets",
-      // 3. Scope(s) requested, space seperated. Must be provisioned on supplied client id.
+      // 3. Scope(s) requested, space separated. Must be provisioned on the supplied client id.
       "Scope": "altinn:events.publish altinn:events.publish.admin altinn:register/partylookup.admin altinn:authorization/authorize.admin altinn:accessmanagement/authorizedparties.admin",
       // --------------------------
       // Any additional settings are specific for the selected client definition type.

--- a/src/Digdir.Domain.Dialogporten.GraphQL/appsettings.staging.json
+++ b/src/Digdir.Domain.Dialogporten.GraphQL/appsettings.staging.json
@@ -11,7 +11,7 @@
       "Environment": "test",
       // 2. Client Id/integration as configured in Maskinporten
       "ClientId": "TODO: Add to local secrets",
-      // 3. Scope(s) requested, space seperated. Must be provisioned on supplied client id.
+      // 3. Scope(s) requested, space separated. Must be provisioned on the supplied client id.
       "Scope": "altinn:events.publish altinn:events.publish.admin altinn:register/partylookup.admin altinn:authorization/authorize.admin altinn:accessmanagement/authorizedparties.admin",
       // --------------------------
       // Any additional settings are specific for the selected client definition type.

--- a/src/Digdir.Domain.Dialogporten.GraphQL/appsettings.test.json
+++ b/src/Digdir.Domain.Dialogporten.GraphQL/appsettings.test.json
@@ -11,7 +11,7 @@
       "Environment": "test",
       // 2. Client Id/integration as configured in Maskinporten
       "ClientId": "TODO: Add to local secrets",
-      // 3. Scope(s) requested, space seperated. Must be provisioned on supplied client id.
+      // 3. Scope(s) requested, space separated. Must be provisioned on the supplied client id.
       "Scope": "altinn:events.publish altinn:events.publish.admin altinn:register/partylookup.admin altinn:authorization/authorize.admin altinn:accessmanagement/authorizedparties.admin",
       // --------------------------
       // Any additional settings are specific for the selected client definition type.

--- a/src/Digdir.Domain.Dialogporten.GraphQL/appsettings.yt01.json
+++ b/src/Digdir.Domain.Dialogporten.GraphQL/appsettings.yt01.json
@@ -11,7 +11,7 @@
       "Environment": "test",
       // 2. Client Id/integration as configured in Maskinporten
       "ClientId": "TODO: Add to local secrets",
-      // 3. Scope(s) requested, space seperated. Must be provisioned on supplied client id.
+      // 3. Scope(s) requested, space separated. Must be provisioned on the supplied client id.
       "Scope": "altinn:events.publish altinn:events.publish.admin altinn:register/partylookup.admin altinn:authorization/authorize.admin altinn:accessmanagement/authorizedparties.admin",
       // --------------------------
       // Any additional settings are specific for the selected client definition type.

--- a/src/Digdir.Domain.Dialogporten.Service/appsettings.Development.json
+++ b/src/Digdir.Domain.Dialogporten.Service/appsettings.Development.json
@@ -13,7 +13,7 @@
       // 2. Client Id/integration as configured in Maskinporten
       "ClientId": "TODO: Add to local secrets",
 
-      // 3. Scope(s) requested, space seperated. Must be provisioned on supplied client id.
+      // 3. Scope(s) requested, space separated. Must be provisioned on the supplied client id.
       "Scope": "altinn:events.publish altinn:events.publish.admin altinn:register/partylookup.admin altinn:authorization/authorize.admin altinn:accessmanagement/authorizedparties.admin",
 
       // --------------------------

--- a/src/Digdir.Domain.Dialogporten.Service/appsettings.prod.json
+++ b/src/Digdir.Domain.Dialogporten.Service/appsettings.prod.json
@@ -14,7 +14,7 @@
       "Environment": "prod",
       // 2. Client Id/integration as configured in Maskinporten
       "ClientId": "TODO: Add to local secrets",
-      // 3. Scope(s) requested, space seperated. Must be provisioned on supplied client id.
+      // 3. Scope(s) requested, space separated. Must be provisioned on the supplied client id.
       "Scope": "altinn:events.publish altinn:events.publish.admin altinn:register/partylookup.admin altinn:authorization/authorize.admin altinn:accessmanagement/authorizedparties.admin",
       // --------------------------
       // Any additional settings are specific for the selected client definition type.

--- a/src/Digdir.Domain.Dialogporten.Service/appsettings.staging.json
+++ b/src/Digdir.Domain.Dialogporten.Service/appsettings.staging.json
@@ -14,7 +14,7 @@
       "Environment": "test",
       // 2. Client Id/integration as configured in Maskinporten
       "ClientId": "TODO: Add to local secrets",
-      // 3. Scope(s) requested, space seperated. Must be provisioned on supplied client id.
+      // 3. Scope(s) requested, space separated. Must be provisioned on the supplied client id.
       "Scope": "altinn:events.publish altinn:events.publish.admin altinn:register/partylookup.admin altinn:authorization/authorize.admin altinn:accessmanagement/authorizedparties.admin",
       // --------------------------
       // Any additional settings are specific for the selected client definition type.

--- a/src/Digdir.Domain.Dialogporten.Service/appsettings.test.json
+++ b/src/Digdir.Domain.Dialogporten.Service/appsettings.test.json
@@ -14,7 +14,7 @@
       "Environment": "test",
       // 2. Client Id/integration as configured in Maskinporten
       "ClientId": "TODO: Add to local secrets",
-      // 3. Scope(s) requested, space seperated. Must be provisioned on supplied client id.
+      // 3. Scope(s) requested, space separated. Must be provisioned on the supplied client id.
       "Scope": "altinn:events.publish altinn:events.publish.admin altinn:register/partylookup.admin altinn:authorization/authorize.admin altinn:accessmanagement/authorizedparties.admin",
       // --------------------------
       // Any additional settings are specific for the selected client definition type.

--- a/src/Digdir.Domain.Dialogporten.Service/appsettings.yt01.json
+++ b/src/Digdir.Domain.Dialogporten.Service/appsettings.yt01.json
@@ -14,7 +14,7 @@
       "Environment": "test",
       // 2. Client Id/integration as configured in Maskinporten
       "ClientId": "TODO: Add to local secrets",
-      // 3. Scope(s) requested, space seperated. Must be provisioned on supplied client id.
+      // 3. Scope(s) requested, space separated. Must be provisioned on the supplied client id.
       "Scope": "altinn:events.publish altinn:events.publish.admin altinn:register/partylookup.admin altinn:authorization/authorize.admin altinn:accessmanagement/authorizedparties.admin",
       // --------------------------
       // Any additional settings are specific for the selected client definition type.

--- a/src/Digdir.Domain.Dialogporten.WebApi/appsettings.Development.json
+++ b/src/Digdir.Domain.Dialogporten.WebApi/appsettings.Development.json
@@ -13,7 +13,7 @@
       // 2. Client Id/integration as configured in Maskinporten
       "ClientId": "TODO: Add to local secrets",
 
-      // 3. Scope(s) requested, space seperated. Must be provisioned on supplied client id.
+      // 3. Scope(s) requested, space separated. Must be provisioned on the supplied client id.
       "Scope": "altinn:events.publish altinn:events.publish.admin altinn:register/partylookup.admin altinn:authorization/authorize.admin altinn:accessmanagement/authorizedparties.admin",
 
       // --------------------------

--- a/src/Digdir.Domain.Dialogporten.WebApi/appsettings.prod.json
+++ b/src/Digdir.Domain.Dialogporten.WebApi/appsettings.prod.json
@@ -11,7 +11,7 @@
       "Environment": "prod",
       // 2. Client Id/integration as configured in Maskinporten
       "ClientId": "TODO: Add to local secrets",
-      // 3. Scope(s) requested, space seperated. Must be provisioned on supplied client id.
+      // 3. Scope(s) requested, space separated. Must be provisioned on the supplied client id.
       "Scope": "altinn:events.publish altinn:events.publish.admin altinn:register/partylookup.admin altinn:authorization/authorize.admin altinn:accessmanagement/authorizedparties.admin",
       // --------------------------
       // Any additional settings are specific for the selected client definition type.

--- a/src/Digdir.Domain.Dialogporten.WebApi/appsettings.staging.json
+++ b/src/Digdir.Domain.Dialogporten.WebApi/appsettings.staging.json
@@ -13,7 +13,7 @@
       // 2. Client Id/integration as configured in Maskinporten
       "ClientId": "TODO: Add to local secrets",
 
-      // 3. Scope(s) requested, space seperated. Must be provisioned on supplied client id.
+      // 3. Scope(s) requested, space separated. Must be provisioned on the supplied client id.
       "Scope": "altinn:events.publish altinn:events.publish.admin altinn:register/partylookup.admin altinn:authorization/authorize.admin altinn:accessmanagement/authorizedparties.admin",
 
       // --------------------------

--- a/src/Digdir.Domain.Dialogporten.WebApi/appsettings.test.json
+++ b/src/Digdir.Domain.Dialogporten.WebApi/appsettings.test.json
@@ -13,7 +13,7 @@
       // 2. Client Id/integration as configured in Maskinporten
       "ClientId": "TODO: Add to local secrets",
 
-      // 3. Scope(s) requested, space seperated. Must be provisioned on supplied client id.
+      // 3. Scope(s) requested, space separated. Must be provisioned on the supplied client id.
       "Scope": "altinn:events.publish altinn:events.publish.admin altinn:register/partylookup.admin altinn:authorization/authorize.admin altinn:accessmanagement/authorizedparties.admin",
 
       // --------------------------

--- a/src/Digdir.Domain.Dialogporten.WebApi/appsettings.yt01.json
+++ b/src/Digdir.Domain.Dialogporten.WebApi/appsettings.yt01.json
@@ -11,7 +11,7 @@
       "Environment": "test",
       // 2. Client Id/integration as configured in Maskinporten
       "ClientId": "TODO: Add to local secrets",
-      // 3. Scope(s) requested, space seperated. Must be provisioned on supplied client id.
+      // 3. Scope(s) requested, space separated. Must be provisioned on the supplied client id.
       "Scope": "altinn:events.publish altinn:events.publish.admin altinn:register/partylookup.admin altinn:authorization/authorize.admin altinn:accessmanagement/authorizedparties.admin",
       // --------------------------
       // Any additional settings are specific for the selected client definition type.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected typographical errors in comments across various configuration files regarding the "Scope" field, changing "space seperated" to "space separated."
- **Chores**
	- Added newlines at the end of configuration files for improved formatting consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->