### PR TITLE
chore: Use correct database name for local Docker setup

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,7 @@
 # ENV variables for docker-compose
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=supersecret
-POSTGRES_DB=Dialogporten
+POSTGRES_DB=dialogporten
 DB_CONNECTION_STRING=Server=dialogporten-postgres;Port=5432;Database=${POSTGRES_DB};User ID=${POSTGRES_USER};Password=${POSTGRES_PASSWORD};
 
 COMPOSE_PROJECT_NAME=digdir


### PR DESCRIPTION
`dialogporten != Dialogporten` 
Had some confusing moments in pgAdmin with dual databases 😇 