### PR TITLE
fix(webapi): Only allow transmissionId on TransmissionOpened activities

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Create/CreateDialogCommandValidator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Create/CreateDialogCommandValidator.cs
@@ -434,8 +434,8 @@ internal sealed class CreateDialogDialogActivityDtoValidator : AbstractValidator
             .When(x => x.Type != DialogActivityType.Values.Information);
         RuleFor(x => x.TransmissionId)
             .Null()
-            .WithMessage($"A {nameof(DialogActivityType.Values.DialogOpened)} activity cannot reference a transmission.")
-            .When(x => x.Type == DialogActivityType.Values.DialogOpened);
+            .WithMessage($"Only {nameof(DialogActivityType.Values.TransmissionOpened)} activity can reference a transmission.")
+            .When(x => x.Type != DialogActivityType.Values.TransmissionOpened);
         RuleFor(x => x.TransmissionId)
             .NotEmpty()
             .WithMessage($"A {nameof(DialogActivityType.Values.TransmissionOpened)} needs to reference a transmission.")

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Create/CreateDialogCommandValidator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Create/CreateDialogCommandValidator.cs
@@ -434,11 +434,11 @@ internal sealed class CreateDialogDialogActivityDtoValidator : AbstractValidator
             .When(x => x.Type != DialogActivityType.Values.Information);
         RuleFor(x => x.TransmissionId)
             .Null()
-            .WithMessage($"Only {nameof(DialogActivityType.Values.TransmissionOpened)} activity can reference a transmission.")
+            .WithMessage($"Only activities of type {nameof(DialogActivityType.Values.TransmissionOpened)} can reference a transmission.")
             .When(x => x.Type != DialogActivityType.Values.TransmissionOpened);
         RuleFor(x => x.TransmissionId)
             .NotEmpty()
-            .WithMessage($"A {nameof(DialogActivityType.Values.TransmissionOpened)} needs to reference a transmission.")
+            .WithMessage($"An activity of type {nameof(DialogActivityType.Values.TransmissionOpened)} needs to reference a transmission.")
             .When(x => x.Type == DialogActivityType.Values.TransmissionOpened);
     }
 }

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/UpdateDialogCommandValidator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/UpdateDialogCommandValidator.cs
@@ -400,8 +400,8 @@ internal sealed class UpdateDialogDialogActivityDtoValidator : AbstractValidator
             .When(x => x.Type != DialogActivityType.Values.Information);
         RuleFor(x => x.TransmissionId)
             .Null()
-            .WithMessage($"A {nameof(DialogActivityType.Values.DialogOpened)} activity cannot reference a transmission.")
-            .When(x => x.Type == DialogActivityType.Values.DialogOpened);
+            .WithMessage($"Only {nameof(DialogActivityType.Values.TransmissionOpened)} activity can reference a transmission.")
+            .When(x => x.Type != DialogActivityType.Values.TransmissionOpened);
         RuleFor(x => x.TransmissionId)
             .NotEmpty()
             .WithMessage($"A {nameof(DialogActivityType.Values.TransmissionOpened)} needs to reference a transmission.")

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/UpdateDialogCommandValidator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/UpdateDialogCommandValidator.cs
@@ -400,11 +400,11 @@ internal sealed class UpdateDialogDialogActivityDtoValidator : AbstractValidator
             .When(x => x.Type != DialogActivityType.Values.Information);
         RuleFor(x => x.TransmissionId)
             .Null()
-            .WithMessage($"Only {nameof(DialogActivityType.Values.TransmissionOpened)} activity can reference a transmission.")
+            .WithMessage($"Only activities of type {nameof(DialogActivityType.Values.TransmissionOpened)} can reference a transmission.")
             .When(x => x.Type != DialogActivityType.Values.TransmissionOpened);
         RuleFor(x => x.TransmissionId)
             .NotEmpty()
-            .WithMessage($"A {nameof(DialogActivityType.Values.TransmissionOpened)} needs to reference a transmission.")
+            .WithMessage($"An activity of type {nameof(DialogActivityType.Values.TransmissionOpened)} needs to reference a transmission.")
             .When(x => x.Type == DialogActivityType.Values.TransmissionOpened);
     }
 }

--- a/tests/Digdir.Domain.Dialogporten.Application.Unit.Tests/Features/V1/ServiceOwner/Activities/ActivityValidatorTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Unit.Tests/Features/V1/ServiceOwner/Activities/ActivityValidatorTests.cs
@@ -7,14 +7,16 @@ using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Activities;
 using Digdir.Library.Entity.Abstractions.Features.Identifiable;
 using Digdir.Tool.Dialogporten.GenerateFakeData;
 using FluentAssertions;
-using ActivityDto = Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialogs.Commands.Create.ActivityDto;
+
+using UpdateActivityDto =
+    Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialogs.Commands.Update.ActivityDto;
+using CreateActivityDto =
+    Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialogs.Commands.Create.ActivityDto;
 
 namespace Digdir.Domain.Dialogporten.Application.Unit.Tests.Features.V1.ServiceOwner.Activities;
 
 public class ActivityValidatorTests
 {
-
-
     public static IEnumerable<object[]> ActivityTypes() =>
         from DialogActivityType.Values activityType in Enum.GetValues(typeof(DialogActivityType.Values))
         select new object[] { activityType, };
@@ -24,18 +26,20 @@ public class ActivityValidatorTests
         DialogActivityType.Values activityType)
     {
         // Arrange
-        var mapper = new MapperConfiguration(cfg => cfg.CreateMap<ActivityDto, Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialogs.Commands.Update.ActivityDto>()).CreateMapper();
+        var mapper = new MapperConfiguration(cfg => cfg.CreateMap<CreateActivityDto, UpdateActivityDto>()).CreateMapper();
+
         var activity = DialogGenerator.GenerateFakeDialogActivity(type: activityType);
         activity.TransmissionId = IdentifiableExtensions.CreateVersion7();
 
         var localizationValidator = new LocalizationDtosValidator();
         var actorValidator = new ActorValidator();
+
         var createValidator = new CreateDialogDialogActivityDtoValidator(localizationValidator, actorValidator);
         var updateValidator = new UpdateDialogDialogActivityDtoValidator(localizationValidator, actorValidator);
 
         // Act
         var createValidation = createValidator.Validate(activity);
-        var updateValidation = updateValidator.Validate(mapper.Map<Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialogs.Commands.Update.ActivityDto>(activity));
+        var updateValidation = updateValidator.Validate(mapper.Map<UpdateActivityDto>(activity));
 
         // Assert
         if (activityType == DialogActivityType.Values.TransmissionOpened)

--- a/tests/Digdir.Domain.Dialogporten.Application.Unit.Tests/Features/V1/ServiceOwner/Activities/ActivityValidatorTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Unit.Tests/Features/V1/ServiceOwner/Activities/ActivityValidatorTests.cs
@@ -1,0 +1,58 @@
+using AutoMapper;
+using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Localizations;
+using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Common.Actors;
+using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialogs.Commands.Create;
+using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialogs.Commands.Update;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Activities;
+using Digdir.Library.Entity.Abstractions.Features.Identifiable;
+using Digdir.Tool.Dialogporten.GenerateFakeData;
+using FluentAssertions;
+using ActivityDto = Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialogs.Commands.Create.ActivityDto;
+
+namespace Digdir.Domain.Dialogporten.Application.Unit.Tests.Features.V1.ServiceOwner.Activities;
+
+public class ActivityValidatorTests
+{
+
+
+    public static IEnumerable<object[]> ActivityTypes() =>
+        from DialogActivityType.Values activityType in Enum.GetValues(typeof(DialogActivityType.Values))
+        select new object[] { activityType, };
+
+    [Theory, MemberData(nameof(ActivityTypes))]
+    public void Only_TransmissionOpened_Is_Allowed_To_Set_TransmissionId(
+        DialogActivityType.Values activityType)
+    {
+        // Arrange
+        var mapper = new MapperConfiguration(cfg => cfg.CreateMap<ActivityDto, Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialogs.Commands.Update.ActivityDto>()).CreateMapper();
+        var activity = DialogGenerator.GenerateFakeDialogActivity(type: activityType);
+        activity.TransmissionId = IdentifiableExtensions.CreateVersion7();
+
+        var localizationValidator = new LocalizationDtosValidator();
+        var actorValidator = new ActorValidator();
+        var createValidator = new CreateDialogDialogActivityDtoValidator(localizationValidator, actorValidator);
+        var updateValidator = new UpdateDialogDialogActivityDtoValidator(localizationValidator, actorValidator);
+
+        // Act
+        var createValidation = createValidator.Validate(activity);
+        var updateValidation = updateValidator.Validate(mapper.Map<Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialogs.Commands.Update.ActivityDto>(activity));
+
+        // Assert
+        if (activityType == DialogActivityType.Values.TransmissionOpened)
+        {
+            createValidation.IsValid.Should().BeTrue();
+            updateValidation.IsValid.Should().BeTrue();
+        }
+        else
+        {
+            createValidation.IsValid.Should().BeFalse();
+            updateValidation.IsValid.Should().BeFalse();
+
+            createValidation.Errors.Should().ContainSingle();
+            updateValidation.Errors.Should().ContainSingle();
+
+            createValidation.Errors.First().ErrorMessage.Should().Contain("TransmissionOpened");
+            updateValidation.Errors.First().ErrorMessage.Should().Contain("TransmissionOpened");
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
The validator activity validator allows setting TransmissionId on every activity type except DialogOpened.
It should only allow on TransmissionOpened.

## Related Issue(s)

- #1630 

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
