### PR TITLE
feat(graphql): Create separate type for sub-parties

### DIFF
--- a/docs/schema/V1/schema.verified.graphql
+++ b/docs/schema/V1/schema.verified.graphql
@@ -79,7 +79,6 @@ type AuthorizedParty {
 }
 
 type AuthorizedSubParty {
-  subParties: [AuthorizedSubParty!]
   party: String!
   name: String!
   partyType: String!

--- a/docs/schema/V1/schema.verified.graphql
+++ b/docs/schema/V1/schema.verified.graphql
@@ -66,6 +66,7 @@ type AttachmentUrl {
 }
 
 type AuthorizedParty {
+  subParties: [AuthorizedSubParty!]
   party: String!
   name: String!
   partyType: String!
@@ -75,7 +76,19 @@ type AuthorizedParty {
   isMainAdministrator: Boolean!
   isAccessManager: Boolean!
   hasOnlyAccessToSubParties: Boolean!
-  subParties: [AuthorizedParty!]
+}
+
+type AuthorizedSubParty {
+  subParties: [AuthorizedSubParty!]
+  party: String!
+  name: String!
+  partyType: String!
+  isDeleted: Boolean!
+  hasKeyRole: Boolean!
+  isCurrentEndUser: Boolean!
+  isMainAdministrator: Boolean!
+  isAccessManager: Boolean!
+  hasOnlyAccessToSubParties: Boolean!
 }
 
 type Content {

--- a/src/Digdir.Domain.Dialogporten.GraphQL/EndUser/Parties/MappingProfile.cs
+++ b/src/Digdir.Domain.Dialogporten.GraphQL/EndUser/Parties/MappingProfile.cs
@@ -8,5 +8,6 @@ public sealed class MappingProfile : Profile
     public MappingProfile()
     {
         CreateMap<AuthorizedPartyDto, AuthorizedParty>();
+        CreateMap<AuthorizedPartyDto, AuthorizedSubParty>();
     }
 }

--- a/src/Digdir.Domain.Dialogporten.GraphQL/EndUser/Parties/ObjectTypes.cs
+++ b/src/Digdir.Domain.Dialogporten.GraphQL/EndUser/Parties/ObjectTypes.cs
@@ -1,6 +1,6 @@
 namespace Digdir.Domain.Dialogporten.GraphQL.EndUser.Parties;
 
-public sealed class AuthorizedParty
+public class AuthorizedPartyBase
 {
     public string Party { get; init; } = null!;
     public string Name { get; init; } = null!;
@@ -11,5 +11,12 @@ public sealed class AuthorizedParty
     public bool IsMainAdministrator { get; init; }
     public bool IsAccessManager { get; init; }
     public bool HasOnlyAccessToSubParties { get; init; }
-    public List<AuthorizedParty>? SubParties { get; init; }
 }
+
+public class AuthorizedParty : AuthorizedPartyBase
+{
+    public List<AuthorizedSubParty>? SubParties { get; init; }
+}
+
+
+public sealed class AuthorizedSubParty : AuthorizedParty;

--- a/src/Digdir.Domain.Dialogporten.GraphQL/EndUser/Parties/ObjectTypes.cs
+++ b/src/Digdir.Domain.Dialogporten.GraphQL/EndUser/Parties/ObjectTypes.cs
@@ -19,4 +19,4 @@ public class AuthorizedParty : AuthorizedPartyBase
 }
 
 
-public sealed class AuthorizedSubParty : AuthorizedParty;
+public sealed class AuthorizedSubParty : AuthorizedPartyBase;

--- a/src/Digdir.Domain.Dialogporten.GraphQL/EndUser/Parties/ObjectTypes.cs
+++ b/src/Digdir.Domain.Dialogporten.GraphQL/EndUser/Parties/ObjectTypes.cs
@@ -13,7 +13,7 @@ public class AuthorizedPartyBase
     public bool HasOnlyAccessToSubParties { get; init; }
 }
 
-public class AuthorizedParty : AuthorizedPartyBase
+public sealed class AuthorizedParty : AuthorizedPartyBase
 {
     public List<AuthorizedSubParty>? SubParties { get; init; }
 }

--- a/src/Digdir.Domain.Dialogporten.GraphQL/EndUser/Parties/ObjectTypes.cs
+++ b/src/Digdir.Domain.Dialogporten.GraphQL/EndUser/Parties/ObjectTypes.cs
@@ -18,5 +18,4 @@ public sealed class AuthorizedParty : AuthorizedPartyBase
     public List<AuthorizedSubParty>? SubParties { get; init; }
 }
 
-
 public sealed class AuthorizedSubParty : AuthorizedPartyBase;

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/Authorization/LocalDevelopmentAltinnAuthorization.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/Authorization/LocalDevelopmentAltinnAuthorization.cs
@@ -3,6 +3,7 @@ using Digdir.Domain.Dialogporten.Application.Common.Extensions;
 using Digdir.Domain.Dialogporten.Application.Externals;
 using Digdir.Domain.Dialogporten.Application.Externals.AltinnAuthorization;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities;
+using Digdir.Domain.Dialogporten.Domain.Parties;
 using Digdir.Domain.Dialogporten.Domain.Parties.Abstractions;
 using Microsoft.EntityFrameworkCore;
 
@@ -53,7 +54,23 @@ internal sealed class LocalDevelopmentAltinnAuthorization : IAltinnAuthorization
 
     [SuppressMessage("Performance", "CA1822:Mark members as static")]
     public async Task<AuthorizedPartiesResult> GetAuthorizedParties(IPartyIdentifier authenticatedParty, bool _ = false, CancellationToken __ = default)
-        => await Task.FromResult(new AuthorizedPartiesResult { AuthorizedParties = [new() { Name = "Local Party", Party = authenticatedParty.FullId, IsCurrentEndUser = true }] });
+        => await Task.FromResult(new AuthorizedPartiesResult
+        {
+            AuthorizedParties = [new()
+            {
+                Name = "Local Party",
+                Party = authenticatedParty.FullId,
+                IsCurrentEndUser = true,
+                SubParties = [
+                    new()
+                    {
+                        Name = "Local Sub Party",
+                        Party = NorwegianOrganizationIdentifier.PrefixWithSeparator + "123456789",
+                        IsCurrentEndUser = true
+                    }
+                ]
+            }]
+        });
 
     public Task<bool> HasListAuthorizationForDialog(DialogEntity dialog, CancellationToken cancellationToken) => Task.FromResult(true);
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue(s)

- #1226 

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new fields in the `AuthorizedParty` and `AuthorizedSubParty` types to enhance user representation and relationships.
	- Added a new type `AuthorizedSubParty` to support nested party structures.

- **Bug Fixes**
	- Improved the `GetAuthorizedParties` method to return a more complex structure, including nested sub-party information.

- **Refactor**
	- Updated class structure and inheritance for `AuthorizedParty` and `AuthorizedSubParty` to facilitate better organization and relationships.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->