### PR TITLE
chore: Improve error message when unable to find resource in resource registry.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -381,3 +381,5 @@ FodyWeavers.xsd
 # Generated files with tokens
 **/.endusers-with-tokens.csv
 **/.serviceowners-with-tokens.csv
+
+**/http-client.private.env.json

--- a/src/Digdir.Domain.Dialogporten.Application/Common/Authorization/Constants.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Common/Authorization/Constants.cs
@@ -1,4 +1,6 @@
-﻿namespace Digdir.Domain.Dialogporten.Application.Common.Authorization;
+﻿using System.Collections.Immutable;
+
+namespace Digdir.Domain.Dialogporten.Application.Common.Authorization;
 
 public static class Constants
 {
@@ -9,4 +11,11 @@ public static class Constants
     public const string CorrespondenceScope = "digdir:dialogporten.correspondence";
     public const string ServiceOwnerAdminScope = "digdir:dialogporten.serviceprovider.admin";
     public const string LegacyHtmlScope = "digdir:dialogporten.serviceprovider.legacyhtml";
+
+    public static readonly ImmutableArray<string> SupportedResourceTypes =
+    [
+        "GenericAccessResource",
+        "AltinnApp",
+        "CorrespondenceService"
+    ];
 }

--- a/src/Digdir.Domain.Dialogporten.Application/Common/Authorization/IServiceResourceAuthorizer.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Common/Authorization/IServiceResourceAuthorizer.cs
@@ -74,8 +74,11 @@ internal sealed class ServiceResourceAuthorizer : IServiceResourceAuthorizer
         var serviceResourceInformation = await _resourceRegistry.GetResourceInformation(dialog.ServiceResource, cancellationToken);
         if (serviceResourceInformation is null)
         {
+            var supportedResourceTypes = string.Join(", ", Constants.SupportedResourceTypes);
             _domainContext.AddError(nameof(CreateDialogCommand.ServiceResource),
-                $"Service resource '{dialog.ServiceResource}' does not exist in the resource registry.");
+                $"Service resource '{dialog.ServiceResource}' does not exist in the resource " +
+                $"registry, or is not of the following supported resource types: " +
+                $"[{supportedResourceTypes}].");
             return new DomainContextInvalidated();
         }
 

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/ResourceRegistry/ResourceRegistryClient.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/ResourceRegistry/ResourceRegistryClient.cs
@@ -13,9 +13,6 @@ namespace Digdir.Domain.Dialogporten.Infrastructure.Altinn.ResourceRegistry;
 internal sealed class ResourceRegistryClient : IResourceRegistry
 {
     private const string ServiceResourceInformationCacheKey = "ServiceResourceInformationCacheKey";
-    private const string ResourceTypeGenericAccess = "GenericAccessResource";
-    private const string ResourceTypeAltinnApp = "AltinnApp";
-    private const string ResourceTypeCorrespondence = "CorrespondenceService";
     private const string ResourceRegistryResourceEndpoint = "resourceregistry/api/v1/resource/";
     private const string AuthenticationLevelCategory = "urn:altinn:minimum-authenticationlevel";
 
@@ -185,10 +182,7 @@ internal sealed class ResourceRegistryClient : IResourceRegistry
 
                 return response
                     .Where(x => !string.IsNullOrWhiteSpace(x.HasCompetentAuthority.Organization))
-                    .Where(x => x.ResourceType is
-                        ResourceTypeGenericAccess or
-                        ResourceTypeAltinnApp or
-                        ResourceTypeCorrespondence)
+                    .Where(x => Application.Common.Authorization.Constants.SupportedResourceTypes.Contains(x.ResourceType))
                     .Select(x => new ServiceResourceInformation(
                         $"{Constants.ServiceResourcePrefix}{x.Identifier}",
                         x.ResourceType,


### PR DESCRIPTION
From support: 
1. User found resource `digdir-maskinportenschemaid-8` in RR
2. User tried to create a dialog on resource `urn:altinn:resource:digdir-maskinportenschemaid-8`
3. Got message `Service resource 'urn:altinn:resource:digdir-maskinportenschemaid-8' does not exist in the resource registry`

Dialogporten only supports the following resource types:
- GenericAccessResource
- AltinnApp
- CorrespondenceService

This PR will improve the previous message to the following: `Service resource 'urn:altinn:resource:digdir-maskinportenschemaid-8' does not exist in the resource registry, or is not of the following supported resource types: [GenericAccessResource, AltinnApp, CorrespondenceService].`