### PR TITLE
fix(app): Add dedicated scope and dbcontext to GetSubjectResources

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/Authorization/AltinnAuthorizationClient.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/Authorization/AltinnAuthorizationClient.cs
@@ -10,7 +10,9 @@ using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities;
 using Digdir.Domain.Dialogporten.Domain.Parties.Abstractions;
 using Digdir.Domain.Dialogporten.Domain.SubjectResources;
 using Digdir.Domain.Dialogporten.Infrastructure.Common.Exceptions;
+using Digdir.Domain.Dialogporten.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using ZiggyCreatures.Caching.Fusion;
 
@@ -27,6 +29,7 @@ internal sealed class AltinnAuthorizationClient : IAltinnAuthorization
     private readonly IUser _user;
     private readonly IDialogDbContext _dialogDbContext;
     private readonly ILogger _logger;
+    private readonly IServiceScopeFactory _serviceScopeFactory;
 
     private static readonly JsonSerializerOptions SerializerOptions = new()
     {
@@ -39,7 +42,8 @@ internal sealed class AltinnAuthorizationClient : IAltinnAuthorization
         IFusionCacheProvider cacheProvider,
         IUser user,
         IDialogDbContext dialogDbContext,
-        ILogger<AltinnAuthorizationClient> logger)
+        ILogger<AltinnAuthorizationClient> logger,
+        IServiceScopeFactory serviceScopeFactory)
     {
         _httpClient = client ?? throw new ArgumentNullException(nameof(client));
         _pdpCache = cacheProvider.GetCache(nameof(Authorization)) ?? throw new ArgumentNullException(nameof(cacheProvider));
@@ -48,6 +52,7 @@ internal sealed class AltinnAuthorizationClient : IAltinnAuthorization
         _user = user ?? throw new ArgumentNullException(nameof(user));
         _dialogDbContext = dialogDbContext ?? throw new ArgumentNullException(nameof(dialogDbContext));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _serviceScopeFactory = serviceScopeFactory ?? throw new ArgumentNullException(nameof(serviceScopeFactory));
     }
 
     public async Task<DialogDetailsAuthorizationResult> GetDialogDetailsAuthorization(
@@ -180,10 +185,13 @@ internal sealed class AltinnAuthorizationClient : IAltinnAuthorization
 
         return dialogSearchAuthorizationResult;
     }
-
     private async Task<List<SubjectResource>> GetAllSubjectResources(CancellationToken cancellationToken) =>
-        await _subjectResourcesCache.GetOrSetAsync(nameof(SubjectResource), async ct
-                => await _dialogDbContext.SubjectResources.ToListAsync(cancellationToken: ct),
+        await _subjectResourcesCache.GetOrSetAsync(nameof(SubjectResource), async ct =>
+            {
+                using var scope = _serviceScopeFactory.CreateScope();
+                var dbContext = scope.ServiceProvider.GetRequiredService<DialogDbContext>();
+                return await dbContext.SubjectResources.ToListAsync(cancellationToken: ct);
+            },
             token: cancellationToken);
 
     private async Task<DialogDetailsAuthorizationResult> PerformDialogDetailsAuthorization(

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/Authorization/AltinnAuthorizationClient.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/Authorization/AltinnAuthorizationClient.cs
@@ -27,7 +27,6 @@ internal sealed class AltinnAuthorizationClient : IAltinnAuthorization
     private readonly IFusionCache _partiesCache;
     private readonly IFusionCache _subjectResourcesCache;
     private readonly IUser _user;
-    private readonly IDialogDbContext _dialogDbContext;
     private readonly ILogger _logger;
     private readonly IServiceScopeFactory _serviceScopeFactory;
 
@@ -41,7 +40,6 @@ internal sealed class AltinnAuthorizationClient : IAltinnAuthorization
         HttpClient client,
         IFusionCacheProvider cacheProvider,
         IUser user,
-        IDialogDbContext dialogDbContext,
         ILogger<AltinnAuthorizationClient> logger,
         IServiceScopeFactory serviceScopeFactory)
     {
@@ -50,7 +48,6 @@ internal sealed class AltinnAuthorizationClient : IAltinnAuthorization
         _partiesCache = cacheProvider.GetCache(nameof(AuthorizedPartiesResult)) ?? throw new ArgumentNullException(nameof(cacheProvider));
         _subjectResourcesCache = cacheProvider.GetCache(nameof(SubjectResource)) ?? throw new ArgumentNullException(nameof(cacheProvider));
         _user = user ?? throw new ArgumentNullException(nameof(user));
-        _dialogDbContext = dialogDbContext ?? throw new ArgumentNullException(nameof(dialogDbContext));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _serviceScopeFactory = serviceScopeFactory ?? throw new ArgumentNullException(nameof(serviceScopeFactory));
     }

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/Authorization/AltinnAuthorizationClient.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/Authorization/AltinnAuthorizationClient.cs
@@ -187,7 +187,7 @@ internal sealed class AltinnAuthorizationClient : IAltinnAuthorization
             {
                 using var scope = _serviceScopeFactory.CreateScope();
                 var dbContext = scope.ServiceProvider.GetRequiredService<DialogDbContext>();
-                return await dbContext.SubjectResources.ToListAsync(cancellationToken: ct);
+                return await dbContext.SubjectResources.AsNoTracking().ToListAsync(cancellationToken: ct);
             },
             token: cancellationToken);
 


### PR DESCRIPTION
Add dedicated scope and dbcontext to GetSubjectResources to avoid concurrency errors

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue(s)

- #1649

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
