### PR TITLE
feat(azure): adjust SKU and storage for yt01 and prod

### DIFF
--- a/.azure/infrastructure/main.bicep
+++ b/.azure/infrastructure/main.bicep
@@ -55,9 +55,11 @@ import { Sku as SlackNotifierSku } from '../modules/functionApp/slackNotifier.bi
 param slackNotifierSku SlackNotifierSku
 
 import { Sku as PostgresSku } from '../modules/postgreSql/create.bicep'
+import { StorageConfiguration as PostgresStorageConfig } from '../modules/postgreSql/create.bicep'
 
 param postgresConfiguration {
   sku: PostgresSku
+  storage: PostgresStorageConfig
   enableIndexTuning: bool
   enableQueryPerformanceInsight: bool
 }
@@ -215,6 +217,7 @@ module postgresql '../modules/postgreSql/create.bicep' = {
       ? srcKeyVaultResource.getSecret('dialogportenPgAdminPassword${environment}')
       : secrets.dialogportenPgAdminPassword
     sku: postgresConfiguration.sku
+    storage: postgresConfiguration.storage
     appInsightWorkspaceName: appInsights.outputs.appInsightsWorkspaceName
     enableIndexTuning: postgresConfiguration.enableIndexTuning
     enableQueryPerformanceInsight: postgresConfiguration.enableQueryPerformanceInsight

--- a/.azure/infrastructure/prod.bicepparam
+++ b/.azure/infrastructure/prod.bicepparam
@@ -31,11 +31,17 @@ param slackNotifierSku = {
 }
 param postgresConfiguration = {
   sku: {
-    name: 'Standard_D4ads_v5'
+    name: 'Standard_D8ads_v5'
     tier: 'GeneralPurpose'
   }
-  enableQueryPerformanceInsight: false
+  storage: {
+    storageSizeGB: 256
+    iops: 1100
+    autoGrow: 'Enabled'
+    tier: 'Premium'
+  }
   enableIndexTuning: false
+  enableQueryPerformanceInsight: false
 }
 
 param redisSku = {

--- a/.azure/infrastructure/prod.bicepparam
+++ b/.azure/infrastructure/prod.bicepparam
@@ -36,9 +36,9 @@ param postgresConfiguration = {
   }
   storage: {
     storageSizeGB: 256
-    iops: 1100
     autoGrow: 'Enabled'
-    tier: 'Premium'
+    tier: 'P15'
+    type: 'Premium_LRS'
   }
   enableIndexTuning: false
   enableQueryPerformanceInsight: false

--- a/.azure/infrastructure/staging.bicepparam
+++ b/.azure/infrastructure/staging.bicepparam
@@ -34,6 +34,10 @@ param postgresConfiguration = {
     name: 'Standard_B1ms'
     tier: 'Burstable'
   }
+  storage: {
+    storageSizeGB: 32
+    autoGrow: 'Enabled'
+  }
   enableIndexTuning: false
   enableQueryPerformanceInsight: true
 }

--- a/.azure/infrastructure/staging.bicepparam
+++ b/.azure/infrastructure/staging.bicepparam
@@ -37,6 +37,7 @@ param postgresConfiguration = {
   storage: {
     storageSizeGB: 32
     autoGrow: 'Enabled'
+    type: 'Premium_LRS'
   }
   enableIndexTuning: false
   enableQueryPerformanceInsight: true

--- a/.azure/infrastructure/test.bicepparam
+++ b/.azure/infrastructure/test.bicepparam
@@ -34,6 +34,10 @@ param postgresConfiguration = {
     name: 'Standard_B2s'
     tier: 'Burstable'
   }
+  storage: {
+    storageSizeGB: 32
+    autoGrow: 'Enabled'
+  }
   enableIndexTuning: false
   enableQueryPerformanceInsight: true
 }

--- a/.azure/infrastructure/test.bicepparam
+++ b/.azure/infrastructure/test.bicepparam
@@ -37,6 +37,7 @@ param postgresConfiguration = {
   storage: {
     storageSizeGB: 32
     autoGrow: 'Enabled'
+    type: 'Premium_LRS'
   }
   enableIndexTuning: false
   enableQueryPerformanceInsight: true

--- a/.azure/infrastructure/yt01.bicepparam
+++ b/.azure/infrastructure/yt01.bicepparam
@@ -36,9 +36,9 @@ param postgresConfiguration = {
   }
   storage: {
     storageSizeGB: 256
-    iops: 1100
     autoGrow: 'Enabled'
-    tier: 'Premium'
+    tier: 'P15'
+    type: 'Premium_LRS'
   }
   enableIndexTuning: true
   enableQueryPerformanceInsight: true

--- a/.azure/infrastructure/yt01.bicepparam
+++ b/.azure/infrastructure/yt01.bicepparam
@@ -31,8 +31,14 @@ param slackNotifierSku = {
 }
 param postgresConfiguration = {
   sku: {
-    name: 'Standard_D4ads_v5'
+    name: 'Standard_D8ads_v5'
     tier: 'GeneralPurpose'
+  }
+  storage: {
+    storageSizeGB: 256
+    iops: 1100
+    autoGrow: 'Enabled'
+    tier: 'Premium'
   }
   enableIndexTuning: true
   enableQueryPerformanceInsight: true

--- a/.azure/modules/postgreSql/create.bicep
+++ b/.azure/modules/postgreSql/create.bicep
@@ -34,9 +34,9 @@ param sku Sku
 @export()
 type StorageConfiguration = {
   storageSizeGB: int
-  iops: int?
   autoGrow: 'Enabled' | 'Disabled'
-  tier: 'Premium'? // For burstable skus, this is not supported
+  type: 'Premium_LRS' | 'PremiumV2_LRS'
+  tier: 'P1' | 'P2' | 'P3' | 'P4' | 'P6' | 'P10' | 'P15' | 'P20' | 'P30' | 'P40' | 'P50' | 'P60' | 'P70' | 'P80' | null
 }
 
 @description('The storage configuration for the PostgreSQL server')
@@ -108,7 +108,7 @@ resource postgres 'Microsoft.DBforPostgreSQL/flexibleServers@2024-08-01' = {
     storage: {
       storageSizeGB: storage.storageSizeGB
       autoGrow: storage.autoGrow
-      iops: storage.iops
+      type: storage.type
       tier: storage.tier
     }
     dataEncryption: {

--- a/.azure/modules/postgreSql/create.bicep
+++ b/.azure/modules/postgreSql/create.bicep
@@ -24,12 +24,23 @@ param tags object
 
 @export()
 type Sku = {
-  name: 'Standard_B1ms' | 'Standard_B2s' | 'Standard_B4ms' | 'Standard_B8ms' | 'Standard_B12ms' | 'Standard_B16ms' | 'Standard_B20ms' | 'Standard_D4ads_v5'
+  name: 'Standard_B1ms' | 'Standard_B2s' | 'Standard_B4ms' | 'Standard_B8ms' | 'Standard_B12ms' | 'Standard_B16ms' | 'Standard_B20ms' | 'Standard_D4ads_v5' | 'Standard_D8ads_v5'
   tier: 'Burstable' | 'GeneralPurpose' | 'MemoryOptimized'
 }
 
 @description('The SKU of the PostgreSQL server')
 param sku Sku
+
+@export()
+type StorageConfiguration = {
+  storageSizeGB: int
+  iops: int?
+  autoGrow: 'Enabled' | 'Disabled'
+  tier: 'Premium'? // For burstable skus, this is not supported
+}
+
+@description('The storage configuration for the PostgreSQL server')
+param storage StorageConfiguration
 
 @description('Enable query performance insight')
 param enableQueryPerformanceInsight bool
@@ -94,7 +105,12 @@ resource postgres 'Microsoft.DBforPostgreSQL/flexibleServers@2024-08-01' = {
     version: '15'
     administratorLogin: administratorLogin
     administratorLoginPassword: administratorLoginPassword
-    storage: { storageSizeGB: 32 }
+    storage: {
+      storageSizeGB: storage.storageSizeGB
+      autoGrow: storage.autoGrow
+      iops: storage.iops
+      tier: storage.tier
+    }
     dataEncryption: {
       type: 'SystemManaged'
     }

--- a/.azure/modules/postgreSql/create.bicep
+++ b/.azure/modules/postgreSql/create.bicep
@@ -36,6 +36,7 @@ type StorageConfiguration = {
   @minValue(32)
   storageSizeGB: int
   autoGrow: 'Enabled' | 'Disabled'
+  @description('The type of storage account to use. Default is Premium_LRS.')
   type: 'Premium_LRS' | 'PremiumV2_LRS'
   @description('Required when type is Premium_LRS or PremiumV2_LRS')
   tier: 'P1' | 'P2' | 'P3' | 'P4' | 'P6' | 'P10' | 'P15' | 'P20' | 'P30' | 'P40' | 'P50' | 'P60' | 'P70' | 'P80' | null

--- a/.azure/modules/postgreSql/create.bicep
+++ b/.azure/modules/postgreSql/create.bicep
@@ -33,9 +33,11 @@ param sku Sku
 
 @export()
 type StorageConfiguration = {
+  @minValue(32)
   storageSizeGB: int
   autoGrow: 'Enabled' | 'Disabled'
   type: 'Premium_LRS' | 'PremiumV2_LRS'
+  @description('Required when type is Premium_LRS or PremiumV2_LRS')
   tier: 'P1' | 'P2' | 'P3' | 'P4' | 'P6' | 'P10' | 'P15' | 'P20' | 'P30' | 'P40' | 'P50' | 'P60' | 'P70' | 'P80' | null
 }
 


### PR DESCRIPTION
This reverts commit 304f4da7eae3657dc85118bbedce393d1a12d5a8.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

* The sku and storage now match what Storage has configured their database with in yt01

## Related Issue(s)

- #N/A Disussed here: https://digdir.slack.com/archives/C07R312076E/p1732198146365369

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced PostgreSQL configuration with new storage settings, including size and auto-grow options.
	- Updated SKU for PostgreSQL resources to a higher capacity version.
- **Bug Fixes**
	- Improved flexibility in the PostgreSQL resource setup by allowing dynamic storage configurations.
- **Documentation**
	- Updated parameter definitions to reflect new storage properties and SKU options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->