### PR TITLE
fix(azure): adjust SKU and storage for yt01 and prod

### DIFF
--- a/.azure/infrastructure/prod.bicepparam
+++ b/.azure/infrastructure/prod.bicepparam
@@ -37,7 +37,6 @@ param postgresConfiguration = {
   storage: {
     storageSizeGB: 256
     autoGrow: 'Enabled'
-    tier: 'P15'
     type: 'Premium_LRS'
   }
   enableIndexTuning: false

--- a/.azure/infrastructure/yt01.bicepparam
+++ b/.azure/infrastructure/yt01.bicepparam
@@ -37,7 +37,6 @@ param postgresConfiguration = {
   storage: {
     storageSizeGB: 256
     autoGrow: 'Enabled'
-    tier: 'P15'
     type: 'Premium_LRS'
   }
   enableIndexTuning: true

--- a/.azure/modules/postgreSql/create.bicep
+++ b/.azure/modules/postgreSql/create.bicep
@@ -38,8 +38,6 @@ type StorageConfiguration = {
   autoGrow: 'Enabled' | 'Disabled'
   @description('The type of storage account to use. Default is Premium_LRS.')
   type: 'Premium_LRS' | 'PremiumV2_LRS'
-  @description('Required when type is Premium_LRS or PremiumV2_LRS')
-  tier: 'P1' | 'P2' | 'P3' | 'P4' | 'P6' | 'P10' | 'P15' | 'P20' | 'P30' | 'P40' | 'P50' | 'P60' | 'P70' | 'P80' | null
 }
 
 @description('The storage configuration for the PostgreSQL server')
@@ -112,7 +110,6 @@ resource postgres 'Microsoft.DBforPostgreSQL/flexibleServers@2024-08-01' = {
       storageSizeGB: storage.storageSizeGB
       autoGrow: storage.autoGrow
       type: storage.type
-      tier: storage.tier
     }
     dataEncryption: {
       type: 'SystemManaged'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

By setting 256gb as storage size, the IOPS will be p15

## Related Issue(s)

- #{issue number}

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
