### PR TITLE
fix(webapi): Return 410 GONE for sub-resources on soft-deleted dialogs

### DIFF
--- a/docs/schema/V1/swagger.verified.json
+++ b/docs/schema/V1/swagger.verified.json
@@ -6579,6 +6579,9 @@
               }
             },
             "description": "The given dialog ID was not found or was deleted, or the given activity ID was not found."
+          },
+          "410": {
+            "description": "Entity with the given key(s) is removed."
           }
         },
         "security": [
@@ -6635,7 +6638,10 @@
                 }
               }
             },
-            "description": "Not Found"
+            "description": "The given dialog ID was not found or is already deleted."
+          },
+          "410": {
+            "description": "Entity with the given key(s) is removed."
           }
         },
         "security": [
@@ -6698,7 +6704,10 @@
                 }
               }
             },
-            "description": "Not Found"
+            "description": "The given dialog ID was not found or is already deleted."
+          },
+          "410": {
+            "description": "Entity with the given key(s) is removed."
           }
         },
         "security": [
@@ -6753,6 +6762,9 @@
               }
             },
             "description": "The given dialog ID was not found or is already deleted."
+          },
+          "410": {
+            "description": "Entity with the given key(s) is removed."
           }
         },
         "security": [
@@ -6924,6 +6936,9 @@
               }
             },
             "description": "The given dialog ID was not found or was deleted, or the given transmission ID was not found."
+          },
+          "410": {
+            "description": "Entity with the given key(s) is removed."
           }
         },
         "security": [

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/DialogTransmissions/Queries/Search/SearchTransmissionQuery.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/DialogTransmissions/Queries/Search/SearchTransmissionQuery.cs
@@ -16,7 +16,7 @@ public sealed class SearchTransmissionQuery : IRequest<SearchTransmissionResult>
 }
 
 [GenerateOneOf]
-public sealed partial class SearchTransmissionResult : OneOfBase<List<TransmissionDto>, EntityNotFound>;
+public sealed partial class SearchTransmissionResult : OneOfBase<List<TransmissionDto>, EntityNotFound, EntityDeleted>;
 
 internal sealed class SearchTransmissionQueryHandler : IRequestHandler<SearchTransmissionQuery, SearchTransmissionResult>
 {
@@ -48,12 +48,21 @@ internal sealed class SearchTransmissionQueryHandler : IRequestHandler<SearchTra
             .Include(x => x.Transmissions)
                 .ThenInclude(x => x.Sender)
             .IgnoreQueryFilters()
-            .WhereIf(!_userResourceRegistry.IsCurrentUserServiceOwnerAdmin(), x => resourceIds.Contains(x.ServiceResource))
+            .WhereIf(!_userResourceRegistry.IsCurrentUserServiceOwnerAdmin(),
+                x => resourceIds.Contains(x.ServiceResource))
             .FirstOrDefaultAsync(x => x.Id == request.DialogId,
                 cancellationToken: cancellationToken);
 
-        return dialog is null
-            ? (SearchTransmissionResult)new EntityNotFound<DialogEntity>(request.DialogId)
-            : _mapper.Map<List<TransmissionDto>>(dialog.Transmissions);
+        if (dialog is null)
+        {
+            return new EntityNotFound<DialogEntity>(request.DialogId);
+        }
+
+        if (dialog.Deleted)
+        {
+            return new EntityDeleted<DialogEntity>(request.DialogId);
+        }
+
+        return _mapper.Map<List<TransmissionDto>>(dialog.Transmissions);
     }
 }

--- a/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/DialogActivities/Get/GetDialogActivityEndpoint.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/DialogActivities/Get/GetDialogActivityEndpoint.cs
@@ -23,7 +23,8 @@ public sealed class GetDialogActivityEndpoint : Endpoint<GetActivityQuery, Activ
         Group<ServiceOwnerGroup>();
         Description(b => b.ProducesOneOf<ActivityDto>(
             StatusCodes.Status200OK,
-            StatusCodes.Status404NotFound));
+            StatusCodes.Status404NotFound,
+            StatusCodes.Status410Gone));
     }
 
     public override async Task HandleAsync(GetActivityQuery req, CancellationToken ct)
@@ -31,6 +32,7 @@ public sealed class GetDialogActivityEndpoint : Endpoint<GetActivityQuery, Activ
         var result = await _sender.Send(req, ct);
         await result.Match(
             dto => SendOkAsync(dto, ct),
-            notFound => this.NotFoundAsync(notFound, ct));
+            notFound => this.NotFoundAsync(notFound, ct),
+            deleted => this.GoneAsync(deleted, ct));
     }
 }

--- a/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/DialogActivities/Get/GetDialogActivitySwaggerConfig.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/DialogActivities/Get/GetDialogActivitySwaggerConfig.cs
@@ -17,5 +17,6 @@ public sealed class GetDialogActivityEndpointSummary : Summary<GetDialogActivity
         Responses[StatusCodes.Status401Unauthorized] = Constants.SwaggerSummary.ServiceOwnerAuthenticationFailure.FormatInvariant(AuthorizationScope.ServiceProvider);
         Responses[StatusCodes.Status403Forbidden] = Constants.SwaggerSummary.AccessDeniedToDialogForChildEntity.FormatInvariant("get");
         Responses[StatusCodes.Status404NotFound] = Constants.SwaggerSummary.DialogActivityNotFound;
+        Responses[StatusCodes.Status410Gone] = Constants.SwaggerSummary.DialogDeleted;
     }
 }

--- a/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/DialogActivities/Search/SearchDialogActivityEndpoint.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/DialogActivities/Search/SearchDialogActivityEndpoint.cs
@@ -27,6 +27,7 @@ public sealed class SearchDialogActivityEndpoint : Endpoint<SearchActivityQuery,
         var result = await _sender.Send(req, ct);
         await result.Match(
             dto => SendOkAsync(dto, ct),
-            notFound => this.NotFoundAsync(notFound, ct));
+            notFound => this.NotFoundAsync(notFound, ct),
+            deleted => this.GoneAsync(deleted, ct));
     }
 }

--- a/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/DialogActivities/Search/SearchDialogActivityEndpointSummary.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/DialogActivities/Search/SearchDialogActivityEndpointSummary.cs
@@ -18,5 +18,6 @@ public sealed class SearchDialogActivityEndpointSummary : Summary<SearchDialogAc
         Responses[StatusCodes.Status401Unauthorized] = Constants.SwaggerSummary.ServiceOwnerAuthenticationFailure.FormatInvariant(AuthorizationScope.ServiceProvider);
         Responses[StatusCodes.Status403Forbidden] = Constants.SwaggerSummary.AccessDeniedToDialog.FormatInvariant("get");
         Responses[StatusCodes.Status404NotFound] = Constants.SwaggerSummary.DialogNotFound;
+        Responses[StatusCodes.Status410Gone] = Constants.SwaggerSummary.DialogDeleted;
     }
 }

--- a/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/DialogSeenLogs/Get/GetDialogSeenLogEndpoint.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/DialogSeenLogs/Get/GetDialogSeenLogEndpoint.cs
@@ -24,7 +24,8 @@ public sealed class GetDialogSeenLogEndpoint : Endpoint<GetSeenLogQuery, SeenLog
 
         Description(d => d.ProducesOneOf<SeenLogDto>(
             StatusCodes.Status200OK,
-            StatusCodes.Status404NotFound));
+            StatusCodes.Status404NotFound,
+            StatusCodes.Status410Gone));
     }
 
     public override async Task HandleAsync(GetSeenLogQuery req, CancellationToken ct)
@@ -32,6 +33,7 @@ public sealed class GetDialogSeenLogEndpoint : Endpoint<GetSeenLogQuery, SeenLog
         var result = await _sender.Send(req, ct);
         await result.Match(
             dto => SendOkAsync(dto, ct),
-            notFound => this.NotFoundAsync(notFound, ct));
+            notFound => this.NotFoundAsync(notFound, ct),
+            deleted => this.GoneAsync(deleted, ct));
     }
 }

--- a/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/DialogSeenLogs/Get/GetDialogSeenLogEndpointSummary.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/DialogSeenLogs/Get/GetDialogSeenLogEndpointSummary.cs
@@ -14,5 +14,7 @@ public sealed class GetDialogSeenLogEndpointSummary : Summary<GetDialogSeenLogEn
                       """;
 
         Responses[StatusCodes.Status200OK] = Constants.SwaggerSummary.ReturnedResult.FormatInvariant("seen log record");
+        Responses[StatusCodes.Status404NotFound] = Constants.SwaggerSummary.DialogNotFound;
+        Responses[StatusCodes.Status410Gone] = Constants.SwaggerSummary.DialogDeleted;
     }
 }

--- a/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/DialogSeenLogs/Search/SearchDialogSeenLogEndpoint.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/DialogSeenLogs/Search/SearchDialogSeenLogEndpoint.cs
@@ -24,7 +24,8 @@ public sealed class SearchDialogSeenLogEndpoint : Endpoint<SearchSeenLogQuery, L
 
         Description(d => d.ProducesOneOf<List<SeenLogDto>>(
             StatusCodes.Status200OK,
-            StatusCodes.Status404NotFound));
+            StatusCodes.Status404NotFound,
+            StatusCodes.Status410Gone));
     }
 
     public override async Task HandleAsync(SearchSeenLogQuery req, CancellationToken ct)
@@ -32,6 +33,7 @@ public sealed class SearchDialogSeenLogEndpoint : Endpoint<SearchSeenLogQuery, L
         var result = await _sender.Send(req, ct);
         await result.Match(
             dto => SendOkAsync(dto, ct),
-            notFound => this.NotFoundAsync(notFound, ct));
+            notFound => this.NotFoundAsync(notFound, ct),
+            deleted => this.GoneAsync(deleted, ct));
     }
 }

--- a/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/DialogSeenLogs/Search/SearchDialogSeenLogEndpointSummary.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/DialogSeenLogs/Search/SearchDialogSeenLogEndpointSummary.cs
@@ -15,5 +15,7 @@ public sealed class SearchDialogSeenLogEndpointSummary : Summary<SearchDialogSee
                       """;
 
         Responses[StatusCodes.Status200OK] = Constants.SwaggerSummary.ReturnedResult.FormatInvariant("seen log records");
+        Responses[StatusCodes.Status404NotFound] = Constants.SwaggerSummary.DialogNotFound;
+        Responses[StatusCodes.Status410Gone] = Constants.SwaggerSummary.DialogDeleted;
     }
 }

--- a/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/DialogTransmissions/Get/GetDialogTransmissionEndpoint.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/DialogTransmissions/Get/GetDialogTransmissionEndpoint.cs
@@ -24,7 +24,8 @@ public sealed class GetDialogTransmissionEndpoint : Endpoint<GetTransmissionQuer
 
         Description(b => b.ProducesOneOf<TransmissionDto>(
             StatusCodes.Status200OK,
-            StatusCodes.Status404NotFound));
+            StatusCodes.Status404NotFound,
+            StatusCodes.Status410Gone));
     }
 
     public override async Task HandleAsync(GetTransmissionQuery req, CancellationToken ct)
@@ -32,6 +33,7 @@ public sealed class GetDialogTransmissionEndpoint : Endpoint<GetTransmissionQuer
         var result = await _sender.Send(req, ct);
         await result.Match(
             dto => SendOkAsync(dto, ct),
-            notFound => this.NotFoundAsync(notFound, ct));
+            notFound => this.NotFoundAsync(notFound, ct),
+            deleted => this.GoneAsync(deleted, ct));
     }
 }

--- a/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/DialogTransmissions/Get/GetDialogTransmissionEndpointSummary.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/DialogTransmissions/Get/GetDialogTransmissionEndpointSummary.cs
@@ -17,5 +17,6 @@ public sealed class GetDialogTransmissionEndpointSummary : Summary<GetDialogTran
         Responses[StatusCodes.Status401Unauthorized] = Constants.SwaggerSummary.ServiceOwnerAuthenticationFailure.FormatInvariant(AuthorizationScope.ServiceProvider);
         Responses[StatusCodes.Status403Forbidden] = Constants.SwaggerSummary.AccessDeniedToDialogForChildEntity.FormatInvariant("get");
         Responses[StatusCodes.Status404NotFound] = Constants.SwaggerSummary.DialogTransmissionNotFound;
+        Responses[StatusCodes.Status410Gone] = Constants.SwaggerSummary.DialogDeleted;
     }
 }

--- a/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/DialogTransmissions/Search/SearchDialogTransmissionEndpoint.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/DialogTransmissions/Search/SearchDialogTransmissionEndpoint.cs
@@ -24,7 +24,8 @@ public sealed class SearchDialogTransmissionEndpoint : Endpoint<SearchTransmissi
 
         Description(b => b.ProducesOneOf<TransmissionDto>(
             StatusCodes.Status200OK,
-            StatusCodes.Status404NotFound));
+            StatusCodes.Status404NotFound,
+            StatusCodes.Status410Gone));
     }
 
     public override async Task HandleAsync(SearchTransmissionQuery req, CancellationToken ct)
@@ -32,6 +33,7 @@ public sealed class SearchDialogTransmissionEndpoint : Endpoint<SearchTransmissi
         var result = await _sender.Send(req, ct);
         await result.Match(
             dto => SendOkAsync(dto, ct),
-            notFound => this.NotFoundAsync(notFound, ct));
+            notFound => this.NotFoundAsync(notFound, ct),
+            deleted => this.GoneAsync(deleted, ct));
     }
 }

--- a/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/DialogTransmissions/Search/SearchDialogTransmissionEndpointSummary.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/DialogTransmissions/Search/SearchDialogTransmissionEndpointSummary.cs
@@ -18,5 +18,6 @@ public sealed class SearchDialogTransmissionEndpointSummary : Summary<SearchDial
         Responses[StatusCodes.Status401Unauthorized] = Constants.SwaggerSummary.ServiceOwnerAuthenticationFailure.FormatInvariant(AuthorizationScope.ServiceProvider);
         Responses[StatusCodes.Status403Forbidden] = Constants.SwaggerSummary.AccessDeniedToDialog.FormatInvariant("get");
         Responses[StatusCodes.Status404NotFound] = Constants.SwaggerSummary.DialogNotFound;
+        Responses[StatusCodes.Status410Gone] = Constants.SwaggerSummary.DialogDeleted;
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue(s)

- #1563

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced API documentation with new response status `410 Gone` for various endpoints, indicating resources that have been permanently removed.
  - Improved error handling for deleted entities across multiple query handlers, allowing clearer responses for deleted dialogs and transmissions.

- **Bug Fixes**
  - Adjusted response handling in several endpoints to properly return `410 Gone` when resources are deleted, enhancing clarity for API consumers.

- **Documentation**
  - Updated API summaries to reflect new status codes and response behaviors, improving guidance for developers interacting with the API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->