### PR TITLE
fix(azure): enable public access for azure monitor

### DIFF
--- a/.azure/infrastructure/main.bicep
+++ b/.azure/infrastructure/main.bicep
@@ -131,8 +131,6 @@ module monitorWorkspace '../modules/monitor-workspace/main.bicep' = {
   params: {
     namePrefix: namePrefix
     location: location
-    subnetId: vnet.outputs.monitorSubnetId
-    vnetId: vnet.outputs.virtualNetworkId
     tags: tags
   }
 }

--- a/.azure/modules/monitor-workspace/main.bicep
+++ b/.azure/modules/monitor-workspace/main.bicep
@@ -17,7 +17,8 @@ resource monitorWorkspace 'Microsoft.Monitor/accounts@2023-04-03' = {
   name: '${namePrefix}-monitor'
   location: location
   properties: {
-    publicNetworkAccess: 'Disabled'
+    // todo: enable once we have a use case for it https://github.com/digdir/dialogporten/issues/1462
+    publicNetworkAccess: 'Enabled'
   }
   tags: tags
 }

--- a/.azure/modules/monitor-workspace/main.bicep
+++ b/.azure/modules/monitor-workspace/main.bicep
@@ -17,7 +17,7 @@ resource monitorWorkspace 'Microsoft.Monitor/accounts@2023-04-03' = {
   name: '${namePrefix}-monitor'
   location: location
   properties: {
-    // todo: enable once we have a use case for it https://github.com/digdir/dialogporten/issues/1462
+    // todo: enable once we have ensured a connection to this monitor workspace https://github.com/digdir/dialogporten/issues/1462
     publicNetworkAccess: 'Enabled'
   }
   tags: tags


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Struggling with connecting to the monitor workspace. Enabling public access and removing the private dns for now. https://github.com/digdir/dialogporten/issues/1462

## Related Issue(s)

- #{issue number}

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enabled public network access for the monitoring workspace, allowing for improved connectivity.

- **Bug Fixes**
	- Adjusted the configuration to ensure a reliable connection to the monitor workspace.

- **Chores**
	- Removed parameters related to private networking (`subnetId` and `vnetId`) from the deployment configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->