### PR TITLE
fix: Don't rethrow deserialization exceptions from FusionCache

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Infrastructure/InfrastructureExtensions.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/InfrastructureExtensions.cs
@@ -337,7 +337,12 @@ public static class InfrastructureExtensions
                 JitterMaxDuration = settings.JitterMaxDuration,
                 EagerRefreshThreshold = settings.EagerRefreshThreshold,
 
-                SkipMemoryCache = settings.SkipMemoryCache
+                SkipMemoryCache = settings.SkipMemoryCache,
+
+                // This will stop deserialization exceptions to be re-thrown, which will cause the factory to run as if
+                // the cache entry was not found. This avoids crashes which otherwise would happen if entities that
+                // are cached are changed in a way that makes them incompatible with the cached version.
+                ReThrowSerializationExceptions = false
             })
             .WithRegisteredSerializer()
             // If Redis is disabled (eg. in local development or non-web runtimes), we must instruct FusionCache to


### PR DESCRIPTION
## Description

This causes any deserialization exceptions happening when fetching caches to trigger a factory run, instead of bubbling up and hitting the global exception handler.

This error was introduced in #1409, which added a non-nullable field to an entity that existed in the distributed cache. 

## Related Issue(s)

- #1409 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced caching mechanism to improve system resilience by preventing crashes due to serialization exceptions.
  
- **Bug Fixes**
	- Adjusted behavior of the cache to handle deserialization issues more gracefully.

- **Style**
	- Minor formatting adjustments for improved code clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->